### PR TITLE
Initial responsive design pass for appointments view.

### DIFF
--- a/frontend/src/views/AppointmentsView.vue
+++ b/frontend/src/views/AppointmentsView.vue
@@ -1,8 +1,8 @@
 <template>
   <!-- page title area -->
-  <div class="flex justify-between items-start select-none">
-    <div class="text-4xl font-light">{{ t('label.appointments') }}</div>
-    <div class="flex gap-8 items-center">
+  <div class="flex flex-col lg:flex-row justify-between text-center lg:items-start select-none">
+    <div class="text-4xl font-light mb-8 lg:mb-0">{{ t('label.appointments') }}</div>
+    <div class="flex flex-col lg:flex-row gap-8 mx-auto lg:ml-0 lg:mr-0 items-center">
       <tab-bar :tab-items="views" :active="tabActive" @update="updateTab" class="text-xl" />
       <primary-button
         :label="t('label.createAppointments')"
@@ -12,9 +12,9 @@
     </div>
   </div>
   <!-- page content -->
-  <div class="flex justify-between gap-24 mt-8">
+  <div class="flex flex-col flex-col-reverse lg:flex-row justify-between gap-4 xl:gap-24 mt-8">
     <!-- main section: list/grid of appointments with filter -->
-    <div class="w-4/5">
+    <div class="w-full lg:w-4/5">
       <!-- filter bar -->
       <div class="relative flex gap-5 select-none">
         <select v-model="filter" class="rounded border text-sm">
@@ -151,7 +151,7 @@
         </tbody>
       </table>
       <!-- appointments grid -->
-      <div v-show="view === viewTypes.grid" class="w-full mt-4 grid grid-cols-3 gap-8 p-4">
+      <div v-show="view === viewTypes.grid" class="w-full mt-4 grid grid-cols-[repeat(_auto-fit,_minmax(250px,_1fr))] xl:grid-cols-3 gap-8 p-4">
         <appointment-grid-item
           v-for="(appointment, i) in filteredAppointments" :key="i"
           :appointment="appointment"
@@ -160,7 +160,7 @@
       </div>
     </div>
     <!-- page side bar -->
-    <div class="w-1/5 min-w-[310px]">
+    <div class="w-full sm:w-1/2 lg:w-1/5 mx-auto mb-10 md:mb-0 min-w-[310px]">
       <div v-if="creationStatus === creationState.hidden">
         <!-- monthly mini calendar -->
         <calendar-month


### PR DESCRIPTION
Appointments view time! 🎉 

Followed the changes from Calendar. Luckily no side effects here! 

The grid view can now scale from 1 item to 3 items max. (Curse repeat() for only allowing <int>, auto-fit, and auto-fill in its first parameter for css grids.)

Some things break at a higher rate than Calendar, only because the appointment list can expand a lot farther out, and I didn't want to crush the columns as they're pretty crunchy on a small window 

I finally figured out how to full-page screenshot, but they're a little funky due to the navbar. So imagine the appointments list is properly centered and spaced. 

Screenshots:

![Screen Shot 2023-03-07 at 14 21 51-fullpage](https://user-images.githubusercontent.com/97147377/223567709-b741458f-c8a4-453a-815e-1dfe9ce75e48.png)
![Screen Shot 2023-03-07 at 14 21 47-fullpage](https://user-images.githubusercontent.com/97147377/223567714-89076f2f-d0bb-4abd-8fe5-f169661edb5d.png)
![Screen Shot 2023-03-07 at 14 21 42-fullpage](https://user-images.githubusercontent.com/97147377/223567720-e594d793-d74e-411d-8912-cb6b8827795d.png)
![Screen Shot 2023-03-07 at 14 25 49-fullpage](https://user-images.githubusercontent.com/97147377/223567697-3346cba6-349c-47c6-9a8b-ed14209ecc33.png)