### PR TITLE
Request the scopes: calendar.readonly and calendar.events instead of just requesting calendar.

### DIFF
--- a/backend/src/controller/calendar.py
+++ b/backend/src/controller/calendar.py
@@ -13,9 +13,6 @@ from ..database import schemas, repo
 from ..database.models import CalendarProvider
 from ..controller.mailer import Attachment, InvitationMail
 
-SCOPES = ['https://www.googleapis.com/auth/calendar']
-
-
 class GoogleConnector:
   """Generic interface for Google Calendar REST API. This should match CaldavConnector (except for the constructor)"""
   def __init__(self, db, google_client : GoogleClient, calendar_id, subscriber_id, google_tkn: str = None):

--- a/backend/src/controller/google.py
+++ b/backend/src/controller/google.py
@@ -8,7 +8,7 @@ from ..database import repo
 
 class GoogleClient:
     """Authenticates with Google OAuth and allows the retrieval of Google Calendar information"""
-    SCOPES = ['https://www.googleapis.com/auth/calendar', 'https://www.googleapis.com/auth/userinfo.email', 'openid']
+    SCOPES = ['https://www.googleapis.com/auth/calendar.readonly', 'https://www.googleapis.com/auth/calendar.events', 'https://www.googleapis.com/auth/userinfo.email', 'openid']
     client: Flow | None = None
 
     def __init__(self, client_id, client_secret, project_id, callback_url):


### PR DESCRIPTION
Resolves #29 

@devmount When you find the time can you test this on your local and see if everything still works alright. Works fine on my end!

Removed scope:
- calendar : See, edit, share, and permanently delete all the calendars you can access using Google Calendar 

New scopes:
- calendar.readonly : See and download any calendar you can access using your Google Calendar 
- calendar.events : View and edit events on all your calendars 