### PR TITLE
Fix imports potentially having different environment variables.

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -35,6 +35,10 @@
                 {
                     "name": "LOG_USE_STREAM",
                     "value": "True"
+                },
+                {
+                    "name": "APP_ENV",
+                    "value": "prod"
                 }
             ],
             "secrets": [

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -48,3 +48,6 @@ GOOGLE_AUTH_CLIENT_ID=
 GOOGLE_AUTH_SECRET=
 GOOGLE_AUTH_PROJECT_ID=
 GOOGLE_AUTH_CALLBACK=http://localhost:5000/google/callback
+
+# Possible values: prod, dev
+APP_ENV=dev

--- a/backend/src/database/database.py
+++ b/backend/src/database/database.py
@@ -5,7 +5,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
-SQLALCHEMY_DATABASE_URL = os.getenv('DATABASE_URL', "sqlite:///src/appointment.db")
+SQLALCHEMY_DATABASE_URL = os.getenv('DATABASE_URL')
 connect_args = {}
 
 if 'sqlite://' in SQLALCHEMY_DATABASE_URL:

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -2,25 +2,28 @@
 
 Boot application, init database, authenticate user and provide all API endpoints.
 """
-import logging
+from .secrets import normalize_secrets
+
 import os
+
+# load any available .env into env
+if os.getenv('APP_ENV', 'prod') == 'dev':
+  from dotenv import load_dotenv
+  load_dotenv()
+
+# This needs to be ran before any other imports
+normalize_secrets()
+
+import logging
 import sys
 
 import validators
 
-from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, HTTPException, Security
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi_auth0 import Auth0User
 from datetime import timedelta
 from .database.schemas import EventLocation
-from .secrets import normalize_secrets
-
-# Do this before dependencies!!!!
-# load any available .env into env
-load_dotenv()
-normalize_secrets()
-
 from .controller.google import GoogleClient
 from .database.models import Subscriber, CalendarProvider
 from .dependencies.google import get_google_client

--- a/backend/src/secrets.py
+++ b/backend/src/secrets.py
@@ -13,7 +13,6 @@ def normalize_secrets():
         os.environ['AUTH0_API_CLIENT_ID'] = secrets.get('client_id')
         os.environ['AUTH0_API_SECRET'] = secrets.get('secret')
         os.environ['AUTH0_API_AUDIENCE'] = secrets.get('audience')
-        os.environ['AUTH0_SECRETS'] = ''
 
     database_secrets = os.getenv('DATABASE_SECRETS')
 
@@ -21,7 +20,6 @@ def normalize_secrets():
         secrets = json.loads(database_secrets)
 
         os.environ['DATABASE_URL'] = f"mysql+mysqldb://{secrets['username']}:{secrets['password']}@{secrets['host']}:{secrets['port']}/appointment"
-        os.environ['DATABASE_SECRETS'] = ''
 
     database_enc_secret = os.getenv('DB_ENC_SECRET')
 
@@ -29,7 +27,6 @@ def normalize_secrets():
         secrets = json.loads(database_enc_secret)
 
         os.environ['DB_SECRET'] = secrets.get('secret')
-        os.environ['DB_ENC_SECRET'] = ''
 
     smtp_secrets = os.getenv('SMTP_SECRETS')
 
@@ -42,7 +39,6 @@ def normalize_secrets():
         os.environ['SMTP_USER'] = secrets.get('username')
         os.environ['SMTP_PASS'] = secrets.get('password')
         os.environ['SMTP_SENDER'] = secrets.get('sender')
-        os.environ['SMTP_SECRETS'] = ''
 
     google_oauth_secrets = os.getenv('GOOGLE_OAUTH_SECRETS')
 
@@ -53,4 +49,3 @@ def normalize_secrets():
         os.environ['GOOGLE_AUTH_SECRET'] = secrets.get('secret')
         os.environ['GOOGLE_AUTH_PROJECT_ID'] = secrets.get('project_id')
         os.environ['GOOGLE_AUTH_CALLBACK'] = secrets.get('callback_url')
-        os.environ['GOOGLE_OAUTH_SECRETS'] = ''


### PR DESCRIPTION
Hiii I'm not suppose to be working today, but I couldn't get this off my head so I'm marking this as a therapeutic fix. A dumb oversight on my end causes database.schema to load the sqlite database, while the rest of the app uses the AWS RDS. I'm not sure how this app is even functional, but this should fix disappearing events...

- Database schema was imported before we normalize aws secrets
- Remove load_dotenv on non-dev environments
- Rip out any mention of sqlite as a default value

