### PR TITLE
(Google Calendar) Split reoccurring events into their own event instance

### DIFF
--- a/backend/src/controller/google.py
+++ b/backend/src/controller/google.py
@@ -83,7 +83,7 @@ class GoogleClient:
     def list_events(self, calendar_id, time_min, time_max, token):
         response = {}
         with build('calendar', 'v3', credentials=token) as service:
-            request = service.events().list(calendarId=calendar_id, timeMin=time_min, timeMax=time_max)
+            request = service.events().list(calendarId=calendar_id, timeMin=time_min, timeMax=time_max, singleEvents=True)
             while request is not None:
                 try:
                     response = request.execute()


### PR DESCRIPTION
Possible fix for #28 

I could not find any examples in my calendars with this specific issue, but I noticed my re-occuring events didn't populate. Google has a parameter to split reoccuring events into their own event so this enables that!

We'll ask folks to confirm if this fixes their issues once it gets merged on stage.