### PR TITLE
If a calendar exists, update it instead of attempting to re-create it and then erroring out.

### DIFF
--- a/backend/src/controller/google.py
+++ b/backend/src/controller/google.py
@@ -98,7 +98,7 @@ class GoogleClient:
         response = {}
         with build("calendar", "v3", credentials=token) as service:
             request = service.events().list(
-                calendarId=calendar_id, timeMin=time_min, timeMax=time_max, singleEvents=True, orderBy='startTime'
+                calendarId=calendar_id, timeMin=time_min, timeMax=time_max, singleEvents=True, orderBy="startTime"
             )
             while request is not None:
                 try:

--- a/backend/src/database/repo.py
+++ b/backend/src/database/repo.py
@@ -9,7 +9,6 @@ from fastapi import HTTPException
 from sqlalchemy.orm import Session
 from . import models, schemas
 
-
 """ SUBSCRIBERS repository functions
 """
 
@@ -118,6 +117,11 @@ def get_calendar(db: Session, calendar_id: int):
     return db.get(models.Calendar, calendar_id)
 
 
+def get_calendar_by_url(db: Session, url: str):
+    """retrieve calendar by calendar url"""
+    return db.query(models.Calendar).filter(models.Calendar.url == url).first()
+
+
 def get_calendars_by_subscriber(db: Session, subscriber_id: int):
     """retrieve list of calendars by owner id"""
     return db.query(models.Calendar).filter(models.Calendar.owner_id == subscriber_id).all()
@@ -154,6 +158,18 @@ def update_subscriber_calendar(db: Session, calendar: schemas.CalendarConnection
     db.commit()
     db.refresh(db_calendar)
     return db_calendar
+
+
+def update_or_create_subscriber_calendar(
+    db: Session, calendar: schemas.CalendarConnection, calendar_url: str, subscriber_id: int
+):
+    """update or create a subscriber calendar"""
+    subscriber_calendar = get_calendar_by_url(db, calendar_url)
+
+    if subscriber_calendar is None:
+        return create_subscriber_calendar(db, calendar, subscriber_id)
+
+    return update_subscriber_calendar(db, calendar, subscriber_calendar.id)
 
 
 def delete_subscriber_calendar(db: Session, calendar_id: int):

--- a/backend/src/routes/google.py
+++ b/backend/src/routes/google.py
@@ -89,7 +89,9 @@ def google_callback(
         )
         # add calendar
         try:
-            repo.create_subscriber_calendar(db=db, calendar=cal, subscriber_id=subscriber.id)
+            repo.update_or_create_subscriber_calendar(
+                db=db, calendar=cal, calendar_url=calendar.get("id"), subscriber_id=subscriber.id
+            )
         except Exception as err:
             logging.warning(
                 f"[routes.google.google_callback] Error occurred while creating calendar. Error: {str(err)}"


### PR DESCRIPTION
Fixes #66 

Eventually we'll have a very fun second step to this process to only import/update the ones you want, but for now this will fix an annoying error message.