### PR TITLE
Implement email templating

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,6 +7,7 @@ fastapi==0.91.0
 google-api-python-client==2.85.0
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==1.0.0
+Jinja2==3.1.2
 icalendar==5.0.4
 mysqlclient==2.1.1
 mysql-connector-python==8.0.32

--- a/backend/src/controller/mailer.py
+++ b/backend/src/controller/mailer.py
@@ -6,6 +6,8 @@ import logging
 import os
 import smtplib
 import ssl
+
+import jinja2
 import validators
 
 from html import escape
@@ -13,6 +15,14 @@ from email import encoders
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from fastapi.templating import Jinja2Templates
+
+templates = Jinja2Templates("src/templates/email")
+
+
+def get_template(template_name) -> "jinja2.Template":
+    """Retrieves a template under the templates/email folder. Make sure to include the file extension!"""
+    return templates.get_template(template_name)
 
 
 class Attachment:
@@ -119,8 +129,10 @@ class InvitationMail(Mailer):
     def __init__(self, *args, **kwargs):
         """init Mailer with invitation specific defaults"""
         defaultKwargs = {
-            "subject": "[TBA] Invitation sent from Thunderbird Appintment",
-            "html": "<html><body><p>This message is sent from <b>Appointment</b>.</p></body></html>",
+            "subject": "[TBA] Invitation sent from Thunderbird Appointment",
             "plain": "This message is sent from Appointment.",
         }
         super(InvitationMail, self).__init__(*args, **defaultKwargs, **kwargs)
+
+    def html(self):
+        return get_template("invite.jinja2").render()

--- a/backend/src/templates/email/invite.jinja2
+++ b/backend/src/templates/email/invite.jinja2
@@ -1,0 +1,5 @@
+<html lang="en">
+  <body>
+    <p>This message is sent from <b>Appointment</b>.</p>
+  </body>
+</html>


### PR DESCRIPTION
## Description of the Change

Adds jinja2 for email templating. Moves the invite email to a template, and on its html() function it will retrieve and render the template. 

In the future when we need to pass data to a template, that would occur on the render() call, and the data will be filled in on the constructor.

## Benefits

We can use all the wonderful features of Jinja and FastAPI's templating module (that uses Jinja)

https://fastapi.tiangolo.com/advanced/templates/

## Applicable Issues

#10 
