### PR TITLE
If we have an expired refresh token, try refreshing it! (Fixes #94)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -83,6 +83,9 @@ const checkLogin = async () => {
       // data.value holds appointment subscriber structure
       // auth.user.value holds auth0 user structure
       currentUser.value = data.value;
+    } else if (data.value && data.value.detail === 'Missing bearer token') {
+      // Try logging in if we have an expired refresh token, but a valid authentication id.
+      await auth.loginWithRedirect();
     }
   }
 };


### PR DESCRIPTION
## Description of the Change

Relogins the user if their refresh token expires. This will either be a page refresh, or a complete auth0 relogin flow. 

## Benefits

Prevents the user from being in a state where they can't login or logout 🙀 

## Applicable Issues

#94 
