### PR TITLE
Fix migration issues

### DIFF
--- a/backend/src/database/models.py
+++ b/backend/src/database/models.py
@@ -134,7 +134,7 @@ class Appointment(Base):
     )
     keep_open = Column(Boolean)
     status = Column(Enum(AppointmentStatus), default=AppointmentStatus.draft)
-    appointment_type = (Column(Enum(AppointmentType)),)
+    appointment_type = Column(Enum(AppointmentType))
 
     calendar = relationship("Calendar", back_populates="appointments")
     slots = relationship("Slot", cascade="all,delete", back_populates="appointment")

--- a/backend/src/migrations/versions/2023_06_27_1108-f9660871710e_add_general_availability_tables.py
+++ b/backend/src/migrations/versions/2023_06_27_1108-f9660871710e_add_general_availability_tables.py
@@ -20,7 +20,7 @@ def secret():
 
 # revision identifiers, used by Alembic.
 revision = "f9660871710e"
-down_revision = "da069f44bca7"
+down_revision = "845089644770"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION


## Description of the Change

- Removes extraneous comma from `Appointment.appointment_type` column definition
- Manually sets `down_revision` on migration file to multiple `head`s

## Benefits

Allows migrations to run correctly 🚀

## Applicable Issues

Closes #110 
