### PR TITLE
Add the site title to vue config. (Fixes #180)

### DIFF
--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -5,6 +5,12 @@ module.exports = defineConfig({
   transpileDependencies: true,
   productionSourceMap: true,
   publicPath: '/',
+  pages: {
+    index: {
+      entry: 'src/main.js',
+      title: 'Thunderbird Appointment',
+    },
+  },
   configureWebpack: {
     devtool: 'source-map', // Source map generation must be turned on
     plugins: [


### PR DESCRIPTION
This will need to change when we swap to vite but it works for now. 