### PR TITLE
[DRAFT] Multi-booked event view

### DIFF
--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -73,20 +73,25 @@ export const initialEventPopupData = {
   left: 'initial',
 };
 // calculate properties of event popup for given element and show popup
-export const showEventPopup = (el, event, position='right') => {
+export const showEventPopup = (el, event, position = 'right') => {
   const obj = { ...initialEventPopupData };
   obj.event = event;
   obj.display = 'block';
-  obj.top = `${el.target.offsetTop + el.target.clientHeight / 2 - el.target.parentElement.scrollTop}px`;
+
+  const bounds = el.target.getBoundingClientRect();
+  const top = window.scrollY + bounds.top;
+  const left = window.scrollX + bounds.left;
+
+  obj.top = `${top + bounds.height / 2 - el.target.parentElement.scrollTop}px`;
   if (!position || position === 'right') {
-    obj.left = `${el.target.offsetLeft + el.target.clientWidth + 4}px`;
+    obj.left = `${left + bounds.width + 4}px`;
   }
   if (position === 'left') {
-    obj.left = `${el.target.offsetLeft - 4}px`;;
+    obj.left = `${left - 4}px`;
   }
   if (position === 'top') {
-    obj.left = `${el.target.offsetLeft + el.target.clientWidth/2}px`;
-    obj.top = `${el.target.offsetTop - 50}px`;
+    obj.left = `${left + bounds.width/2}px`;
+    obj.top = `${top - 50}px`;
   }
   return obj;
 };


### PR DESCRIPTION
Fixes #70 

An extreme edge case of multi-booking yourself:
<img width="1331" alt="image" src="https://github.com/thunderbird/appointment/assets/97147377/2488e6e0-8ff4-4e85-8176-4185b056867e">


In order to get this working nicely, I dropped the css grid approach, and just group events by start time and then set their `top` absolute value. Our calendar doesn't resize, so this is probably not a bad option. i haven't implemented it in daily view, as it wasn't as much of an issue there. 

It's still sort of ugly, but we just needed something better for the MVP. I didn't want to re-write the existing weekly calendar code, but I sort of did anyways lol. I'd like to re-work that insertEvents function so we don't have to duplicate the same code twice, and to get rid of that ugly order processor but it works for now. Also reduce the amount of classes on some of these divs lol. 