### PR TITLE
Pull remote calendar information on a month by month basis. (Fixes #186)

### DIFF
--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -239,8 +239,8 @@ onMounted(async () => {
 watch(
   () => activeDate.value,
   (newValue, oldValue) => {
-    // remote data is retrieved per year, so data request happens only if the user navigates to a different year
-    if (dj(oldValue).format('MM') !== dj(newValue).format('MM')) {
+    // remote data is retrieved per month, so a data request happens as soon as the user navigates to a different month
+    if (dj(oldValue).format('YYYYMM') !== dj(newValue).format('YYYYMM')) {
       getRemoteEvents(
         dj(newValue).startOf('month').format('YYYY-MM-DD'),
         dj(newValue).endOf('month').format('YYYY-MM-DD'),

--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -187,8 +187,8 @@ onMounted(async () => {
 watch(
   () => activeDate.value,
   (newValue, oldValue) => {
-    // remote data is retrieved per year, so data request happens only if the user navigates to a different year
-    if (dj(oldValue).format('MM') !== dj(newValue).format('MM')) {
+    // remote data is retrieved per month, so a data request happens as soon as the user navigates to a different month
+    if (dj(oldValue).format('YYYYMM') !== dj(newValue).format('YYYYMM')) {
       getRemoteEvents(
         dj(newValue).startOf('month').format('YYYY-MM-DD'),
         dj(newValue).endOf('month').format('YYYY-MM-DD'),


### PR DESCRIPTION
Very simple fix, I think we originally pulled an entire year to save on google api calls, but I'm not sure that matters. I don't cache the calendar data as we don't have a way of knowing if its been updated without doing the entire request. 

Eventually we'll store this data and have google tell us what's new (with occasionally double checks on our side) but for now this should speed things up quite a bit! 