### PR TITLE
Run backend tests as a github action

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -2,7 +2,11 @@
 
 name: Run Backend Tests
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
Fixes #193 

This will run pytest on every push. It seems a little excessive but it seems like that's how everyone else does it. 

We could fancy it up by making it comment with the failed job or pytest results, but I think this is a good first step into just having the test visibility. 

Let me know if anything is missing.