### PR TITLE
Only return data we need for google events.

### DIFF
--- a/backend/src/appointment/controller/apis/google_client.py
+++ b/backend/src/appointment/controller/apis/google_client.py
@@ -109,7 +109,9 @@ class GoogleClient:
                 'items/description',
                 'items/attendees',
                 'items/start',
-                'items/end'
+                'items/end',
+                # Top level stuff
+                'nextPageToken',
             )
         )
 


### PR DESCRIPTION
No ticket, but I was reading up on the google docs for something else and noticed they recommend only pulling what you need. I'm not sure how much of a speed up this will be as I have a small calendar, but worth a shot!

I think I have all the fields, but feel free to double check GoogleConnector@list_events.

https://developers.google.com/calendar/api/guides/performance
