### PR TITLE
Make getRemoteEvents inclusive of the last day, by adding one to the …

### DIFF
--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -212,9 +212,12 @@ const calendarEvents = ref([]);
 const hideUntilRefreshed = ref(true);
 
 const getRemoteEvents = async (from, to) => {
+  // Most calendar impl are non-inclusive of the last day, so just add one to the day.
+  const inclusiveTo = dj(to).add(1, 'day').format('YYYY-MM-DD');
+
   calendarEvents.value = [];
   await Promise.all(calendarStore.connectedCalendars.map(async (calendar) => {
-    const { data } = await call(`rmt/cal/${calendar.id}/${from}/${to}`).get().json();
+    const { data } = await call(`rmt/cal/${calendar.id}/${from}/${inclusiveTo}`).get().json();
     if (Array.isArray(data.value)) {
       calendarEvents.value.push(...data.value.map((e) => ({ ...e, duration: dj(e.end).diff(dj(e.start), 'minutes') })));
     }

--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -144,9 +144,12 @@ const dateNav = (unit = 'auto', forward = true) => {
 // get remote calendar data for current year
 const calendarEvents = ref([]);
 const getRemoteEvents = async (from, to) => {
+  // Most calendar impl are non-inclusive of the last day, so just add one to the day.
+  const inclusiveTo = dj(to).add(1, 'day').format('YYYY-MM-DD');
+
   calendarEvents.value = [];
   await Promise.all(calendarStore.connectedCalendars.map(async (calendar) => {
-    const { data } = await call(`rmt/cal/${calendar.id}/${from}/${to}`).get().json();
+    const { data } = await call(`rmt/cal/${calendar.id}/${from}/${inclusiveTo}`).get().json();
     if (Array.isArray(data.value)) {
       calendarEvents.value.push(...data.value.map((e) => ({ ...e, duration: dj(e.end).diff(dj(e.start), 'minutes') })));
     }


### PR DESCRIPTION
Should fix #239 

Originally I was doing this on the backend, but if the caldav/google api impl are exclusive of the backend, I guess our api should be as well. 

We should move that call into the store when we get a chance, but this is fine for now. 