### PR TITLE
Don't require authentication when responding to booking requests.

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -126,7 +126,7 @@ const appointmentStore = useAppointmentStore();
 
 // true if route can be accessed without authentication
 const routeIsPublic = computed(
-  () => ['booking', 'availability', 'home', 'login', 'post-login'].includes(route.name),
+  () => ['booking', 'availability', 'home', 'login', 'post-login', 'confirmation'].includes(route.name),
 );
 const routeIsHome = computed(
   () => ['home'].includes(route.name),


### PR DESCRIPTION
Fixes #319 

I was expecting some sort of issue on the frontend, but nope it just works. 