### PR TITLE
Make schedule creation container sticky

### DIFF
--- a/frontend/src/components/ScheduleCreation.vue
+++ b/frontend/src/components/ScheduleCreation.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative flex h-full flex-col gap-4">
+  <div class="sticky top-24 flex flex-col gap-4">
     <div class="flex items-center justify-around text-center text-xl font-semibold text-teal-500">
       <span>{{ t("heading.generalAvailability") }}</span>
       <switch-toggle v-if="existing" class="mt-0.5" :active="schedule.active" no-legend @changed="toggleActive"/>
@@ -272,14 +272,14 @@
       </div>
     </div>
     <!-- action buttons -->
-    <div class="mt-auto flex justify-center gap-4">
+    <div class="my-8 flex justify-center gap-4">
       <primary-button
         v-if="user.data.signedUrl && existing"
         :label="t('label.shareMyLink')"
         :copy="user.data.signedUrl"
       />
     </div>
-    <div class="mt-auto flex gap-4">
+    <div class="flex gap-4">
       <secondary-button
         :label="t('label.cancel')"
         @click="resetSchedule()"


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change keeps the schedule creation container always on screen, even if scrolling down.

![image](https://github.com/thunderbird/appointment/assets/5441654/b8bcc220-b9a3-4376-8ae1-87063ea7da63)

## Benefits

Creation form is always visible now even on scrolling down.

## Applicable Issues

Closes #335 
