### PR TITLE
Ignore events that have the event type of workingLocation. (Fixes #363)

### DIFF
--- a/backend/src/appointment/controller/apis/google_client.py
+++ b/backend/src/appointment/controller/apis/google_client.py
@@ -114,10 +114,18 @@ class GoogleClient:
             )
         )
 
+        # Explicitly ignore workingLocation events
+        # See: https://developers.google.com/calendar/api/v3/reference/events#eventType
+        event_types = [
+            'default',
+            'focusTime',
+            'outOfOffice'
+        ]
+
         with build("calendar", "v3", credentials=token, cache_discovery=False) as service:
             request = service.events().list(
                 calendarId=calendar_id, timeMin=time_min, timeMax=time_max, singleEvents=True, orderBy="startTime",
-                fields=fields
+                eventTypes=event_types, fields=fields
             )
             while request is not None:
                 try:


### PR DESCRIPTION
Fixes #363 

Google Calendar has a feature where you can set working locations. Kind of neat, but behind the scenes it's just an event with a special type. This ignores that type.

<img width="649" alt="image" src="https://github.com/thunderbird/appointment/assets/97147377/97ea8acf-2617-446a-87a5-1affe7b09b48">

Before:
<img width="833" alt="image" src="https://github.com/thunderbird/appointment/assets/97147377/834f7adb-a8b2-427a-937d-109ea1c4abd0">


After:
<img width="789" alt="image" src="https://github.com/thunderbird/appointment/assets/97147377/635a0c6f-b76e-4a72-87b2-91f6b2124389">
