### PR TITLE
Ensure the incoming fxa uid matches all existing ones

### DIFF
--- a/backend/src/appointment/l10n.py
+++ b/backend/src/appointment/l10n.py
@@ -1,10 +1,14 @@
 from typing import Union, Dict, Any
-from starlette_context import context
+
+from starlette_context import context, errors
 
 
 def l10n(msg_id: str, args: Union[Dict[str, Any], None] = None) -> str:
     """Helper function to automatically call fluent.format_value from context"""
-    if 'l10n' not in context:
+    try:
+        if 'l10n' not in context:
+            return msg_id
+    except errors.ContextDoesNotExistError:
         return msg_id
 
     return context['l10n'](msg_id, args)


### PR DESCRIPTION
(there should only be one!)

Adds a test that has an existing subscriber with an existing fxa uid that is not the incoming fxa uid. 

I'm fairly certain sentry should give us the necessary on that capture_exception but we may have to revisit this if we find we don't get anything useful.

