### PR TITLE
Watch dayBoundary and forward updates to Qalendar.

### DIFF
--- a/frontend/src/components/CalendarQalendar.vue
+++ b/frontend/src/components/CalendarQalendar.vue
@@ -254,15 +254,15 @@ const calendarEvents = computed(() => {
  * @type {ComputedRef<{start, end}>}
  */
 const dayBoundary = computed(() => {
-  let startHour = 99;
-  let endHour = 0;
-
   if (calendarEvents?.value.length === 0) {
     return {
       start: 0,
       end: 24,
     };
   }
+
+  let startHour = 99;
+  let endHour = 0;
 
   calendarEvents.value.forEach((event) => {
     // Calculate start/end hours
@@ -322,7 +322,23 @@ if (locale) {
  * Qalendar's selectedDate is only set on init and never updated. So we have to poke at their internals...
  */
 watch(currentDate, () => onCurrentDateChange(currentDate.value));
+/**
+ * We need to update the Time object manually when we get new dayBoundaries. (But only if they're not the default val)
+ */
+watch(dayBoundary, () => {
+  // Don't try to update qalendar if we don't have a valid reference!
+  if (!qalendarRef?.value) {
+    return;
+  }
 
+  // Don't refresh with the default values
+  if (dayBoundary.value.start === 0 && dayBoundary.value.end === 24) {
+    return;
+  }
+
+  qalendarRef.value.time.DAY_START = dayBoundary.value.start * 100;
+  qalendarRef.value.time.DAY_END = dayBoundary.value.end * 100;
+});
 </script>
 <template>
   <div


### PR DESCRIPTION
Fixes #384 

Adds a watch for dayBoundary and forwards the data to qalendar.time. In Qalendar time is created from the config value and is not referenced directly again. So we need to poke at it manually.

<img width="1057" alt="image" src="https://github.com/thunderbird/appointment/assets/97147377/b34ad688-e79c-4ec8-a448-5c3057e5048a">

It looks a bit silly with one event, but we can adjust that as needed I think!

(Please give it a test 😄 )