### PR TITLE
Disable the "Generate Zoom Meeting" checkbox if they don't have a zoom account connected.

### DIFF
--- a/frontend/src/components/ScheduleCreation.vue
+++ b/frontend/src/components/ScheduleCreation.vue
@@ -252,7 +252,7 @@
             <input
               type="checkbox"
               :checked="scheduleInput.meeting_link_provider === meetingLinkProviderType.zoom"
-              :disabled="!scheduleInput.active"
+              :disabled="!scheduleInput.active || !hasZoomAccount"
               @change="toggleZoomLinkCreation"
               class="size-5 rounded-md"
             />
@@ -369,11 +369,13 @@ import AlertBox from '@/elements/AlertBox';
 import SwitchToggle from '@/elements/SwitchToggle';
 import ToolTip from '@/elements/ToolTip.vue';
 import { useCalendarStore } from '@/stores/calendar-store';
+import { useExternalConnectionsStore } from '@/stores/external-connections-store';
 import SnackishBar from '@/elements/SnackishBar.vue';
 
 // component constants
 const user = useUserStore();
 const calendarStore = useCalendarStore();
+const externalConnectionStore = useExternalConnectionsStore();
 const { t } = useI18n();
 const dj = inject('dayjs');
 const call = inject('call');
@@ -384,6 +386,8 @@ const firstStep = scheduleCreationState.availability;
 
 // component emits
 const emit = defineEmits(['created', 'updated']);
+
+const hasZoomAccount = computed(() => externalConnectionStore.zoom[0]);
 
 // component properties
 const props = defineProps({

--- a/frontend/src/components/ScheduleCreation.vue
+++ b/frontend/src/components/ScheduleCreation.vue
@@ -443,6 +443,9 @@ const scheduleInput = ref({ ...defaultSchedule });
 const referenceSchedule = ref({ ...defaultSchedule });
 
 onMounted(() => {
+  // Retrieve the current external connections
+  externalConnectionStore.fetch(call);
+
   if (props.schedule) {
     scheduleInput.value = { ...props.schedule };
     // calculate utc back to user timezone


### PR DESCRIPTION
Fixes #389 

Spotted via a Sentry bug report and then confirmed it was a bug. Easy fix thankfully.