### PR TITLE
Fix all day events bleeding over to following day:

### DIFF
--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -323,13 +323,15 @@ class CalDavConnector(BaseConnector):
             start = e.vobject_instance.vevent.dtstart.value
             # get_duration grabs either end or duration into a timedelta
             end = start + e.get_duration()
+            # if start doesn't hold time information (no datetime), it's a whole day
+            all_day = not isinstance(start, datetime)
 
             events.append(
                 schemas.Event(
                     title=title,
                     start=start,
                     end=end,
-                    all_day=not isinstance(start, datetime),
+                    all_day=all_day,
                     tentative=tentative,
                     description=e.icalendar_component["description"] if "description" in e.icalendar_component else "",
                 )

--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -319,12 +319,17 @@ class CalDavConnector(BaseConnector):
             # Mark tentative events
             tentative = status == "tentative"
 
+            title = e.vobject_instance.vevent.summary.value
+            start = e.vobject_instance.vevent.dtstart.value
+            # get_duration grabs either end or duration into a timedelta
+            end = start + e.get_duration()
+
             events.append(
                 schemas.Event(
-                    title=e.vobject_instance.vevent.summary.value,
-                    start=e.vobject_instance.vevent.dtstart.value,
-                    end=e.vobject_instance.vevent.dtend.value,
-                    all_day=not isinstance(e.vobject_instance.vevent.dtstart.value, datetime),
+                    title=title,
+                    start=start,
+                    end=end,
+                    all_day=not isinstance(start, datetime),
                     tentative=tentative,
                     description=e.icalendar_component["description"] if "description" in e.icalendar_component else "",
                 )

--- a/frontend/src/components/CalendarQalendar.vue
+++ b/frontend/src/components/CalendarQalendar.vue
@@ -187,7 +187,7 @@ const calendarEvents = computed(() => {
           ? start.format(dateFormatStrings.qalendarFullDay)
           : start.format(dateFormatStrings.qalendar),
         end: event.all_day
-          ? end.format(dateFormatStrings.qalendarFullDay)
+          ? end.subtract(1, 'minute').format(dateFormatStrings.qalendarFullDay)
           : end.format(dateFormatStrings.qalendar),
       },
       description: event.description,


### PR DESCRIPTION
* Google defines all day as "Midnight" to "Midnight + 1 day"
* Subtract 1 minute from the end time.

Fixed:
<img width="337" alt="image" src="https://github.com/thunderbird/appointment/assets/97147377/ae42b4d3-38c5-483d-af34-5cd95fdd8486">


Sample all day event:
```
{
	"11": {
		"title": "Test All Day",
		"start": "2024-05-10T00:00:00",
		"end": "2024-05-11T00:00:00",
		"all_day": true,
		"tentative": false,
		"description": "",
		"calendar_title": "<redacted>",
		"calendar_color": "#9fe1e7",
		"location": null,
		"uuid": null
	}
}
```