### PR TITLE
Ensure a trailing slash for CalDAV urls

### DIFF
--- a/backend/src/appointment/routes/api.py
+++ b/backend/src/appointment/routes/api.py
@@ -135,6 +135,10 @@ def create_my_calendar(
             google_tkn=external_connection.token,
         )
     else:
+        # make sure, the CalDAV url has a trailing slash
+        if calendar.url[-1] != '/':
+            calendar.url += '/'
+
         con = CalDavConnector(
             redis_instance=None,
             url=calendar.url,
@@ -189,6 +193,10 @@ def update_my_calendar(
         raise validation.CalendarNotFoundException()
     if not repo.calendar.is_owned(db, calendar_id=id, subscriber_id=subscriber.id):
         raise validation.CalendarNotAuthorizedException()
+
+    # make sure, the CalDAV url has a trailing slash
+    if calendar.provider == CalendarProvider.caldav and calendar.url[-1] != '/':
+        calendar.url += '/'
 
     cal = repo.calendar.update(db=db, calendar=calendar, calendar_id=id)
     return schemas.CalendarOut(id=cal.id, title=cal.title, color=cal.color, connected=cal.connected)


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change adds a slash `/` to the end of CalDAV urls, when a CalDAV calendar is added or updated and the given url doesn't already end with one.

I normally test with a public CalDavZIP instance (https://calendar.robur.coop/) but that currently seems to be down. I tested with a NextCloud calendar too and that was working just fine.

## Benefits

Less complaints from picky CalDAV servers enforcing a trailing slash.

## Applicable Issues

Closes #343 