### PR TITLE
Soft delete / disabling / enabling subscribers via panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 Invite others to grab times on your calendar. Choose a date. Make appointments as easy as it gets.
 
-
 ## Feedback and Support
 
 If you'd like to give feedback or need support, please see our [Topicbox](https://thunderbird.topicbox.com/groups/services).

--- a/backend/src/appointment/controller/data.py
+++ b/backend/src/appointment/controller/data.py
@@ -79,7 +79,7 @@ def download(db, subscriber: Subscriber):
 
 def delete_account(db, subscriber: Subscriber):
     # Ok nuke everything (thanks cascade=all,delete)
-    repo.subscriber.delete(db, subscriber)
+    repo.subscriber.hard_delete(db, subscriber)
 
     # Make sure we actually nuked the subscriber
     if repo.subscriber.get(db, subscriber.id) is not None:

--- a/backend/src/appointment/database/models.py
+++ b/backend/src/appointment/database/models.py
@@ -98,15 +98,23 @@ class Base:
     time_updated = Column(DateTime, server_default=func.now(), default=func.now(), onupdate=func.now(), index=True)
 
 
-class Subscriber(Base):
+class HasSoftDelete:
+    """Mixing in a column to support deletion without removing the record"""
+    time_deleted = Column(DateTime, nullable=True)
+
+    @property
+    def is_deleted(self):
+        """A record is marked deleted if a delete time is set."""
+        return self.time_deleted is not None
+
+
+class Subscriber(HasSoftDelete, Base):
     __tablename__ = "subscribers"
 
     id = Column(Integer, primary_key=True, index=True)
     username = Column(StringEncryptedType(String, secret, AesEngine, "pkcs5", length=255), unique=True, index=True)
     # Encrypted (here) and hashed (by the associated hashing functions in routes/auth)
     password = Column(StringEncryptedType(String, secret, AesEngine, "pkcs5", length=255), index=False)
-
-    active: bool = Column(Boolean, index=True, default=True)
 
     # Use subscriber.preferred_email for any email, or other user-facing presence.
     email = Column(StringEncryptedType(String, secret, AesEngine, "pkcs5", length=255), unique=True, index=True)

--- a/backend/src/appointment/database/models.py
+++ b/backend/src/appointment/database/models.py
@@ -106,6 +106,8 @@ class Subscriber(Base):
     # Encrypted (here) and hashed (by the associated hashing functions in routes/auth)
     password = Column(StringEncryptedType(String, secret, AesEngine, "pkcs5", length=255), index=False)
 
+    active: bool = Column(Boolean, index=True, default=True)
+
     # Use subscriber.preferred_email for any email, or other user-facing presence.
     email = Column(StringEncryptedType(String, secret, AesEngine, "pkcs5", length=255), unique=True, index=True)
     secondary_email = Column(StringEncryptedType(String, secret, AesEngine, "pkcs5", length=255), nullable=True, index=True)

--- a/backend/src/appointment/database/repo/subscriber.py
+++ b/backend/src/appointment/database/repo/subscriber.py
@@ -71,8 +71,24 @@ def update(db: Session, data: schemas.SubscriberIn, subscriber_id: int):
     return db_subscriber
 
 
+def disable(db: Session, subscriber: models.Subscriber):
+    """Disable a given subscriber"""
+    subscriber.active = False
+    db.commit()
+    db.refresh(subscriber)
+    return subscriber
+
+
+def enable(db: Session, subscriber: models.Subscriber):
+    """Enable a given subscriber"""
+    subscriber.active = True
+    db.commit()
+    db.refresh(subscriber)
+    return subscriber
+
+
 def delete(db: Session, subscriber: models.Subscriber):
-    """Delete a subscriber by subscriber id"""
+    """Delete a given subscriber"""
     db.delete(subscriber)
     db.commit()
     return True

--- a/backend/src/appointment/database/repo/subscriber.py
+++ b/backend/src/appointment/database/repo/subscriber.py
@@ -77,7 +77,7 @@ def disable(db: Session, subscriber: models.Subscriber):
     # mark subscriber deleted = disable them
     subscriber.time_deleted = datetime.datetime.now(datetime.UTC)
     # invalidate session
-    # subscriber.minimum_valid_iat_time = datetime.datetime.now(datetime.UTC)
+    subscriber.minimum_valid_iat_time = datetime.datetime.now(datetime.UTC)
     db.add(subscriber)
     db.commit()
     db.refresh(subscriber)
@@ -89,15 +89,15 @@ def enable(db: Session, subscriber: models.Subscriber):
     # mark subscriber deleted = disable them
     subscriber.time_deleted = None
     # refresh session
-    # subscriber.minimum_valid_iat_time = datetime.datetime.now(datetime.UTC)
+    subscriber.minimum_valid_iat_time = datetime.datetime.now(datetime.UTC)
     db.add(subscriber)
     db.commit()
     db.refresh(subscriber)
     return subscriber
 
 
-def delete(db: Session, subscriber: models.Subscriber):
-    """Delete a given subscriber"""
+def hard_delete(db: Session, subscriber: models.Subscriber):
+    """Delete a given subscriber by actually removing their record"""
     db.delete(subscriber)
     db.commit()
     return True

--- a/backend/src/appointment/database/repo/subscriber.py
+++ b/backend/src/appointment/database/repo/subscriber.py
@@ -4,6 +4,7 @@ Repository providing CRUD functions for subscriber database models.
 """
 
 import re
+import datetime
 
 from sqlalchemy.orm import Session
 from .. import models, schemas
@@ -73,7 +74,11 @@ def update(db: Session, data: schemas.SubscriberIn, subscriber_id: int):
 
 def disable(db: Session, subscriber: models.Subscriber):
     """Disable a given subscriber"""
-    subscriber.active = False
+    # mark subscriber deleted = disable them
+    subscriber.time_deleted = datetime.datetime.now(datetime.UTC)
+    # invalidate session
+    # subscriber.minimum_valid_iat_time = datetime.datetime.now(datetime.UTC)
+    db.add(subscriber)
     db.commit()
     db.refresh(subscriber)
     return subscriber
@@ -81,7 +86,11 @@ def disable(db: Session, subscriber: models.Subscriber):
 
 def enable(db: Session, subscriber: models.Subscriber):
     """Enable a given subscriber"""
-    subscriber.active = True
+    # mark subscriber deleted = disable them
+    subscriber.time_deleted = None
+    # refresh session
+    # subscriber.minimum_valid_iat_time = datetime.datetime.now(datetime.UTC)
+    db.add(subscriber)
     db.commit()
     db.refresh(subscriber)
     return subscriber

--- a/backend/src/appointment/database/schemas.py
+++ b/backend/src/appointment/database/schemas.py
@@ -269,6 +269,7 @@ class Subscriber(SubscriberAuth):
 
 
 class SubscriberAdminOut(Subscriber):
+    active: bool | None = True
     invite: Invite | None = None
     time_created: datetime
 

--- a/backend/src/appointment/database/schemas.py
+++ b/backend/src/appointment/database/schemas.py
@@ -269,9 +269,9 @@ class Subscriber(SubscriberAuth):
 
 
 class SubscriberAdminOut(Subscriber):
-    active: bool | None = True
     invite: Invite | None = None
     time_created: datetime
+    time_deleted: datetime | None
 
     class Config:
         from_attributes = True

--- a/backend/src/appointment/dependencies/auth.py
+++ b/backend/src/appointment/dependencies/auth.py
@@ -32,6 +32,7 @@ def get_user_from_token(db, token: str):
     # Token has been expired by us - temp measure to avoid spinning a refresh system, or a deny list for this issue
     if any([
         subscriber is None,
+        subscriber.is_deleted,
         subscriber and subscriber.minimum_valid_iat_time and not iat,
         subscriber and subscriber.minimum_valid_iat_time and subscriber.minimum_valid_iat_time.timestamp() > int(iat)
     ]):

--- a/backend/src/appointment/exceptions/validation.py
+++ b/backend/src/appointment/exceptions/validation.py
@@ -213,3 +213,30 @@ class CreateSubscriberAlreadyExistsException(APIException):
 
     def get_msg(self):
         return l10n('subscriber-already-exists')
+
+
+class SubscriberAlreadyDeletedException(APIException):
+    """Raise when a subscriber failed to be marked deleted because they already are"""
+    id_code = 'SUBSCRIBER_ALREADY_DELETED'
+    status_code = 400
+
+    def get_msg(self):
+        return l10n('subscriber-already-deleted')
+
+
+class SubscriberAlreadyEnabledException(APIException):
+    """Raise when a subscriber failed to be marked undeleted because they already are"""
+    id_code = 'SUBSCRIBER_ALREADY_ENABLED'
+    status_code = 400
+
+    def get_msg(self):
+        return l10n('subscriber-already-enabled')
+
+
+class SubscriberSelfDeleteException(APIException):
+    """Raise when a subscriber tries to delete themselves where not allowed"""
+    id_code = 'SUBSCRIBER_SELF_DELETE'
+    status_code = 403
+
+    def get_msg(self):
+        return l10n('subscriber-self-delete')

--- a/backend/src/appointment/l10n/de/main.ftl
+++ b/backend/src/appointment/l10n/de/main.ftl
@@ -42,6 +42,9 @@ event-could-not-be-accepted = Es ist ein Fehler bei der Annahme der Buchungsdate
 
 failed-to-create-subscriber = Es gab einen Fehler beim Anlegen der Person. Bitte später erneut versuchen.
 subscriber-already-exists = Eine Person mit dieser E-Mail-Adresse existiert bereits.
+subscriber-already-deleted = Die Person ist bereits gelöscht.
+subscriber-already-enabled = Die Person ist bereits aktiv.
+subscriber-self-delete = Die Löschung des eigenen Benutzerkontos ist hier nicht möglich.
 
 ## Authentication Exceptions
 

--- a/backend/src/appointment/l10n/de/main.ftl
+++ b/backend/src/appointment/l10n/de/main.ftl
@@ -47,6 +47,7 @@ subscriber-already-exists = Eine Person mit dieser E-Mail-Adresse existiert bere
 
 email-mismatch = E-Mail-Adressen stimmen nicht überein.
 invalid-credentials = Die angegebenen Anmeldedaten sind nicht gültig.
+disabled-account = Das Benutzerkonto wurde deaktiviert.
 oauth-error = Es ist ein Fehler bei der Authentifizierung aufgetreten. Bitte erneut versuchen.
 
 ## Zoom Exceptions

--- a/backend/src/appointment/l10n/en/main.ftl
+++ b/backend/src/appointment/l10n/en/main.ftl
@@ -47,6 +47,7 @@ subscriber-already-exists = A subscriber with this email address already exists.
 
 email-mismatch = Email mismatch.
 invalid-credentials = The provided credentials are not valid.
+disabled-account = Your account has been disabled.
 oauth-error = There was an error with the authentication flow. Please try again.
 
 ## Zoom Exceptions

--- a/backend/src/appointment/l10n/en/main.ftl
+++ b/backend/src/appointment/l10n/en/main.ftl
@@ -42,6 +42,9 @@ event-could-not-be-accepted = There was an error accepting the booking details. 
 
 failed-to-create-subscriber = There was an error creating the subscriber. Please try again later.
 subscriber-already-exists = A subscriber with this email address already exists.
+subscriber-already-deleted = The subscriber is already deleted.
+subscriber-already-enabled = The subscriber is already enabled.
+subscriber-self-delete = You are not allowed to delete yourself here.
 
 ## Authentication Exceptions
 

--- a/backend/src/appointment/migrations/versions/2024_05_31_1454-d5de8f10ab87_add_subscriber_active_flag.py
+++ b/backend/src/appointment/migrations/versions/2024_05_31_1454-d5de8f10ab87_add_subscriber_active_flag.py
@@ -1,0 +1,24 @@
+"""add subscriber active flag
+
+Revision ID: d5de8f10ab87
+Revises: 9fe08ba6f2ed
+Create Date: 2024-05-31 14:54:23.772015
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd5de8f10ab87'
+down_revision = '9fe08ba6f2ed'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('subscribers', sa.Column('active', sa.Boolean, index=True, default=True))
+
+
+def downgrade() -> None:
+    op.drop_column('subscribers', 'active')

--- a/backend/src/appointment/migrations/versions/2024_05_31_1454-d5de8f10ab87_add_subscriber_soft_delete.py
+++ b/backend/src/appointment/migrations/versions/2024_05_31_1454-d5de8f10ab87_add_subscriber_soft_delete.py
@@ -1,4 +1,4 @@
-"""add subscriber active flag
+"""add subscriber soft delete
 
 Revision ID: d5de8f10ab87
 Revises: 9fe08ba6f2ed
@@ -17,8 +17,8 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column('subscribers', sa.Column('active', sa.Boolean, index=True, default=True))
+    op.add_column('subscribers', sa.Column('time_deleted', sa.DateTime, nullable=True))
 
 
 def downgrade() -> None:
-    op.drop_column('subscribers', 'active')
+    op.drop_column('subscribers', 'time_deleted')

--- a/backend/src/appointment/routes/auth.py
+++ b/backend/src/appointment/routes/auth.py
@@ -153,7 +153,7 @@ def fxa_callback(
         subscriber = fxa_subscriber
 
     # Only proceed if user account is enabled (which is the default case for new users)
-    if not subscriber.active:
+    if subscriber.is_deleted:
         raise HTTPException(status_code=403, detail=l10n('disabled-account'))
 
     fxa_connections = repo.external_connection.get_by_type(db, subscriber.id, ExternalConnectionType.fxa)
@@ -222,7 +222,7 @@ def token(
         raise HTTPException(status_code=403, detail=l10n('invalid-credentials'))
 
     # Only proceed if user account is enabled
-    if not subscriber.active:
+    if subscriber.is_deleted:
         raise HTTPException(status_code=403, detail=l10n('disabled-account'))
 
     # Verify the incoming password, and re-hash our password if needed
@@ -279,7 +279,7 @@ def me(
 @router.post("/permission-check")
 def permission_check(subscriber: Subscriber = Depends(get_admin_subscriber)):
     """Checks if they have admin permissions"""
-    return subscriber.active
+    return subscriber.is_deleted
 
 
 # @router.get('/test-create-account')

--- a/backend/src/appointment/routes/auth.py
+++ b/backend/src/appointment/routes/auth.py
@@ -147,7 +147,7 @@ def fxa_callback(
 
         # This shouldn't happen, but just in case!
         if not used:
-            repo.subscriber.delete(db, subscriber)
+            repo.subscriber.hard_delete(db, subscriber)
             raise HTTPException(500, l10n('unknown-error'))
     elif not subscriber:
         subscriber = fxa_subscriber

--- a/backend/src/appointment/routes/subscriber.py
+++ b/backend/src/appointment/routes/subscriber.py
@@ -22,22 +22,28 @@ def get_all_subscriber(db: Session = Depends(get_db), _: Subscriber = Depends(ge
 
 
 @router.put("/disable/{email}")
-def disable_subscriber(email: str, db: Session = Depends(get_db), _: Subscriber = Depends(get_admin_subscriber)):
-    """endpoint to disable a subscriber by email, needs admin permissions"""
-    subscriber = repo.subscriber.get_by_email(db, email)
-    if not subscriber:
+def disable_subscriber(email: str, db: Session = Depends(get_db), subscriber: Subscriber = Depends(get_admin_subscriber)):
+    """endpoint to mark a subscriber deleted by email, needs admin permissions"""
+    subscriber_to_delete = repo.subscriber.get_by_email(db, email)
+    if not subscriber_to_delete:
         raise validation.SubscriberNotFoundException()
-    
+    if subscriber_to_delete.is_deleted:
+        raise validation.SubscriberAlreadyDeletedException()
+    if subscriber.email == subscriber_to_delete.email:
+        raise validation.SubscriberSelfDeleteException()
+
     # Set active flag to false on the subscribers model.
-    return repo.subscriber.disable(db, subscriber)
+    return repo.subscriber.disable(db, subscriber_to_delete)
 
 
 @router.put("/enable/{email}")
 def disable_subscriber(email: str, db: Session = Depends(get_db), _: Subscriber = Depends(get_admin_subscriber)):
-    """endpoint to disable a subscriber by email, needs admin permissions"""
-    subscriber = repo.subscriber.get_by_email(db, email)
-    if not subscriber:
+    """endpoint to enable a subscriber by email, needs admin permissions"""
+    subscriber_to_enable = repo.subscriber.get_by_email(db, email)
+    if not subscriber_to_enable:
         raise validation.SubscriberNotFoundException()
-    
+    if not subscriber_to_enable.is_deleted:
+        raise validation.SubscriberAlreadyEnabledException()
+
     # Set active flag to true on the subscribers model.
-    return repo.subscriber.enable(db, subscriber)
+    return repo.subscriber.enable(db, subscriber_to_enable)

--- a/backend/src/appointment/routes/subscriber.py
+++ b/backend/src/appointment/routes/subscriber.py
@@ -24,12 +24,20 @@ def get_all_subscriber(db: Session = Depends(get_db), _: Subscriber = Depends(ge
 @router.put("/disable/{email}")
 def disable_subscriber(email: str, db: Session = Depends(get_db), _: Subscriber = Depends(get_admin_subscriber)):
     """endpoint to disable a subscriber by email, needs admin permissions"""
-    # TODO: Add status to subscriber, and disable it instead.
-    raise NotImplementedError
-
     subscriber = repo.subscriber.get_by_email(db, email)
     if not subscriber:
         raise validation.SubscriberNotFoundException()
-    # TODO: CAUTION! This actually deletes the subscriber. We might want to only disable them.
-    # This needs an active flag on the subscribers model.
-    return repo.subscriber.delete(db, subscriber)
+    
+    # Set active flag to false on the subscribers model.
+    return repo.subscriber.disable(db, subscriber)
+
+
+@router.put("/enable/{email}")
+def disable_subscriber(email: str, db: Session = Depends(get_db), _: Subscriber = Depends(get_admin_subscriber)):
+    """endpoint to disable a subscriber by email, needs admin permissions"""
+    subscriber = repo.subscriber.get_by_email(db, email)
+    if not subscriber:
+        raise validation.SubscriberNotFoundException()
+    
+    # Set active flag to true on the subscribers model.
+    return repo.subscriber.enable(db, subscriber)

--- a/frontend/src/components/DataTable.vue
+++ b/frontend/src/components/DataTable.vue
@@ -41,6 +41,10 @@
                 <code>{{ fieldData.value }}</code>
                 <text-button :copy="fieldData.value" />
               </span>
+              <span v-else-if="fieldData.type === tableDataType.bool">
+                <span v-if="fieldData.value">Yes</span>
+                <span v-else>No</span>
+              </span>
               <span v-else-if="fieldData.type === tableDataType.link">
                 <a :href="fieldData.link" target="_blank">{{ fieldData.value }}</a>
               </span>

--- a/frontend/src/components/DataTable.vue
+++ b/frontend/src/components/DataTable.vue
@@ -8,7 +8,9 @@
         <label class="flex items-center gap-4 whitespace-nowrap">
         {{ filter.name }} {{ t('label.filter') }}:
         <select class="rounded-md" @change="(evt) => onColumnFilter(evt, filter)">
-          <option :value="option.key" v-for="option in filter.options" :key="option.key">{{ option.name }}</option>
+          <option :value="option.key" v-for="option in filter.options" :key="option.key">
+            {{ option.name }}
+          </option>
         </select>
         </label>
       </div>
@@ -173,7 +175,6 @@ const onFieldSelect = (evt, fieldData) => {
 
 const onColumnFilter = (evt, filter) => {
   mutableDataList.value = filter.fn(evt.target.value, dataList.value);
-  console.log('Data list info: ', mutableDataList.value, ' vs ', dataList.value);
   if (mutableDataList.value === dataList.value) {
     mutableDataList.value = null;
   }

--- a/frontend/src/definitions.js
+++ b/frontend/src/definitions.js
@@ -253,6 +253,7 @@ export const tableDataType = {
   link: 2,
   button: 3,
   code: 4,
+  bool: 5,
 };
 
 export const tableDataButtonType = {

--- a/frontend/src/views/admin/SubscriberPanelView.vue
+++ b/frontend/src/views/admin/SubscriberPanelView.vue
@@ -108,7 +108,7 @@ const filteredSubscribers = computed(() => subscribers.value.map((subscriber) =>
   },
   wasInvited: {
     type: tableDataType.bool,
-    value: subscriber.invite,
+    value: Boolean(subscriber.invite),
   },
   disable: {
     type: tableDataType.button,
@@ -161,11 +161,11 @@ const filters = [
       },
       {
         name: 'Yes',
-        key: 'yes',
+        key: 'true',
       },
       {
         name: 'No',
-        key: 'no',
+        key: 'false',
       },
     ],
     /**
@@ -178,7 +178,7 @@ const filters = [
       if (selectedKey === 'all') {
         return mutableDataList;
       }
-      return mutableDataList.filter((data) => data.wasInvited.value.toLowerCase() === selectedKey);
+      return mutableDataList.filter((data) => data.wasInvited.value?.toString().toLowerCase() === selectedKey);
     },
   },
 ];


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change extends the subscribers model by an active flag and the subscribers panel with buttons for disabling / enabling them.

![image](https://github.com/thunderbird/appointment/assets/5441654/fd11cadc-3c4d-4d63-96d7-1f325b930869)

Also introduces a new data table type `bool` for binary fields.

I added checks for active flag to the login flow, but there must be more places to check for that (maybe even as middleware? I dont know if necessary). @MelissaAutumn Could you add that if needed?

## Benefits

Control over subscribers to quickly ban or reenable them.

## Applicable Issues

Implements a part of #292 