### PR TITLE
Apply the sentry dsn for frontend builds

### DIFF
--- a/frontend/.env.prod.example
+++ b/frontend/.env.prod.example
@@ -4,6 +4,9 @@ VITE_BASE_URL=appointment.day
 VITE_API_SECURE=true
 VITE_SHORT_BASE_URL=https://apmt.day
 
+# -- Sentry --
+VITE_SENTRY_DSN=https://66f57328baac4929be7d62b77f41b510@o4505428107853824.ingest.sentry.io/4505428280279040
+
 # -- Auth scheme --
 VITE_AUTH_SCHEME=fxa
 

--- a/frontend/.env.stage.example
+++ b/frontend/.env.stage.example
@@ -4,6 +4,9 @@ VITE_BASE_URL=stage.appointment.day
 VITE_API_SECURE=true
 VITE_SHORT_BASE_URL=https://stage.apmt.day
 
+# -- Sentry --
+VITE_SENTRY_DSN=https://66f57328baac4929be7d62b77f41b510@o4505428107853824.ingest.sentry.io/4505428280279040
+
 # -- Auth scheme --
 VITE_AUTH_SCHEME=fxa
 


### PR DESCRIPTION
I forgot I manually built prod while our IaC was being developed. These are safe to be public, I believe it's setup to ignore requests not from our domains. 