### PR TITLE
added trimprefix to frontend_url

### DIFF
--- a/tofu/modules/services/backend-infra/main.tf
+++ b/tofu/modules/services/backend-infra/main.tf
@@ -123,7 +123,7 @@ module "backend_alb" {
 
       redirect = {
         status_code = "HTTP_302"
-        host        = var.frontend_url
+        host        = trimprefix(var.frontend_url, "https://")
         path        = "/user/#{path}"
         port        = 443
         protocol    = "HTTPS"

--- a/tofu/modules/services/frontend-infra/main.tf
+++ b/tofu/modules/services/frontend-infra/main.tf
@@ -88,7 +88,7 @@ resource "aws_cloudfront_distribution" "appointment" {
   comment = "appointment ${var.environment} frontend"
   enabled = true
 
-  aliases = [var.frontend_url]
+  aliases = [trimprefix(var.frontend_url, "https://")]
 
   logging_config {
     bucket          = "${aws_s3_bucket.request_logs.id}.s3.amazonaws.com"


### PR DESCRIPTION
## Description of the Change

Some AWS resources require a "https://" prefix while others do not, this trims that prefix where it is not needed

## Benefits

AWS resources requiring the prefix to be removed will launch correctly