### PR TITLE
Unify close button class

### DIFF
--- a/frontend/src/elements/AlertBox.vue
+++ b/frontend/src/elements/AlertBox.vue
@@ -23,7 +23,7 @@
   <span class="ml-1 block sm:inline">
     <slot></slot>
   </span>
-  <span v-if="canClose" class="alert-close ml-auto" @click="emit('close')" :title="t('label.close')">
+  <span v-if="canClose" class="btn-close ml-auto" @click="emit('close')" :title="t('label.close')">
     <icon-x class="size-6 cursor-pointer fill-transparent stroke-white stroke-1" />
   </span>
 </div>


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

Just a quick additional fix after #469. Forgot to unify the `.alert-close` button too.

## Applicable Issues

#451 
