### PR TITLE
Copy a dummy file to prevent import errors

### DIFF
--- a/backend/deploy.dockerfile
+++ b/backend/deploy.dockerfile
@@ -25,6 +25,7 @@ COPY src .
 
 # Remove setup.py as we don't need it on stage/prod
 RUN rm /app/appointment/commands/setup.py
+COPY scripts/dummy_setup.py /app/appointment/commands/setup.py
 
 RUN pip install --upgrade pip
 RUN pip install .'[deploy]'

--- a/backend/scripts/dummy_setup.py
+++ b/backend/scripts/dummy_setup.py
@@ -1,0 +1,7 @@
+"""
+An empty file to replace setup.py for stage/production environments
+"""
+
+
+def run():
+    pass


### PR DESCRIPTION
We remove the setup command from stage/prod dockerfile but this causes an import error. So let's copy over a dummy file for now. 