### PR TITLE
Fix uuids always producing the same result:

### DIFF
--- a/backend/src/appointment/database/models.py
+++ b/backend/src/appointment/database/models.py
@@ -179,7 +179,7 @@ class Appointment(Base):
     __tablename__ = 'appointments'
 
     id = Column(Integer, primary_key=True, index=True)
-    uuid = Column(UUIDType(native=False), default=uuid.uuid4(), index=True)
+    uuid = Column(UUIDType(native=False), default=uuid.uuid4, index=True, unique=True)
     calendar_id = Column(Integer, ForeignKey('calendars.id'))
     duration = Column(Integer)
     title = Column(encrypted_type(String))

--- a/backend/src/appointment/migrations/versions/2024_06_13_1525-e6ed0429ed46_fix_appointment_uuids.py
+++ b/backend/src/appointment/migrations/versions/2024_06_13_1525-e6ed0429ed46_fix_appointment_uuids.py
@@ -1,0 +1,33 @@
+"""fix appointment uuids
+
+Revision ID: e6ed0429ed46
+Revises: 12c7e1b34dd6
+Create Date: 2024-06-13 15:25:07.086174
+
+"""
+import uuid
+
+from alembic import op
+from sqlalchemy.orm import Session
+
+from appointment.database import models, repo
+
+
+# revision identifiers, used by Alembic.
+revision = 'e6ed0429ed46'
+down_revision = '12c7e1b34dd6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    session = Session(op.get_bind())
+    appointments: list[models.Appointment] = session.query(models.Appointment).all()
+    for appointment in appointments:
+        appointment.uuid = uuid.uuid4()
+        session.add(appointment)
+        session.commit()
+
+
+def downgrade() -> None:
+    pass

--- a/backend/src/appointment/migrations/versions/2024_06_13_1525-f732d6e597fe_update_appointments_make_uuid_.py
+++ b/backend/src/appointment/migrations/versions/2024_06_13_1525-f732d6e597fe_update_appointments_make_uuid_.py
@@ -1,0 +1,26 @@
+"""update appointments make uuid unique
+
+Revision ID: f732d6e597fe
+Revises: e6ed0429ed46
+Create Date: 2024-06-13 15:25:22.440864
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f732d6e597fe'
+down_revision = 'e6ed0429ed46'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_index('ix_appointments_uuid', 'appointments')
+    op.create_index('ix_appointments_uuid', 'appointments', ['uuid'], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index('ix_appointments_uuid', 'appointments')
+    op.create_index('ix_appointments_uuid', 'appointments', ['uuid'], unique=False)

--- a/backend/test/unit/test_models.py
+++ b/backend/test/unit/test_models.py
@@ -1,0 +1,28 @@
+from appointment.database import models, repo, schemas
+
+
+class TestAppointment:
+    def test_appointment_uuids_are_unique(self, with_db, make_caldav_calendar):
+        calendar = make_caldav_calendar()
+        with with_db() as db:
+
+            def get_data():
+                return schemas.AppointmentFull(
+                    title='test',
+                    details='my appointment!',
+                    calendar_id=calendar.id,
+                )
+
+            assert len(db.query(models.Appointment).all()) == 0
+
+            appointments = [
+                repo.appointment.create(db, get_data()),
+                repo.appointment.create(db, get_data()),
+                repo.appointment.create(db, get_data()),
+                repo.appointment.create(db, get_data()),
+            ]
+
+            assert len(db.query(models.Appointment).all()) == len(appointments)
+
+            for appointment in appointments:
+                assert len(db.query(models.Appointment).filter(models.Appointment.uuid == appointment.uuid).all()) == 1


### PR DESCRIPTION
* Pass uuid as a callable not a result
* Fix re-create the uuid index to make them unique
* Re-generate all uuids
* Add tests to test uniqueness.

Easy mistake to miss, now fixed and tested.