### PR TITLE
Features/448 health check v2

### DIFF
--- a/backend/.env.test
+++ b/backend/.env.test
@@ -2,7 +2,7 @@
 
 # -- GENERAL --
 # Logging level: DEBUG|INFO|WARNING|ERROR|CRITICAL
-LOG_LEVEL=ERROR
+LOG_LEVEL=DEBUG
 LOG_USE_STREAM=1
 
 # -- FRONTEND --
@@ -90,7 +90,7 @@ GOOGLE_TEST_PASS=
 TEST_USER_EMAIL=test@example.org
 
 # -- Redis --
-REDIS_URL=localhost
+REDIS_URL
 REDIS_PORT=6379
 REDIS_DB=0
 # No value = Python None

--- a/backend/src/appointment/dependencies/database.py
+++ b/backend/src/appointment/dependencies/database.py
@@ -39,7 +39,7 @@ def get_redis() -> Redis | RedisCluster | None:
     port = int(os.getenv('REDIS_PORT'))
     db = os.getenv('REDIS_DB')
     password = os.getenv('REDIS_PASSWORD')
-    ssl = os.getenv('REDIS_USE_SSL')
+    ssl = True if os.getenv('REDIS_USE_SSL').lower() == 'true' or os.getenv('REDIS_USE_SSL').lower() == '1' else False
 
     if os.getenv('REDIS_USE_CLUSTER'):
         return RedisCluster(

--- a/backend/src/appointment/dependencies/database.py
+++ b/backend/src/appointment/dependencies/database.py
@@ -39,7 +39,7 @@ def get_redis() -> Redis | RedisCluster | None:
     port = int(os.getenv('REDIS_PORT'))
     db = os.getenv('REDIS_DB')
     password = os.getenv('REDIS_PASSWORD')
-    ssl = True if os.getenv('REDIS_USE_SSL').lower() == 'true' or os.getenv('REDIS_USE_SSL').lower() == '1' else False
+    ssl = True if os.getenv('REDIS_USE_SSL') and (os.getenv('REDIS_USE_SSL').lower() == 'true' or os.getenv('REDIS_USE_SSL').lower() == '1') else False
 
     if os.getenv('REDIS_USE_CLUSTER'):
         return RedisCluster(

--- a/backend/src/appointment/l10n/en/main.ftl
+++ b/backend/src/appointment/l10n/en/main.ftl
@@ -7,6 +7,7 @@ locale = en
 
 # Should indicate application wellness.
 health-ok = Health OK
+health-bad = Health BAD
 
 ## General Exceptions
 

--- a/backend/src/appointment/main.py
+++ b/backend/src/appointment/main.py
@@ -38,7 +38,8 @@ import sentry_sdk
 
 def _common_setup():
     # load any available .env into env
-    load_dotenv()
+    if os.getenv('APP_ENV') != APP_ENV_TEST:
+        load_dotenv()
 
     # This needs to be ran before any other imports
     normalize_secrets()

--- a/backend/src/appointment/routes/api.py
+++ b/backend/src/appointment/routes/api.py
@@ -37,7 +37,6 @@ def health(db: Session = Depends(get_db)):
     try:
         db.query(Subscriber).first()
     except Exception as ex:
-        print("Ex -> ",ex)
         sentry_sdk.capture_exception(ex)
         return JSONResponse(content=l10n('health-bad'), status_code=503)
 
@@ -46,7 +45,6 @@ def health(db: Session = Depends(get_db)):
             redis_instance: Redis | RedisCluster | None = get_redis()
             redis_instance.ping()
         except Exception as ex:
-            print("Ex -> ", ex)
             sentry_sdk.capture_exception(ex)
             return JSONResponse(content=l10n('health-bad'), status_code=503)
 

--- a/backend/src/appointment/routes/api.py
+++ b/backend/src/appointment/routes/api.py
@@ -37,6 +37,7 @@ def health(db: Session = Depends(get_db)):
     try:
         db.query(Subscriber).first()
     except Exception as ex:
+        print("Ex -> ",ex)
         sentry_sdk.capture_exception(ex)
         return JSONResponse(content=l10n('health-bad'), status_code=503)
 
@@ -45,6 +46,7 @@ def health(db: Session = Depends(get_db)):
             redis_instance: Redis | RedisCluster | None = get_redis()
             redis_instance.ping()
         except Exception as ex:
+            print("Ex -> ", ex)
             sentry_sdk.capture_exception(ex)
             return JSONResponse(content=l10n('health-bad'), status_code=503)
 

--- a/backend/src/appointment/routes/api.py
+++ b/backend/src/appointment/routes/api.py
@@ -1,12 +1,15 @@
+import enum
 import os
 import secrets
+from enum import Enum
 
 import requests.exceptions
+import sentry_sdk
 from redis import Redis, RedisCluster
 
 # database
 from sqlalchemy.orm import Session
-from starlette.responses import HTMLResponse
+from starlette.responses import HTMLResponse, JSONResponse
 
 from .. import utils
 from ..database import repo, schemas
@@ -29,9 +32,23 @@ router = APIRouter()
 
 
 @router.get('/')
-def health():
+def health(db: Session = Depends(get_db)):
     """Small route with no processing that will be used for health checks"""
-    return l10n('health-ok')
+    try:
+        db.query(Subscriber).first()
+    except Exception as ex:
+        sentry_sdk.capture_exception(ex)
+        return JSONResponse(content=l10n('health-bad'), status_code=503)
+
+    if os.getenv('REDIS_URL'):
+        try:
+            redis_instance: Redis | RedisCluster | None = get_redis()
+            redis_instance.ping()
+        except Exception as ex:
+            sentry_sdk.capture_exception(ex)
+            return JSONResponse(content=l10n('health-bad'), status_code=503)
+
+    return JSONResponse(l10n('health-ok'), status_code=200)
 
 
 @router.put('/me', response_model=schemas.SubscriberBase)

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -23,7 +23,8 @@ from factory.subscriber_factory import make_subscriber, make_basic_subscriber, m
 from factory.invite_factory import make_invite  # noqa: F401
 
 # Load our env
-load_dotenv(find_dotenv('.env.test'))
+print("Conftes.py")
+load_dotenv(find_dotenv('.env.test'), override=True)
 
 from appointment.main import server  # noqa: E402
 from appointment.database import models, repo, schemas  # noqa: E402

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -23,7 +23,6 @@ from factory.subscriber_factory import make_subscriber, make_basic_subscriber, m
 from factory.invite_factory import make_invite  # noqa: F401
 
 # Load our env
-print("Conftes.py")
 load_dotenv(find_dotenv('.env.test'), override=True)
 
 from appointment.main import server  # noqa: E402


### PR DESCRIPTION
The healthcheck will now return 503's if MySQL or Redis (If configured) are missing. Otherwise you'll get a 200 `Health OK` message. Technically this message is localized so it ensures locale is working as well. Since the default locale is English, it should say "Health OK". No need to check that though.

This also fixes a local config issue with redis, and tests accidentally inheriting "None" values from your main .env.