### PR TITLE
Update regex to allow for spaces and plus signs, and remove the hash before booking.

### DIFF
--- a/backend/src/appointment/utils.py
+++ b/backend/src/appointment/utils.py
@@ -46,7 +46,7 @@ def setup_encryption_engine():
 
 def retrieve_user_url_data(url):
     """Retrieves username, signature, and main url from /<username>/<signature>/"""
-    pattern = r"[\/]([\w\d\-_\.\@!]+)[\/]?([\w\d\-_\.\@!]*)[\/]?$"
+    pattern = r"[\/]([\w\d\-_\.\@!\+\%]+)[\/]?([\w\d\-_\.\@!\+]*)[\/]?$"
     match = re.findall(pattern, url)
 
     if match is None or len(match) == 0:

--- a/frontend/src/views/BookingView.vue
+++ b/frontend/src/views/BookingView.vue
@@ -183,9 +183,10 @@ const bookEvent = async (attendeeData) => {
     attendee: attendeeData,
   };
 
+  const url = window.location.href.split('#')[0];
   const request = call('schedule/public/availability/request').put({
     s_a: obj,
-    url: window.location.href,
+    url,
   });
 
   // Data should just be true here.


### PR DESCRIPTION
Fixes #500 

This only affects you if you dig into week or day view, but we handle it by removing the hash from the url before we send it up. So this applies it in the booking function.

Also retrieve_user_url_data basically takes `/mel/a6b24d4c/` and splits it into (`mel`, `a6b24d4c`, `/mel/a6b24d4c/`). I'm starting to think we should just split by slash, but that can be another PR. 