### PR TITLE
Don't raise exception if we have an invite code

### DIFF
--- a/backend/src/appointment/routes/auth.py
+++ b/backend/src/appointment/routes/auth.py
@@ -75,7 +75,8 @@ def fxa_login(
     try:
         url, state = fxa_client.get_redirect_url(db, token_urlsafe(32), email)
     except NotInAllowListException:
-        raise HTTPException(status_code=403, detail='Your email is not in the allow list')
+        if not invite_code:
+            raise HTTPException(status_code=403, detail='Your email is not in the allow list')
 
     request.session['fxa_state'] = state
     request.session['fxa_user_email'] = email


### PR DESCRIPTION
Fixes #511 

The first check is so we can show a nice error on the frontend, there's a second check later on. We should clean this up, but i'm waiting for a design refresh first. So here's the fix. 