### PR TITLE
Configuration to fix HMR

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -5,6 +5,8 @@ VITE_BASE_URL=localhost:8080
 VITE_SHORT_BASE_URL=http://localhost:8080/user
 # Set true to activate polling for dev server 
 VITE_SERVER_WATCH_POLLING=
+VITE_SERVER_WATCH_INTERVAL=
+VITE_SERVER_WATCH_BINARY_INTERVAL=
 
 # -- Backend API --
 VITE_API_URL=localhost

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -3,6 +3,8 @@
 # -- Frontend --
 VITE_BASE_URL=localhost:8080
 VITE_SHORT_BASE_URL=http://localhost:8080/user
+# Set true to activate polling for dev server 
+VITE_SERVER_WATCH_POLLING=
 
 # -- Backend API --
 VITE_API_URL=localhost

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,13 +1,24 @@
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import { fileURLToPath, URL } from 'node:url';
 
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig, loadEnv, WatchOptions } from 'vite';
 import vue from '@vitejs/plugin-vue';
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   // Load env file based on `mode` in the current working directory.
   const env = loadEnv(mode, process.cwd());
+
+  // Build watch options
+  const watch = {
+    usePolling: env.VITE_SERVER_WATCH_POLLING === 'true'
+  } as WatchOptions;
+  if (env.VITE_SERVER_WATCH_INTERVAL) {
+    watch.interval = Number(env.VITE_SERVER_WATCH_INTERVAL);
+  }
+  if (env.VITE_SERVER_WATCH_BINARY_INTERVAL) {
+    watch.binaryInterval = Number(env.VITE_SERVER_WATCH_BINARY_INTERVAL);
+  }
 
   return {
     plugins: [
@@ -30,15 +41,7 @@ export default defineConfig(({ mode }) => {
 
     server: {
       host: '0.0.0.0',
-      hmr: {
-        clientPort: 8080,
-      },
-      port: 8080,
-      watch: {
-        usePolling: env.VITE_SERVER_WATCH_POLLING === 'true',
-        interval: 1500,
-        binaryInterval: 3000,
-      },
+      watch: watch,
     },
 
     build: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -26,6 +26,13 @@ export default defineConfig({
 
   server: {
     host: '0.0.0.0',
+    hmr: {
+      clientPort: 8080,
+    },
+    port: 8080,
+    watch: {
+      usePolling: true,
+    },
   },
 
   build: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,41 +1,48 @@
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import { fileURLToPath, URL } from 'node:url';
 
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import vue from '@vitejs/plugin-vue';
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [
-    vue({
-      script: {
-        defineModel: true,
+export default defineConfig(({ mode }) => {
+  // Load env file based on `mode` in the current working directory.
+  const env = loadEnv(mode, process.cwd());
+
+  return {
+    plugins: [
+      vue({
+        script: {
+          defineModel: true,
+        },
+      }),
+      sentryVitePlugin({
+        org: 'thunderbird',
+        project: 'appointment-frontend',
+      }),
+    ],
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
       },
-    }),
-    sentryVitePlugin({
-      org: 'thunderbird',
-      project: 'appointment-frontend',
-    }),
-  ],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
+      extensions: ['.ts', '.js', '.vue'],
     },
-    extensions: ['.ts', '.js', '.vue'],
-  },
 
-  server: {
-    host: '0.0.0.0',
-    hmr: {
-      clientPort: 8080,
+    server: {
+      host: '0.0.0.0',
+      hmr: {
+        clientPort: 8080,
+      },
+      port: 8080,
+      watch: {
+        usePolling: env.VITE_SERVER_WATCH_POLLING === 'true',
+        interval: 1500,
+        binaryInterval: 3000,
+      },
     },
-    port: 8080,
-    watch: {
-      usePolling: true,
-    },
-  },
 
-  build: {
-    sourcemap: true,
-  },
+    build: {
+      sourcemap: true,
+    },
+  }
 });

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -2,19 +2,22 @@ import { fileURLToPath } from 'node:url';
 import { defineConfig, mergeConfig } from 'vitest/config';
 import viteConfig from './vite.config';
 
-export default mergeConfig(viteConfig, defineConfig({
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
+export default defineConfig(configEnv => mergeConfig(
+  viteConfig(configEnv),
+  defineConfig({
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+      },
+      extensions: ['ts', '.js', '.vue'],
     },
-    extensions: ['ts', '.js', '.vue'],
-  },
-  test: {
-    setupFiles: [
-      '/test/setup/fix-fetch.js',
-    ],
-    globals: true,
-    environment: 'jsdom',
-    root: fileURLToPath(new URL('./', import.meta.url)),
-  },
-}));
+    test: {
+      setupFiles: [
+        '/test/setup/fix-fetch.js',
+      ],
+      globals: true,
+      environment: 'jsdom',
+      root: fileURLToPath(new URL('./', import.meta.url)),
+    },
+  })
+));


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

Ever since we switched to Vite, my docker container struggles to properly handle hot module reload (HMR), which is a pain for development on my end. I found a configuration for the server section in vite.config.ts which restores HMR for me.

If this doesn't have any known side effects or interference with other configuration, it would improve my dev flow a lot 😇 