### PR TITLE
Bake in the github short sha as the container's release version.

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -212,11 +212,12 @@ jobs:
         id: build-backend
         env:
           ECR_TAG: '${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT }}:backend-${{ github.sha }}'
+          RELEASE_VERSION: vars.GITHUB_SHA
         run: |
           # Build a docker container and
           # push it to ECR so that it can
           # be deployed to ECS.
-          docker build -t $ECR_TAG ./backend -f ./backend/deploy.dockerfile
+          docker build --build-arg "RELEASE_VERSION=$RELEASE_VERSION" -t $ECR_TAG ./backend -f ./backend/deploy.dockerfile
           docker push $ECR_TAG
           echo "image_backend=$ECR_TAG" >> $GITHUB_OUTPUT
           echo $ECR_TAG > ecr_tag.txt

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -212,7 +212,7 @@ jobs:
         id: build-backend
         env:
           ECR_TAG: '${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT }}:backend-${{ github.sha }}'
-          RELEASE_VERSION: vars.GITHUB_SHA
+          RELEASE_VERSION: ${{ github.sha }}
         run: |
           # Build a docker container and
           # push it to ECR so that it can

--- a/backend/deploy.dockerfile
+++ b/backend/deploy.dockerfile
@@ -36,6 +36,8 @@ RUN pip install .'[deploy]'
 RUN mkdir src
 RUN ln -s /app/appointment src/appointment
 
+ARG RELEASE_VERSION
+ENV RELEASE_VERSION=$RELEASE_VERSION
 
 EXPOSE 5000
 CMD ["/bin/sh", "./scripts/entry.sh"]


### PR DESCRIPTION
I believe this should work. Tested the container side of things locally, without providing one it's an empty env variable, when providing something it fills it in correctly. 