### PR TITLE
Use server_default for migrations, and fix a logic error from my suggestion

### DIFF
--- a/backend/src/appointment/migrations/versions/2024_07_04_1501-fb1feb76c467_schedule_booking_confirmation.py
+++ b/backend/src/appointment/migrations/versions/2024_07_04_1501-fb1feb76c467_schedule_booking_confirmation.py
@@ -7,7 +7,7 @@ Create Date: 2024-07-04 15:01:47.090876
 """
 from alembic import op
 import sqlalchemy as sa
-
+from sqlalchemy import true
 
 # revision identifiers, used by Alembic.
 revision = 'fb1feb76c467'
@@ -17,7 +17,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column('schedules', sa.Column('booking_confirmation', sa.Boolean, nullable=False, default=True, index=True))
+    op.add_column('schedules', sa.Column('booking_confirmation', sa.Boolean, nullable=False, server_default=true(), index=True))
 
 
 def downgrade() -> None:

--- a/frontend/src/views/BookingView.vue
+++ b/frontend/src/views/BookingView.vue
@@ -25,7 +25,7 @@
       <booking-view-success
         :attendee-email="attendee.email"
         :selected-event="selectedEvent"
-        :requested="appointment.booking_confirmation"
+        :requested="appointment?.booking_confirmation"
       />
     </main>
     <!-- booking page content: time slot selection -->
@@ -42,7 +42,7 @@
     <booking-modal
       :open="showBookingModal"
       :event="selectedEvent"
-      :requires-confirmation="appointment.booking_confirmation"
+      :requires-confirmation="appointment?.booking_confirmation"
       @book="bookEvent"
       @close="closeModal()"
     />


### PR DESCRIPTION
This is what I get for looking at things and going "eh, that checks out." without manually checking it out.

The migration wasn't working with default, so I swapped it to server_default along with their true() function. Otherwise existing schedules would have this set as false 😱 

And fixed an error from my suggestion that we can't really work-around with the existing store setup. So adding those question marks back in! 