### PR TITLE
Fix timezone conversion

### DIFF
--- a/frontend/src/components/BookingModal.vue
+++ b/frontend/src/components/BookingModal.vue
@@ -22,7 +22,7 @@
       <div v-if="!isFinished" class="mb-4 text-center text-sm text-teal-500 underline underline-offset-2">
         {{ t('label.timeZone') }}: {{ dj.tz.guess() }}
       </div>
-      <div v-if="!isFinished && route.name === 'availability'" class="text-center text-sm font-semibold">
+      <div v-if="!isFinished && route.name === 'availability' && requiresConfirmation" class="text-center text-sm font-semibold">
         {{ t('text.disclaimerGABooking') }}
       </div>
       <form v-if="!isFinished" ref="bookingForm" class="my-8 flex flex-col gap-4">

--- a/frontend/src/stores/appointment-store.ts
+++ b/frontend/src/stores/appointment-store.ts
@@ -32,7 +32,7 @@ export const useAppointmentStore = defineStore('appointments', () => {
       a.active = a.status !== bookingStatus.booked;
       // convert start dates from UTC back to users timezone
       a.slots.forEach((s: Slot) => {
-        s.start = dj(s.start).utc().tz(userStore.data.timezone ?? tzGuess);
+        s.start = dj(s.start).utc(true).tz(userStore.data.timezone ?? tzGuess);
       });
     });
   };

--- a/frontend/test/stores/appointment-store.test.js
+++ b/frontend/test/stores/appointment-store.test.js
@@ -89,6 +89,9 @@ describe('Appointment Store', () => {
   test('timezone', async () => {
     const apmt = useAppointmentStore();
     await apmt.fetch(createFetch({ baseUrl: API_URL }));
+    // TODO This check depends on the timzone set in the user store.
+    // If no user timezone is set it defaults to UTC, which is currently the case.
+    // So we might want to adjust the github workflow runner to set a timezone for testing.
     expect(apmt.appointments[0].slots[0].start.toISOString()).toBe('3000-01-01T09:00:00.000Z');
   });
 

--- a/frontend/test/stores/appointment-store.test.js
+++ b/frontend/test/stores/appointment-store.test.js
@@ -86,6 +86,12 @@ describe('Appointment Store', () => {
     expect(apmt.pendingAppointments.length).toBe(1);
   });
 
+  test('timezone', async () => {
+    const apmt = useAppointmentStore();
+    await apmt.fetch(createFetch({ baseUrl: API_URL }));
+    expect(apmt.appointments[0].slots[0].start.toISOString()).toBe('3000-01-01T09:00:00.000Z');
+  });
+
   test('reset', async () => {
     const apmt = useAppointmentStore();
     await apmt.fetch(createFetch({ baseUrl: API_URL }));
@@ -94,7 +100,7 @@ describe('Appointment Store', () => {
     expect(apmt.isLoaded).toBe(true);
     expect(apmt.appointments.length).toBe(2);
 
-    // Reset the user which should null all user data.
+    // Reset the appointment which should null all appointment data.
     apmt.$reset();
 
     // Ensure our data is null/don't exist

--- a/frontend/test/stores/calendar-store.test.js
+++ b/frontend/test/stores/calendar-store.test.js
@@ -83,7 +83,7 @@ describe('Calendar Store', () => {
     expect(calStore.isLoaded).toBe(true);
     expect(calStore.calendars.length).toBe(2);
 
-    // Reset the user which should null all user data.
+    // Reset the calendar which should null all calendar data.
     calStore.$reset();
 
     // Ensure our data is null/don't exist


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

We had an issue where times on all appointments from the appointment store were displayed in the wrong timezone, if the timezone between owner and bookee was different. I think I did that wrong last time I touched this 😅 

Also I removed the "Your booking will be confirmed by the calendar owner." hint from the booking model if confirmation was disabled.

## Benefits

Correct times again.

## Applicable Issues

Closes #542 
