### PR TITLE
Add slow api rate limiting

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -33,3 +33,4 @@ requests-oauthlib==2.0.0
 redis==5.0.7
 hiredis==2.3.2
 posthog==3.5.0
+slowapi==0.1.9

--- a/backend/src/appointment/exceptions/validation.py
+++ b/backend/src/appointment/exceptions/validation.py
@@ -304,3 +304,13 @@ class OAuthFlowNotFinished(APIException):
     id_code = 'OAUTH_FLOW_NOT_FINISHED'
     status_code = 400
     message_key = 'oauth-error'  # By default
+
+
+class APIRateLimitExceeded(APIException):
+    """Is raised when rate limit is exceeded"""
+
+    id_code = 'RATE_LIMIT_EXCEEDED'
+    status_code = 429
+
+    def get_msg(self):
+        return l10n('rate-limit-exceeded')

--- a/backend/src/appointment/l10n/de/main.ftl
+++ b/backend/src/appointment/l10n/de/main.ftl
@@ -55,6 +55,8 @@ subscriber-already-deleted = Die Person ist bereits gelöscht.
 subscriber-already-enabled = Die Person ist bereits aktiv.
 subscriber-self-delete = Die Löschung des eigenen Benutzerkontos ist hier nicht möglich.
 
+rate-limit-exceeded = Zu viele Anfragen in zu kurzem Zeitraum. Bitte später noch einmal versuchen.
+
 ## Authentication Exceptions
 
 email-mismatch = E-Mail-Adressen stimmen nicht überein.

--- a/backend/src/appointment/l10n/en/main.ftl
+++ b/backend/src/appointment/l10n/en/main.ftl
@@ -55,6 +55,8 @@ subscriber-already-deleted = The subscriber is already deleted.
 subscriber-already-enabled = The subscriber is already enabled.
 subscriber-self-delete = You are not allowed to delete yourself here.
 
+rate-limit-exceeded = Too many requests in a short period. Please try again later.
+
 ## Authentication Exceptions
 
 email-mismatch = Email mismatch.

--- a/backend/src/appointment/routes/schedule.py
+++ b/backend/src/appointment/routes/schedule.py
@@ -125,7 +125,7 @@ def update_schedule(
 
 
 @router.post('/public/availability', response_model=schemas.AppointmentOut)
-@limiter.limit("10/minute")
+@limiter.limit("20/minute")
 def read_schedule_availabilities(
     request: Request,
     subscriber: Subscriber = Depends(get_subscriber_from_schedule_or_signed_url),
@@ -181,7 +181,7 @@ def read_schedule_availabilities(
 
 
 @router.put('/public/availability/request')
-@limiter.limit("10/minute")
+@limiter.limit("20/minute")
 def request_schedule_availability_slot(
     request: Request,
     s_a: schemas.AvailabilitySlotAttendee,

--- a/backend/src/appointment/routes/schedule.py
+++ b/backend/src/appointment/routes/schedule.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Body, BackgroundTasks
+from fastapi import APIRouter, Depends, BackgroundTasks, Request
 import logging
 import os
 
@@ -39,8 +39,11 @@ from ..tasks.emails import (
     send_rejection_email,
     send_zoom_meeting_failed_email, send_new_booking_email,
 )
+from slowapi import Limiter
+from slowapi.util import get_remote_address
 
 router = APIRouter()
+limiter = Limiter(key_func=get_remote_address)
 
 
 @router.post('/', response_model=schemas.Schedule)
@@ -122,7 +125,9 @@ def update_schedule(
 
 
 @router.post('/public/availability', response_model=schemas.AppointmentOut)
+@limiter.limit("10/minute")
 def read_schedule_availabilities(
+    request: Request,
     subscriber: Subscriber = Depends(get_subscriber_from_schedule_or_signed_url),
     db: Session = Depends(get_db),
     redis=Depends(get_redis),
@@ -176,7 +181,9 @@ def read_schedule_availabilities(
 
 
 @router.put('/public/availability/request')
+@limiter.limit("10/minute")
 def request_schedule_availability_slot(
+    request: Request,
     s_a: schemas.AvailabilitySlotAttendee,
     background_tasks: BackgroundTasks,
     subscriber: Subscriber = Depends(get_subscriber_from_schedule_or_signed_url),

--- a/backend/test/integration/test_waiting_list.py
+++ b/backend/test/integration/test_waiting_list.py
@@ -7,6 +7,7 @@ from appointment.database import models
 from unittest.mock import patch
 
 from appointment.exceptions.validation import APIRateLimitExceeded
+from appointment.routes import waiting_list
 from appointment.routes.waiting_list import WaitingListAction
 from appointment.tasks.emails import send_confirm_email, send_invite_account_email
 from defines import auth_headers
@@ -66,6 +67,9 @@ class TestJoinWaitingList:
 
     def test_rate_limited(self, with_db, with_client):
         """Make sure our rate limit kicks in after 2 requests."""
+        # Reset the waiting list limiter
+        # FIXME: There's gotta be a nicer way to compose this...
+        waiting_list.limiter.reset()
 
         # Oops, they messed up the first sign-up
         email = 'incorrect_spelling_oops@example.org'

--- a/backend/test/integration/test_waiting_list.py
+++ b/backend/test/integration/test_waiting_list.py
@@ -3,11 +3,10 @@ import pytest
 from itsdangerous import URLSafeSerializer
 from sqlalchemy.exc import InvalidRequestError
 
-from appointment.database import models, schemas
+from appointment.database import models
 from unittest.mock import patch
 
-from appointment.dependencies.auth import get_admin_subscriber, get_subscriber
-from appointment.routes.auth import create_access_token
+from appointment.exceptions.validation import APIRateLimitExceeded
 from appointment.routes.waiting_list import WaitingListAction
 from appointment.tasks.emails import send_confirm_email, send_invite_account_email
 from defines import auth_headers
@@ -64,6 +63,34 @@ class TestJoinWaitingList:
 
                 # Ensure we did not send out an email
                 mock.assert_not_called()
+
+    def test_rate_limited(self, with_db, with_client):
+        """Make sure our rate limit kicks in after 2 requests."""
+
+        # Oops, they messed up the first sign-up
+        email = 'incorrect_spelling_oops@example.org'
+        response = with_client.post('/waiting-list/join', json={'email': email})
+
+        # Ensure the response was okay!
+        assert response.status_code == 200, response.json()
+        assert response.json() is True
+
+        # Quickly recover with the right email
+        email = 'hello@example.org'
+        response = with_client.post('/waiting-list/join', json={'email': email})
+
+        # Ensure the response was okay!
+        assert response.status_code == 200, response.json()
+        assert response.json() is True
+
+        # Oh so sneakily signing up a third!
+        email = 'hello2@example.org'
+        response = with_client.post('/waiting-list/join', json={'email': email})
+
+        # Ensure the response was rate limited
+        assert response.status_code == 429, response.json()
+        data = response.json()
+        assert data['detail']['id'] == APIRateLimitExceeded.id_code
 
 
 class TestWaitingListActionConfirm:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -38,6 +38,10 @@ We use post-css to enhance our css. Any post-css that isn't in a SFC must be in 
 }
 ```
 
+### Rate limits
+
+We use slowapi for rate limiting. In order for rate limiting to function an api route needs to be have the @limiter decorator below the request decorator, and they need to have `request: Request` as a parameter.
+
 ### Lints and fixes files
 
 Frontend is formatted using ESlint with airbnb rules.
@@ -52,6 +56,7 @@ npm run lint -- --fix
 ```bash
 npm run test
 ```
+
 
 ### Customize configuration
 

--- a/frontend/src/models.ts
+++ b/frontend/src/models.ts
@@ -289,8 +289,13 @@ export type PydanticExceptionDetail = {
   msg: string,
   type: string
 }
+export type FormExceptionDetail = {
+  id: string,
+  message: string,
+  status: number
+}
 export type PydanticException = {
-  detail?: PydanticExceptionDetail[];
+  detail?: FormExceptionDetail|PydanticExceptionDetail[];
 }
 export type Exception = {
   status_code?: number;

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -62,12 +62,16 @@ const handleFormError = (errObj: PydanticException) => {
   const { detail } = errObj;
   const fields = formRef.value.elements;
 
-  detail.forEach((err) => {
-    const name = err?.loc[1];
-    if (name) {
-      fields[name].setCustomValidity(err.ctx.reason);
-    }
-  });
+  if (Array.isArray(detail)) {
+    detail.forEach((err) => {
+      const name = err?.loc[1];
+      if (name) {
+        fields[name].setCustomValidity(err.ctx.reason);
+      }
+    });
+  } else {
+    loginError.value = detail.message;
+  }
 
   // Finally report it!
   formRef.value.reportValidity();


### PR DESCRIPTION
Fixes #466 

Rules:
* waiting-list/join - 2/minute
* schedule/public/availability - 10/minute
* schedule/public/availability/request - 10/minute

I think we could reduce the request one to like 2 or 3, but it's not really a concern right now. Mostly just preemptively avoiding spam. I didn't hook it up with redis because I don't think we have redis setup correctly on prod yet. Shouldn't be a problem for us right now though. 

It works off of remote ip address, I think that's probably okay. 