### PR TITLE
Switch page load collection to backend.

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,7 +20,7 @@ python-dotenv==1.0.1
 python-multipart==0.0.9
 PyJWT==2.6.0
 pydantic[email]==2.7.4
-sentry-sdk==2.8.0
+sentry-sdk==2.10.0
 starlette-context==0.3.6
 sqlalchemy-utils==0.41.2
 sqlalchemy==2.0.31

--- a/backend/src/appointment/database/schemas.py
+++ b/backend/src/appointment/database/schemas.py
@@ -418,3 +418,18 @@ class WaitingListAdminOut(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class PageLoadIn(BaseModel):
+    browser: Optional[str]
+    browser_version: Optional[str]
+    os: Optional[str]
+    os_version: Optional[str]
+    device: Optional[str]
+    device_model: Optional[str]
+    resolution: Optional[str]
+    effective_resolution: Optional[str]
+    user_agent: Optional[str]
+    locale: Optional[str]
+    theme: Optional[str]
+

--- a/backend/src/appointment/routes/api.py
+++ b/backend/src/appointment/routes/api.py
@@ -4,6 +4,7 @@ import secrets
 
 import requests.exceptions
 import sentry_sdk
+from sentry_sdk import metrics
 from redis import Redis, RedisCluster
 
 # database
@@ -48,6 +49,16 @@ def health(db: Session = Depends(get_db)):
             return JSONResponse(content=l10n('health-bad'), status_code=503)
 
     return JSONResponse(l10n('health-ok'), status_code=200)
+
+
+@router.post('/page-load')
+def page_load(data: schemas.PageLoadIn):
+    if os.getenv('SENTRY_DSN') == '' or os.getenv('SENTRY_DSN') is None:
+        return True
+
+    metrics.increment('page_load', 1, tags=data.model_dump())
+
+    return True
 
 
 @router.put('/me', response_model=schemas.SubscriberMeOut)

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -88,20 +88,26 @@ if (useSentry) {
   const deviceRes = `${window?.screen?.width ?? -1}x${window?.screen?.height ?? -1}`;
   const effectiveDeviceRes = `${window?.screen?.availWidth ?? -1}x${window?.screen?.availHeight ?? -1}`;
 
-  Sentry.metrics.increment('page_load', 1, {
-    tags: {
+  // Native fetch!
+  await fetch(`${apiUrl}/page-load`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
       browser: browser.name,
-      browserVersion: `${browser.name}:${browser.version}`,
+      browser_version: `${browser.name}:${browser.version}`,
       os: os.name,
-      osVersion: `${os.name}:${os.version}`,
+      os_version: `${os.name}:${os.version}`,
       device: device.model,
-      deviceModel: `${device.vendor}:${device.model}`,
+      device_model: `${device.vendor}:${device.model}`,
       resolution: deviceRes,
-      effectiveResolution: effectiveDeviceRes,
-      userAgent: navigator.userAgent,
+      effective_resolution: effectiveDeviceRes,
+      user_agent: navigator.userAgent,
       locale: loc,
       theme: getPreferredTheme(),
-    },
+    }),
   });
 }
 


### PR DESCRIPTION
Fixes #588

I've kept it a separate endpoint in case folks want to block it (We'd rather they not block it, but that's up to them imo.) It requires sentry to be enabled on front and backend.

View:
https://thunderbird.sentry.io/metrics/?interval=30m&project=4505428124827648&statsPeriod=7d