### PR TITLE
Fix aws provider issue

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -110,6 +110,7 @@ jobs:
         id: output-bucket-name
         working-directory: ./tofu/environments/prod/services/frontend-infra
         run: |
+          terragrunt init -upgrade
           output=$(terragrunt output bucket_name | tr -d '"')
           echo bucket=$output >> $GITHUB_OUTPUT
 
@@ -117,6 +118,7 @@ jobs:
         id: output-cloudfront-distro
         working-directory: ./tofu/environments/prod/services/frontend-infra
         run: |
+          terragrunt init -upgrade
           output=$(terragrunt output cloudfront_id)
           echo cloudfront_id=$output >> $GITHUB_OUTPUT
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -180,6 +180,7 @@ jobs:
         id: get-frontend-resources
         working-directory: ./tofu/environments/stage/services/frontend-infra
         run: |
+          terragrunt init -upgrade
           echo "bucket=$(terragrunt output bucket_name | tr -d '"')" >> $GITHUB_OUTPUT
           echo "distribution=$(terragrunt output cloudfront_id)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Description of the Change
Added "terragrunt init -upgrade" ahead of "terragrunt output" commands

## Benefits

Will force Tofu to upgrade the community modules before pulling output.  This should resolve the issue of intermittent provider version errors 
