### PR TITLE
Qalendar fixes

### DIFF
--- a/frontend/src/components/CalendarQalendar.vue
+++ b/frontend/src/components/CalendarQalendar.vue
@@ -1,6 +1,6 @@
 <script setup>
 import {
-  ref, computed, inject, toRefs, watch,
+  ref, computed, inject, toRefs, watch, onMounted
 } from 'vue';
 import { Qalendar } from 'qalendar';
 import 'qalendar/dist/style.css';
@@ -274,7 +274,7 @@ const calendarEvents = computed(() => {
 });
 
 /**
- * Calculate the start and end times, and then space them our by 2 hours for style!
+ * Calculate the start and end times, and then space them out by 2 hours for style!
  * @type {ComputedRef<TimeNumeric>}
  */
 const dayBoundary = computed(() => {
@@ -332,7 +332,10 @@ const config = ref({
     length: timeSlotDuration.value, // Accepts [15, 30, 60]
     height: timeSlotHeight.value, // pixel height of each length
   },
-  dayBoundaries: dayBoundary,
+  dayBoundaries: {
+    start: dayBoundary.value.start,
+    end: dayBoundary.value.end
+  },
   eventDialog: {
     // We roll our own
     isDisabled: true,
@@ -358,6 +361,7 @@ watch(dayBoundary, () => {
     return;
   }
 
+  // TODO: This does update the boundary values, but does NOT update the container height!
   qalendarRef.value.time.DAY_START = dayBoundary.value.start * 100;
   qalendarRef.value.time.DAY_END = dayBoundary.value.end * 100;
 });
@@ -376,7 +380,6 @@ watch(route, () => {
 </script>
 <template>
   <div
-    class="w-full"
     :style="{'color-scheme': preferredTheme === ColorSchemes.Dark ? 'dark' : null}"
     :class="{'is-light-mode': preferredTheme === ColorSchemes.Light}"
   >

--- a/frontend/src/components/CalendarQalendar.vue
+++ b/frontend/src/components/CalendarQalendar.vue
@@ -300,6 +300,9 @@ const dayBoundary = computed(() => {
   };
 });
 
+// For now we only support English and German
+const locale = getLocale();
+
 /**
  * Calendar Config Object
  */
@@ -308,7 +311,7 @@ const config = ref({
     showEventsOnMobileView: false,
   },
   week: {
-    startsOn: 'sunday',
+    startsOn: locale === 'de' ? 'monday' : 'sunday',
   },
   style: {
     // Just the pre-calculated list from tailwind, could use some fine-tuning.
@@ -334,13 +337,8 @@ const config = ref({
     // We roll our own
     isDisabled: true,
   },
+  locale: locale === 'de' ? 'de-DE' : 'en-US'
 });
-
-// We only support two locales right now so just stick this in.
-const locale = getLocale();
-if (locale) {
-  config.value.locale = locale === 'de' ? 'de-DE' : 'en-US';
-}
 
 /**
  * Qalendar's selectedDate is only set on init and never updated. So we have to poke at their internals...

--- a/frontend/src/stores/appointment-store.ts
+++ b/frontend/src/stores/appointment-store.ts
@@ -21,6 +21,9 @@ export const useAppointmentStore = defineStore('appointments', () => {
   const pendingAppointments = computed(
     (): Appointment[] => appointments.value.filter((a) => a?.slots[0]?.booking_status === BookingStatus.Requested),
   );
+  const pendingFutureAppointments = computed(
+    (): Appointment[] => pendingAppointments.value.filter((a) => a?.slots[0]?.start > dj()),
+  );
 
   /**
    * Append additional data to retrieved appointments
@@ -61,6 +64,6 @@ export const useAppointmentStore = defineStore('appointments', () => {
   };
 
   return {
-    isLoaded, appointments, pendingAppointments, postFetchProcess, fetch, $reset,
+    isLoaded, appointments, pendingAppointments, pendingFutureAppointments, postFetchProcess, fetch, $reset,
   };
 });


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

- List of pending events on the calendar page now only shows future pending events (which reduces the list to a reasonable length, but let me know if this not wanted)
- First day of week is now locale aware (Monday for German, Sunday for English). In a future iteration this should be a user setting keeping these as defaults.
- I tried to fix #544 and spent quite some time debugging Qalendar for this. It turns out, that it's an issue with computed / reactive properties and Qalendar not updating their UI accordingly.

## Benefits

Consistent height of events after a change of the day boundary.

## Applicable Issues

#544 
