### PR TITLE
Fix login if username and email differ

### DIFF
--- a/backend/src/appointment/routes/auth.py
+++ b/backend/src/appointment/routes/auth.py
@@ -247,8 +247,8 @@ def token(
     if os.getenv('AUTH_SCHEME') == 'fxa':
         raise HTTPException(status_code=405)
 
-    """Retrieve an access token from a given username and password."""
-    subscriber = repo.subscriber.get_by_username(db, form_data.username)
+    """Retrieve an access token from a given email (=username) and password."""
+    subscriber = repo.subscriber.get_by_email(db, form_data.username)
     if not subscriber or subscriber.password is None:
         raise HTTPException(status_code=403, detail=l10n('invalid-credentials'))
 
@@ -267,11 +267,11 @@ def token(
         db.add(subscriber)
         db.commit()
 
-    # Generate our jwt token, we only store the username on the token
+    # Generate our jwt token, we only store the user id on the token
     access_token_expires = timedelta(minutes=float(os.getenv('JWT_EXPIRE_IN_MINS')))
     access_token = create_access_token(data={'sub': f'uid-{subscriber.id}'}, expires_delta=access_token_expires)
 
-    """Log a user in with the passed username and password information"""
+    """Log a user in with the passed user id and password information"""
     return {'access_token': access_token, 'token_type': 'bearer'}
 
 

--- a/backend/test/integration/test_auth.py
+++ b/backend/test/integration/test_auth.py
@@ -62,7 +62,7 @@ class TestPassword:
         # Test good credentials
         response = with_client.post(
             '/token',
-            data={'username': subscriber.username, 'password': password},
+            data={'username': subscriber.email, 'password': password},
         )
         assert response.status_code == 200, response.text
         data = response.json()
@@ -72,14 +72,14 @@ class TestPassword:
         # Test bad credentials
         response = with_client.post(
             '/token',
-            data={'username': subscriber.username, 'password': bad_password},
+            data={'username': subscriber.email, 'password': bad_password},
         )
         assert response.status_code == 403, response.text
 
         # Test credentials with non-existent user
         response = with_client.post(
             '/token',
-            data={'username': subscriber.username + '1', 'password': password},
+            data={'username': subscriber.email + '1', 'password': password},
         )
         assert response.status_code == 403, response.text
 

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -25,10 +25,10 @@
         <div class="my-8 grid w-full gap-8">
           <label class="flex flex-col items-center pl-4">
           <span class="w-full">
-            {{ isPasswordAuth ? t('label.username') : t('label.email') }}
+            {{ t('label.email') }}
           </span>
             <input
-              v-model="username"
+              v-model="email"
               type="email"
               class="mr-6 w-full rounded-md"
               :class="{'mr-4': isFxaAuth}"
@@ -118,7 +118,7 @@ const showInviteFlow = ref(false);
 const isLoading = ref(false);
 
 // form input and error
-const username = ref('');
+const email = ref('');
 const password = ref('');
 const loginError = ref(null);
 const inviteCode = ref('');
@@ -136,7 +136,7 @@ const signUp = async () => {
   isLoading.value = true;
   loginError.value = '';
   const { data } = await call('waiting-list/join').post({
-    email: username.value,
+    email: email.value,
   }).json();
 
   if (!data.value) {
@@ -149,7 +149,7 @@ const signUp = async () => {
 };
 
 const login = async () => {
-  if (!username.value || (isPasswordAuth && !password.value)) {
+  if (!email.value || (isPasswordAuth && !password.value)) {
     loginError.value = t('error.credentialsIncomplete');
     return;
   }
@@ -160,7 +160,7 @@ const login = async () => {
   // If they come here a second time after not being allowed it's because they have an invite code.
   if (!showInviteFlow.value) {
     const { data: canLogin, error } = await call('can-login').post({
-      email: username.value,
+      email: email.value,
     }).json();
 
     if (error?.value) {
@@ -179,7 +179,7 @@ const login = async () => {
 
   if (isFxaAuth) {
     const params = new URLSearchParams({
-      email: username.value,
+      email: email.value,
       timezone: dj.tz.guess(),
     });
 
@@ -200,7 +200,7 @@ const login = async () => {
     return;
   }
 
-  const { error } = await user.login(call, username.value, password.value);
+  const { error } = await user.login(call, email.value, password.value);
   if (error) {
     loginError.value = error;
     isLoading.value = false;


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

Password based login doesn't work, if username and email differ for a user. This issue was introduced, when the `can-login` endpoint got a check for correct email:

![image](https://github.com/user-attachments/assets/53f33748-c5fd-4536-afa3-46a4f5dd630d)

This made logging in via username impossible, when the username isn't a valid email address. To reduce the confusion, I switched to email based login for the password login too.

## Benefits

Email is always the way to go now for both login modes.

## Applicable Issues

None.