### PR TITLE
Fix posthog init

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -184,13 +184,16 @@ provide(refreshKey, getDbData);
 
 onMounted(async () => {
   const usePosthog = inject(usePosthogKey);
-  const id = await onPageLoad();
+  
+  if (usePosthog) {
+    const id = await onPageLoad();
 
-  if (usePosthog && isAuthenticated.value) {
-    const profile = useUserStore();
-    posthog.identify(profile.data.uniqueHash);
-  } else if (usePosthog && id) {
-    posthog.identify(id);
+    if (isAuthenticated.value) {
+      const profile = useUserStore();
+      posthog.identify(profile.data.uniqueHash);
+    } else if (id) {
+      posthog.identify(id);
+    }
   }
 });
 


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change makes sure we only call metrics if posthog is enabled.

## Benefits

Eliminates a console error.

## Applicable Issues

Closes #598 
