### PR TITLE
Additional metrics

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "core-js": "^3.8.3",
     "dayjs": "^1.11.5",
     "pinia": "^2.1.6",
-    "posthog-js": "^1.150.1",
+    "posthog-js": "^1.154.5",
     "qalendar": "^3.7.0",
     "tailwindcss": "^3.4.3",
     "ua-parser-js": "^1.0.38",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -255,7 +255,6 @@ onMounted(async () => {
         return properties;
       },
     });
-    posthog.debug();
     posthog.register({
       service: 'apmt',
     });

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -190,7 +190,9 @@ onMounted(async () => {
   if (usePosthog) {
     // Hack to clear $set_once until we get confirmation that this can be filtered.
     // Move the function reference so we can patch it and still retrieve the results before we sanitize it.
-    posthog['_original_calculate_set_once_properties'] = posthog._calculate_set_once_properties;
+    if (posthog['_original_calculate_set_once_properties'] === undefined) {
+      posthog['_original_calculate_set_once_properties'] = posthog._calculate_set_once_properties;
+    }
     posthog._calculate_set_once_properties = function (dataSetOnce?) {
       dataSetOnce = posthog['_original_calculate_set_once_properties'](dataSetOnce);
 

--- a/frontend/src/components/DataTable.vue
+++ b/frontend/src/components/DataTable.vue
@@ -41,7 +41,7 @@
               </span>
               <span v-else-if="fieldData.type === tableDataType.code" class="flex items-center gap-4">
                 <code>{{ fieldData.value }}</code>
-                <text-button class="btn-copy" :copy="fieldData.value" :title="t('label.copy')" />
+                <text-button :uid="fieldKey" class="btn-copy" :copy="fieldData.value" :title="t('label.copy')" />
               </span>
               <span v-else-if="fieldData.type === tableDataType.bool">
                 <span v-if="fieldData.value">Yes</span>

--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -46,6 +46,7 @@
             </router-link>
             <text-button
               v-show="user.myLink"
+              uid="myLink"
               :label="t('label.shareMyLink')"
               :copy="user.myLink"
               :title="t('label.copy')"

--- a/frontend/src/components/ScheduleCreation.vue
+++ b/frontend/src/components/ScheduleCreation.vue
@@ -392,18 +392,22 @@ import SecondaryButton from '@/elements/SecondaryButton';
 
 // icons
 import { IconChevronDown, IconInfoCircle } from '@tabler/icons-vue';
+
 import AlertBox from '@/elements/AlertBox';
 import SwitchToggle from '@/elements/SwitchToggle';
 import ToolTip from '@/elements/ToolTip.vue';
 import { useCalendarStore } from '@/stores/calendar-store';
 import { useExternalConnectionsStore } from '@/stores/external-connections-store';
+
 import SnackishBar from '@/elements/SnackishBar.vue';
 import { dayjsKey } from '@/keys';
+import { useScheduleStore } from '@/stores/schedule-store';
 
 // component constants
 const user = useUserStore();
 const calendarStore = useCalendarStore();
 const externalConnectionStore = useExternalConnectionsStore();
+const scheduleStore = useScheduleStore();
 const { t } = useI18n();
 const dj = inject(dayjsKey);
 const call = inject('call');
@@ -656,18 +660,21 @@ const saveSchedule = async (withConfirmation = true) => {
   delete obj.id;
 
   // save schedule data
-  const { data, error } = props.schedule
-    ? await call(`schedule/${props.schedule.id}`).put(obj).json()
-    : await call('schedule/').post(obj).json();
+  const response = props.schedule
+    ? await scheduleStore.updateSchedule(call, props.schedule.id, obj)
+    : await scheduleStore.createSchedule(call, obj);
 
-  if (error.value) {
+  if (response.error) {
     // error message is in data
-    handleErrorResponse(data);
+    scheduleCreationError.value = response.message;
     // go back to the start
     savingInProgress.value = false;
     window.scrollTo(0, 0);
     return;
   }
+
+  // Otherwise it's just data!
+  const { data } = response;
 
   if (withConfirmation) {
     // show confirmation

--- a/frontend/src/definitions.ts
+++ b/frontend/src/definitions.ts
@@ -85,7 +85,7 @@ export enum BookingCalendarViews {
   Loading = 10,
   Success = 11,
   Invalid = 12,
-};
+}
 
 /**
  * Booking status for slots. This mirrors models.BookingStatus on the backend
@@ -103,7 +103,7 @@ export enum BookingStatus {
   None = 1,
   Requested = 2,
   Booked = 3,
-};
+}
 
 /**
  * Status to indicate if an invite code ist still valid or no longer valid
@@ -111,7 +111,7 @@ export enum BookingStatus {
 export enum InviteStatus {
   Active = 1,
   Revoked = 2,
-};
+}
 
 /**
  * Available appointment views
@@ -121,7 +121,7 @@ export enum BookingsViews {
   Pending = 2,
   Past = 3,
   All = 4,
-};
+}
 
 /**
  * List columns for bookings page
@@ -131,7 +131,7 @@ export enum BookingsTableColumns {
   Status = 2,
   Calendar = 3,
   Time = 4,
-};
+}
 
 /**
  * Filter options for bookings page
@@ -144,7 +144,7 @@ export enum BookingsTableFilterOptions {
   AppointmentsNext31Days = 5,
   AppointmentsInMonth = 6,
   AllFutureAppointments = 7,
-};
+}
 
 /**
  * View types for the bookings page
@@ -152,7 +152,7 @@ export enum BookingsTableFilterOptions {
 export enum BookingsViewTypes {
   List = 1,
   Grid = 2,
-};
+}
 
 /**
  * Settings page sections
@@ -173,7 +173,7 @@ export enum ColorSchemes {
   System = 'system',
   Dark = 'dark',
   Light = 'light',
-};
+}
 
 /**
  * Calendar management type states
@@ -204,7 +204,7 @@ export enum ModalStates {
   Open = 2, // Modal is open for editing
   Error = 3, // Modal is open for editing but contains errors
   Finished = 4, // Modal is finished, so either self-close, or show a success screen
-};
+}
 
 /**
  * Alert levels
@@ -216,7 +216,7 @@ export enum AlertSchemes {
   Warning = 2, // Alert indicates something important
   Success = 3, // Alert indicates something's gone right
   Info = 4, // Alert indicates some neutral information
-};
+}
 
 /**
  * Only available duration values supported for Qalendar
@@ -299,6 +299,21 @@ export const waitingListAction = {
   leave: 2,
 };
 
+export enum MetricEvents {
+  PageLoaded = 'apmt.page.loaded',
+  FTUEStep = 'apmt.ftue.step',
+  CopyToClipboard = 'apmt.copy',
+  AddCalendar = 'apmt.calendar.add',
+  EditCalendar = 'apmt.calendar.edit',
+  DeleteCalendar = 'apmt.calendar.delete',
+  ConnectCalendar = 'apmt.calendar.connect',
+  DisconnectCalendar = 'apmt.calendar.disconnect',
+  SyncCalendars = 'apmt.calendar.sync',
+  RefreshLink = 'apmt.account.refreshLink',
+  DownloadData = 'apmt.account.download',
+  DeleteAccount = 'apmt.account.delete',
+}
+
 export default {
   AlertSchemes,
   appointmentCreationState,
@@ -328,4 +343,5 @@ export default {
   tableDataType,
   tooltipPosition,
   waitingListAction,
+  MetricEvents,
 };

--- a/frontend/src/definitions.ts
+++ b/frontend/src/definitions.ts
@@ -312,6 +312,11 @@ export enum MetricEvents {
   RefreshLink = 'apmt.account.refreshLink',
   DownloadData = 'apmt.account.download',
   DeleteAccount = 'apmt.account.delete',
+  ConfirmBooking = 'apmt.booking.confirm',
+  DenyBooking = 'apmt.booking.deny',
+  RequestBooking = 'apmt.booking.request',
+  ScheduleCreated = 'apmt.schedule.created',
+  ScheduleUpdated = 'apmt.schedule.updated',
 }
 
 export default {

--- a/frontend/src/elements/TextButton.vue
+++ b/frontend/src/elements/TextButton.vue
@@ -5,16 +5,19 @@ import ToolTip from '@/elements/ToolTip.vue';
 
 // icons
 import { IconCopy, IconClipboardCheck } from '@tabler/icons-vue';
+import { posthog, usePosthog } from '@/composables/posthog';
+import { MetricEvents } from '@/definitions';
 
 // component constants
 const { t } = useI18n();
 
 // component properties
 interface Props {
+  uid: string; // id for this button
   label?: string; // button text
   tooltip?: string, // optional tooltip
   copy?: string; // text to copy to clipboard
-};
+}
 const props = defineProps<Props>();
 
 // state for copy click
@@ -26,6 +29,13 @@ const copyToClipboard = async () => {
   await navigator.clipboard.writeText(props.copy);
   copied.value = true;
   setTimeout(() => { copied.value = false; }, 4000);
+
+  if (usePosthog) {
+    posthog.capture(MetricEvents.CopyToClipboard, {
+      uid: props.uid,
+      label: props.label,
+    });
+  }
 };
 </script>
 

--- a/frontend/src/stores/calendar-store.ts
+++ b/frontend/src/stores/calendar-store.ts
@@ -21,6 +21,12 @@ export const useCalendarStore = defineStore('calendars', () => {
   };
 
   /**
+   * Retrieve the calendar object by id
+   * @param id
+   */
+  const calendarById = (id: number) => calendars.value.filter((calendar) => calendar.id === id)?.at(0) ?? null;
+
+  /**
    * Get all calendars for current user
    * @param call preconfigured API fetch function
    * @param force force a refetch
@@ -57,6 +63,17 @@ export const useCalendarStore = defineStore('calendars', () => {
   };
 
   return {
-    isLoaded, hasConnectedCalendars, calendars, unconnectedCalendars, connectedCalendars, fetch, $reset, connectGoogleCalendar, connectCalendar, disconnectCalendar, syncCalendars,
+    isLoaded,
+    hasConnectedCalendars,
+    calendars,
+    unconnectedCalendars,
+    connectedCalendars,
+    fetch,
+    $reset,
+    connectGoogleCalendar,
+    connectCalendar,
+    disconnectCalendar,
+    syncCalendars,
+    calendarById,
   };
 });

--- a/frontend/src/stores/schedule-store.ts
+++ b/frontend/src/stores/schedule-store.ts
@@ -2,9 +2,10 @@ import { i18n } from '@/composables/i18n';
 import { defineStore } from 'pinia';
 import { ref, computed, inject } from 'vue';
 import { useUserStore } from '@/stores/user-store';
-import { dateFormatStrings } from '@/definitions';
+import { dateFormatStrings, MetricEvents } from '@/definitions';
 import { Fetch, Schedule, ScheduleListResponse } from '@/models';
 import { dayjsKey } from '@/keys';
+import { posthog, usePosthog } from '@/composables/posthog';
 
 // eslint-disable-next-line import/prefer-default-export
 export const useScheduleStore = defineStore('schedules', () => {
@@ -89,7 +90,7 @@ export const useScheduleStore = defineStore('schedules', () => {
     return i18n.t('error.unknownScheduleError');
   };
 
-  const createSchedule = async (call, scheduleData) => {
+  const createSchedule = async (call: Fetch, scheduleData: object) => {
     // save schedule data
     const { data, error } = await call('schedule/').post(scheduleData).json();
 
@@ -103,10 +104,14 @@ export const useScheduleStore = defineStore('schedules', () => {
     // Update the schedule
     await fetch(call, true);
 
+    if (usePosthog) {
+      posthog.capture(MetricEvents.ScheduleCreated);
+    }
+
     return data;
   };
 
-  const updateSchedule = async (call, id, scheduleData) => {
+  const updateSchedule = async (call: Fetch, id: number, scheduleData: object) => {
     // save schedule data
     const { data, error } = await call(`schedule/${id}`).put(scheduleData).json();
 
@@ -119,6 +124,10 @@ export const useScheduleStore = defineStore('schedules', () => {
 
     // Update the schedule
     await fetch(call, true);
+
+    if (usePosthog) {
+      posthog.capture(MetricEvents.ScheduleUpdated);
+    }
 
     return data;
   };

--- a/frontend/src/views/BookingView.vue
+++ b/frontend/src/views/BookingView.vue
@@ -1,17 +1,20 @@
 <script setup lang="ts">
-import { BookingCalendarViews, ModalStates } from '@/definitions';
+import { BookingCalendarViews, MetricEvents, ModalStates } from '@/definitions';
 import { inject, onMounted, ref } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
 import { useBookingViewStore } from '@/stores/booking-view-store';
 import { useBookingModalStore } from '@/stores/booking-modal-store';
-import { dayjsKey, callKey } from "@/keys";
-import { Appointment, Slot, Exception, Attendee, ExceptionDetail, AppointmentResponse, SlotResponse } from '@/models';
+import { dayjsKey, callKey } from '@/keys';
+import {
+  Appointment, Slot, Exception, Attendee, ExceptionDetail, AppointmentResponse, SlotResponse,
+} from '@/models';
 import LoadingSpinner from '@/elements/LoadingSpinner.vue';
 import BookingModal from '@/components/BookingModal.vue';
 import BookingViewSlotSelection from '@/components/bookingView/BookingViewSlotSelection.vue';
 import BookingViewSuccess from '@/components/bookingView/BookingViewSuccess.vue';
 import BookingViewError from '@/components/bookingView/BookingViewError.vue';
+import { usePosthog, posthog } from '@/composables/posthog';
 
 // component constants
 const { t } = useI18n();
@@ -151,6 +154,12 @@ const bookEvent = async (attendeeData: Attendee) => {
   activeView.value = BookingCalendarViews.Success;
   // update modal view as well
   modalState.value = ModalStates.Finished;
+
+  if (usePosthog) {
+    posthog.capture(MetricEvents.RequestBooking, {
+      autoConfirmed: appointment?.value.booking_confirmation,
+    });
+  }
 };
 
 // initially retrieve slot data and decide which view to show

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -20,9 +20,8 @@ const { t } = useI18n({ useScope: 'global' });
 const route = useRoute();
 const router = useRouter();
 const sections = enumToObject(SettingsSections);
-const routeView = route.params.view as string;
-
-const activeView = computed<number>(() => (routeView && sections[routeView] ? sections[routeView] : SettingsSections.General));
+// Note: Use direct variables in computed, otherwise it won't be updated if transformed (like by typing)
+const activeView = computed<number>(() => (route.params.view && sections[route.params.view as string] ? sections[route.params.view as string] : SettingsSections.General));
 
 // menu navigation of different views
 const show = (key: string) => {


### PR DESCRIPTION
Adds the following metrics to help guide development resources and priority:

* apmt.copy - Copy to clipboard with a generic uid and label of the button
* apmt.calendar.add - Add a calendar with provider
* apmt.calendar.edit - Edit a calendar with provider
* apmt.calendar.delete - Delete a calendar with provider
* apmt.calendar.connect - Connect a calendar with provider
* apmt.calendar.disconnect - Disconnect a calendar with provider
* apmt.calendar.sync - Sync your calendars with old and new calendar counts
* apmt.account.refreshLink - Refresh your booking link
* apmt.account.download - Download your account data
* apmt.account.deleteAccount - Delete your account
* apmt.booking.confirm - Confirmed a booking request
* apmt.booking.deny - Denied a booking request
* apmt.booking.request - Someone has requested a booking, comes with a autoConfirmed param
* apmt.schedule.created - Schedule has been created
* apmt.schedule.updated - Schedule has been updated
--

I need to double check posthog's charting abilities to see if I can get the rest of the requested captures without adding more capture calls. 

Most of the metrics are to track provider popularity, track how many times a user copies their booking link, or if we need refresh their calendars in the background instead of just on-demand.


