### PR TITLE
Perform server-side validation for bookings (Fixes #669)

### DIFF
--- a/backend/src/appointment/database/repo/schedule.py
+++ b/backend/src/appointment/database/repo/schedule.py
@@ -18,7 +18,7 @@ def create(db: Session, schedule: schemas.ScheduleBase):
     return db_schedule
 
 
-def get_by_subscriber(db: Session, subscriber_id: int):
+def get_by_subscriber(db: Session, subscriber_id: int) -> list[models.Schedule]:
     """Get schedules by subscriber id"""
     return (
         db.query(models.Schedule)


### PR DESCRIPTION
Fixes #669 

Doing a sweep of backend validation issues. 

For tests we should always declare the timezone as UTC time. The frontend only ever sends utc time so it's not a problem. To make the code easier to maintain we'll fail any non-UTC time coming in through the booking route. 