### PR TITLE
added conditional to determine # of backend containers

### DIFF
--- a/tofu/modules/services/backend-service/main.tf
+++ b/tofu/modules/services/backend-service/main.tf
@@ -17,7 +17,7 @@ resource "aws_ecs_service" "backend_service" {
 
   health_check_grace_period_seconds = 180
   task_definition                   = aws_ecs_task_definition.backend.arn
-  desired_count                     = 1
+  desired_count                     = var.app_env != "prod" ? 1 : 2
   tags                              = var.tags
 }
 


### PR DESCRIPTION
 Description of the Change

Added a conditional to launch two backend containers on prod but maintain a single container in non-prod environments

## Benefits
increases reliability of production environment while maintaining minimum costs in non-prod

## Applicable Issues

resolves #674
