### PR TITLE
Fix booking link toggle in schedule creation

### DIFF
--- a/frontend/src/components/ScheduleCreation.vue
+++ b/frontend/src/components/ScheduleCreation.vue
@@ -720,7 +720,7 @@ watch(
             <switch-toggle
               class="my-1 text-sm font-medium text-gray-500 dark:text-gray-300"
               name="booking_confirmation"
-              :active="scheduleInput.booking_confirmation === true"
+              :active="scheduleInput.booking_confirmation"
               :label="t('label.bookingConfirmation')"
               :disabled="!scheduleInput.active"
               @changed="toggleBookingConfirmation"

--- a/frontend/src/components/ScheduleCreation.vue
+++ b/frontend/src/components/ScheduleCreation.vue
@@ -720,7 +720,7 @@ watch(
             <switch-toggle
               class="my-1 text-sm font-medium text-gray-500 dark:text-gray-300"
               name="booking_confirmation"
-              :active="schedule.booking_confirmation"
+              :active="scheduleInput.booking_confirmation === true"
               :label="t('label.bookingConfirmation')"
               :disabled="!scheduleInput.active"
               @changed="toggleBookingConfirmation"

--- a/frontend/src/tbpro/elements/SwitchToggle.vue
+++ b/frontend/src/tbpro/elements/SwitchToggle.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 // component constants
@@ -29,6 +29,15 @@ const toggleState = () => {
     emit('changed', state.value);
   }
 };
+
+// Update state if parent changes active prop
+// e.g. after initializing async data
+watch(
+  () => props.active,
+  () => {
+    state.value = props.active;
+  }
+);
 </script>
 
 <template>

--- a/frontend/src/tbpro/elements/SwitchToggle.vue
+++ b/frontend/src/tbpro/elements/SwitchToggle.vue
@@ -16,7 +16,11 @@ interface Props {
   label?: string; // input label
   noLegend?: boolean; // hide "on" and "off" labels
 }
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+  disabled: false,
+  label: null,
+  noLegend: true,
+});
 
 // current state
 const state = ref(false);


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

- Booking confirmation is now properly handled via schedule input object. This fixes a bug where a direct call on the retrieved schedule object happend on null.
- The SwitchToggle component now handles state changes from the parent. This sometimes happens during initialization when waiting for async data.

## Applicable Issues

Fixes #695 
