### PR TITLE
Add contact form hint to mails

### DIFF
--- a/backend/src/appointment/controller/mailer.py
+++ b/backend/src/appointment/controller/mailer.py
@@ -51,6 +51,7 @@ class Mailer:
         self,
         to: str,
         sender: str = os.getenv('SERVICE_EMAIL'),
+        reply_to: str = os.getenv('SUPPORT_EMAIL'),
         subject: str = '',
         html: str = '',
         plain: str = '',
@@ -58,6 +59,7 @@ class Mailer:
     ):
         self.sender = sender
         self.to = to
+        self.reply_to = reply_to
         self.subject = subject
         self.body_html = html
         self.body_plain = plain
@@ -84,6 +86,7 @@ class Mailer:
         message['Subject'] = self.subject
         message['From'] = self.sender
         message['To'] = self.to
+        message['Reply-To'] = self.reply_to
 
         # add body as html and text parts
         message.set_content(self.text())

--- a/backend/src/appointment/l10n/de/email.ftl
+++ b/backend/src/appointment/l10n/de/email.ftl
@@ -10,6 +10,8 @@
                 {-brand-name}
                 {-brand-slogan} {-brand-sign-up-with-url}
 
+mail-brand-contact-form = Kontaktformular
+mail-brand-support-hint = Du hast Fragen? Wir helfen gern. Nutze unser { $contact_form_link }, oder antworte einfach auf diese E-Mail für Support.
 mail-brand-footer = Diese Nachricht wurde gesendet von:
                     {-brand-name}
                     {-brand-slogan} {-brand-sign-up-with-no-url}

--- a/backend/src/appointment/l10n/en/email.ftl
+++ b/backend/src/appointment/l10n/en/email.ftl
@@ -10,6 +10,8 @@
                 {-brand-name}
                 {-brand-slogan} {-brand-sign-up-with-url}
 
+mail-brand-contact-form = contact form
+mail-brand-support-hint = Got questions? We're here to help. Fill out our { $contact_form_link }, or simply reply to this email for support.
 mail-brand-footer = This message was sent from:
                     {-brand-name}
                     {-brand-slogan} {-brand-sign-up-with-no-url}

--- a/backend/src/appointment/templates/email/confirm.jinja2
+++ b/backend/src/appointment/templates/email/confirm.jinja2
@@ -1,4 +1,5 @@
 {% extends "includes/base.jinja2" %}
+{% set show_contact_form_hint = True %}
 {# Helper vars #}
 {% set clock_image_small = '<img style="width: 11px; height: 11px; position: relative; top: 2px;" alt="" src="cid:%(cid)s" />'|format(cid=clock_icon_cid) %}
 {% set clock_image = '<img style="width: 15px; height: 15px; position: relative; top: 2px;" alt="" src="cid:%(cid)s" />'|format(cid=clock_icon_cid) %}

--- a/backend/src/appointment/templates/email/errors/zoom_invite_failed.jinja2
+++ b/backend/src/appointment/templates/email/errors/zoom_invite_failed.jinja2
@@ -1,4 +1,5 @@
 {% extends "includes/base.jinja2" %}
+{% set show_contact_form_hint = True %}
 {# Code begins! #}
 {% block introduction %}
   <div style="color: {{ colour_text_base }}; text-align: center; line-height: 16px;">

--- a/backend/src/appointment/templates/email/includes/base.jinja2
+++ b/backend/src/appointment/templates/email/includes/base.jinja2
@@ -14,14 +14,14 @@
   background-color: {{ colour_surface_base }};
   font-family: 'Inter', sans-serif;
   margin: 24px 0;
-  ">
+">
 <body>
 {% if self.introduction()|trim %}
 <div style="
-    margin-left: auto;
-    margin-right: auto;
-    margin-bottom: 24px;
-    ">
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 24px;
+">
   {% block introduction %}{% endblock %}
 </div>
 {% endif %}
@@ -35,7 +35,7 @@
   border-radius: 6px;
   padding: 12px;
   background-color: {{ colour_surface_raised }}
-  ">
+">
   {% block information %}{% endblock %}
 </div>
 {% endif %}
@@ -44,15 +44,21 @@
   {% block call_to_action %}{% endblock %}
 </div>
 {% endif %}
+{% if show_contact_form_hint %}
+{% set link = '<a href="%(url)s">%(label)s</a>'|format(url=homepage_url + '/contact', label=l10n('mail-brand-contact-form')) %}
+<div style="text-align: center; margin-left: auto; margin-right: auto; margin-bottom: 24px; padding: 12px; max-width: 310px;">
+  {{ l10n('mail-brand-support-hint', {'contact_form_link': link})|safe }}
+</div>
+{% endif %}
 <div style="
-      display: block;
-      width: 100%;
-      padding-bottom: 1px;
-      border-radius: unset;
-      margin-top: 12px;
-      margin-bottom: 12px;
-      background: linear-gradient(90deg, rgba(21, 66, 124, 0) 20.5%, rgba(21, 66, 124, 0.2) 50%, rgba(21, 66, 124, 0) 79.5%);
-      "></div>
+  display: block;
+  width: 100%;
+  padding-bottom: 1px;
+  border-radius: unset;
+  margin-top: 12px;
+  margin-bottom: 12px;
+  background: linear-gradient(90deg, rgba(21, 66, 124, 0) 20.5%, rgba(21, 66, 124, 0.2) 50%, rgba(21, 66, 124, 0) 79.5%);
+"></div>
 {% include './includes/footer.jinja2' %}
 </body>
 </html>

--- a/backend/src/appointment/templates/email/new_account.jinja2
+++ b/backend/src/appointment/templates/email/new_account.jinja2
@@ -1,4 +1,5 @@
 {% extends "includes/base.jinja2" %}
+{% set show_contact_form_hint = True %}
 {# Code begins! #}
 {% block introduction %}
   <div style="color: {{ colour_text_base }}; text-align: center; line-height: 16px;">

--- a/backend/src/appointment/templates/email/new_booking.jinja2
+++ b/backend/src/appointment/templates/email/new_booking.jinja2
@@ -3,6 +3,7 @@
 {% set clock_image_small = '<img style="width: 11px; height: 11px; position: relative; top: 2px;" alt="" src="cid:%(cid)s" />'|format(cid=clock_icon_cid) %}
 {% set clock_image = '<img style="width: 15px; height: 15px; position: relative; top: 2px;" alt="" src="cid:%(cid)s" />'|format(cid=clock_icon_cid) %}
 {% set calendar_image = '<img style="width: 14px; height: 14px; position: relative; top: 2px;" alt="" src="cid:%(cid)s" />'|format(cid=calendar_icon_cid) %}
+{% set show_contact_form_hint = True %}
 {# Code begins! #}
 {% block introduction %}
   <div style="color: {{ colour_text_base }}; text-align: center; line-height: 16px;">


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change extends the base email template by a section above the email footer containing a hint with a link to the contact form and how to get support.

It can be enabled in email templates by setting:

```jinja
{% set show_contact_form_hint = True %}
```

It was enabled in the following templates:

- Email to confirm a booking request
- Email that a zoom invitation failed
- Email for account invitation
- Email for new booking information

![image](https://github.com/user-attachments/assets/3f9be455-1bda-40a6-b512-434a272c75ee)

## Benefits

Info for users where/how to get help/support.

## Applicable Issues

Closes #642 
