### PR TITLE
Filter out declined for Google Events

### DIFF
--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -185,8 +185,17 @@ class GoogleConnector(BaseConnector):
             if status == 'cancelled' or transparency == 'transparent':
                 continue
 
-            # Mark tentative events
+            # Grab the attendee list for marking tentative events / filtering out declined events
             attendees = event.get('attendees') or []
+            declined = any(
+                (attendee.get('self') and attendee.get('responseStatus') == 'declined') for attendee in attendees
+            )
+
+            # Don't show declined events
+            if declined:
+                continue
+
+            # Mark tentative events
             tentative = any(
                 (attendee.get('self') and attendee.get('responseStatus') == 'tentative') for attendee in attendees
             )


### PR DESCRIPTION
Fixes #696 

The fix is only applied to the google calendar connector because we don't actually of a method of determining which attendee is the calendar owner. (As they could technically have no email associated with a caldav calendar...) This will hopefully be cleared up with the freebusy api. 

