### PR TITLE
Fix language on schedule creation

### DIFF
--- a/frontend/src/components/ScheduleCreation.vue
+++ b/frontend/src/components/ScheduleCreation.vue
@@ -795,7 +795,7 @@ watch(
         @click="revertForm()"
         :disabled="!scheduleInput.active"
       >
-        {{ t('label.clearForm') }}
+        {{ t('label.revertChanges') }}
       </link-button>
     </snackish-bar>
     <div v-else>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -270,6 +270,7 @@
     "requested": "Angefragt",
     "restoreColumnOrder": "Spaltenreihenfolge wiederherstellen",
     "revert": "Zurücksetzen",
+    "revertChanges": "Änderungen zurücksetzen",
     "save": "Speichern",
     "saveChanges": "Änderungen speichern",
     "schedule": "Zeitplan",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -270,6 +270,7 @@
     "requested": "Requested",
     "restoreColumnOrder": "Restore Column Order",
     "revert": "Revert",
+    "revertChanges": "Revert changes",
     "save": "Save",
     "saveChanges": "Save changes",
     "schedule": "Schedule",


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This changes the "Clear form" button label to "Revert changes" on schedule creation / modification.

## Applicable Issues

Closes #701 
