### PR TITLE
Handle generic modal close event

### DIFF
--- a/frontend/src/components/GenericModal.vue
+++ b/frontend/src/components/GenericModal.vue
@@ -43,33 +43,33 @@ onUnmounted(() => {
   <div class="new-design overlay" role="dialog" tabindex="-1" aria-labelledby="title" aria-modal="true">
     <div class="dismiss-zone" @click="emits('close')"></div>
     <div class="modal">
-        <link-button class="modal-close" v-if="closable" @click="emits('close')" aria-labelledby="modal-close-button">
-          <img id="modal-close-button" src="@/assets/svg/icons/close.svg" :alt="t('label.close')" :title="t('label.close')"/>
-        </link-button>
-        <div class="modal-header">
-          <slot name="header"></slot>
-          <notice-bar type="error" v-if="errorMessage">
-            {{ errorMessage }}
-          </notice-bar>
-          <notice-bar type="warning" v-else-if="warningMessage">
-            {{ warningMessage }}
-          </notice-bar>
-          <notice-bar v-else-if="infoMessage">
-            {{ infoMessage }}
-          </notice-bar>
-          <div class="pls-keep-height" v-else/>
-        </div>
-        <div class="modal-body">
-          <slot></slot>
-        </div>
-        <div class="modal-actions">
-          <slot name="actions"></slot>
-        </div>
-        <div class="divider"></div>
-        <div class="footer">
-          <slot name="footer"></slot>
-        </div>
+      <link-button class="modal-close" v-if="closable" @click="emits('close')" aria-labelledby="modal-close-button">
+        <img id="modal-close-button" src="@/assets/svg/icons/close.svg" :alt="t('label.close')" :title="t('label.close')"/>
+      </link-button>
+      <div class="modal-header">
+        <slot name="header"></slot>
+        <notice-bar type="error" v-if="errorMessage">
+          {{ errorMessage }}
+        </notice-bar>
+        <notice-bar type="warning" v-else-if="warningMessage">
+          {{ warningMessage }}
+        </notice-bar>
+        <notice-bar v-else-if="infoMessage">
+          {{ infoMessage }}
+        </notice-bar>
+        <div class="pls-keep-height" v-else/>
       </div>
+      <div class="modal-body">
+        <slot></slot>
+      </div>
+      <div class="modal-actions">
+        <slot name="actions"></slot>
+      </div>
+      <div class="divider"></div>
+      <div class="footer">
+        <slot name="footer"></slot>
+      </div>
+    </div>
   </div>
 </template>
 <style scoped>

--- a/frontend/src/views/WaitingListActionView.vue
+++ b/frontend/src/views/WaitingListActionView.vue
@@ -63,7 +63,7 @@ onMounted(async () => {
 <template>
   <div>
   <home-view></home-view>
-  <generic-modal :error-message="errorMsg">
+  <generic-modal :error-message="errorMsg" @close="() => router.push({name: 'home'})">
     <template v-slot:header>
       <word-mark/>
       <h2 id="title" v-if="isError">


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This PR adds event handling for a `close` emit from the GenericModal.

## Benefits

Close buttons on the waiting list modal will work now.

## Applicable Issues
Closes #719 