### PR TITLE
Upgrade MySQL minor version

### DIFF
--- a/tofu/modules/data-store/database/main.tf
+++ b/tofu/modules/data-store/database/main.tf
@@ -1,7 +1,7 @@
 locals {
   username = replace("${var.name_prefix}_user", "-", "_")
   secret = {
-    
+
   }
 }
 
@@ -19,7 +19,7 @@ module "db" {
   identifier = var.name_prefix
 
   engine            = "mysql"
-  engine_version    = "8.0.32"
+  engine_version    = "8.0.35"
   instance_class    = "db.t3.medium"
   allocated_storage = 20
 

--- a/tofu/modules/data-store/database/main.tf
+++ b/tofu/modules/data-store/database/main.tf
@@ -1,7 +1,6 @@
 locals {
   username = replace("${var.name_prefix}_user", "-", "_")
   secret = {
-
   }
 }
 


### PR DESCRIPTION
## Description of the Change

AWS auto-upgraded the MySQL database's minor version. This PR adjusts our code to match the version.

## Benefits

Deploys, which currently throw this error...

```
Error: updating RDS DB Instance (tb-apmt-prod): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: 56ae8219-9792-451c-a05b-a15fdc6c5241, api error InvalidParameterCombination: Cannot upgrade mysql from 8.0.35 to 8.0.32
```

...will no longer fail.

## Applicable Issues

Related to errors noticed in [this job](https://github.com/thunderbird/appointment/actions/runs/11463482722/job/31897432138).
