### PR TITLE
Disable quick link update on inactive schedules

### DIFF
--- a/frontend/src/components/ScheduleCreation.vue
+++ b/frontend/src/components/ScheduleCreation.vue
@@ -716,7 +716,14 @@ watch(
               >
                 {{ t("label.quickLink") }}
               </text-input>
-              <refresh-icon class="mt-7 cursor-pointer text-teal-600" @click.prevent="refreshSlug" />
+              <refresh-icon
+                class="mt-7"
+                :class="{
+                  'text-teal-600 cursor-pointer': scheduleInput.active,
+                  'text-gray-500 cursor-not-allowed': !scheduleInput.active,
+                }"
+                @click.prevent="scheduleInput.active ? refreshSlug() : null"
+              />
             </div>
           </label>
           <!-- option to deactivate confirmation -->

--- a/frontend/src/components/ScheduleCreation.vue
+++ b/frontend/src/components/ScheduleCreation.vue
@@ -703,7 +703,7 @@ watch(
           <hr/>
           <!-- custom quick link -->
           <label class="relative flex flex-col gap-1">
-            <div class="flex gap-2">
+            <div class="flex items-center gap-2">
               <text-input
                 type="text"
                 name="slug"
@@ -716,14 +716,13 @@ watch(
               >
                 {{ t("label.quickLink") }}
               </text-input>
-              <refresh-icon
-                class="mt-7"
-                :class="{
-                  'text-teal-600 cursor-pointer': scheduleInput.active,
-                  'text-gray-500 cursor-not-allowed': !scheduleInput.active,
-                }"
-                @click.prevent="scheduleInput.active ? refreshSlug() : null"
-              />
+              <link-button
+                class="p-0.5"
+                @click="scheduleInput.active ? refreshSlug() : null"
+                :disabled="!scheduleInput.active"
+              >
+                <refresh-icon />
+              </link-button>
             </div>
           </label>
           <!-- option to deactivate confirmation -->


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

The button for updating the quick link slug is now grayed out and inactive, as soon as the schedule becomes inactive.

![image](https://github.com/user-attachments/assets/03e34d83-1c19-4c59-95c0-3264a7684f5b)


## Applicable Issues

Closes #686 
