### PR TITLE
Schedule page stores

### DIFF
--- a/frontend/src/definitions.ts
+++ b/frontend/src/definitions.ts
@@ -8,6 +8,8 @@ export enum DateFormatStrings {
   // Time display formats
   Display12Hour = 'hh:mma',
   Display24Hour = 'HH:mm',
+  // Other formats
+  UniqueMonth = 'YYYY-MM',
 }
 
 /**

--- a/frontend/src/models.ts
+++ b/frontend/src/models.ts
@@ -292,7 +292,7 @@ export type ExceptionDetail = {
   status?: number;
 }
 export type PydanticExceptionDetail = {
-  ctx: { reason: string },
+  ctx: { reason: string, ge?: string },
   input: string,
   loc: string[],
   msg: string,
@@ -333,7 +333,7 @@ export type Fetch = (url: string) => UseFetchReturn<any> & PromiseLike<UseFetchR
 export type InviteListResponse = UseFetchReturn<Invite[]|Exception>;
 export type Refresh = () => Promise<void>;
 export type RemoteEventListResponse = UseFetchReturn<RemoteEvent[]>;
-export type ScheduleResponse = UseFetchReturn<Schedule>;
+export type ScheduleResponse = UseFetchReturn<Schedule|Exception>;
 export type ScheduleListResponse = UseFetchReturn<Schedule[]>;
 export type SignatureResponse = UseFetchReturn<Signature>;
 export type SlotResponse = UseFetchReturn<Slot|Exception>;

--- a/frontend/src/stores/calendar-store.ts
+++ b/frontend/src/stores/calendar-store.ts
@@ -1,9 +1,13 @@
-import { Calendar, CalendarListResponse, Fetch } from '@/models';
+import { Calendar, CalendarListResponse, Fetch, RemoteEvent, RemoteEventListResponse } from '@/models';
 import { defineStore } from 'pinia';
-import { ref, computed } from 'vue';
+import { ref, computed, inject } from 'vue';
+import { dayjsKey } from '@/keys';
+import { Dayjs } from 'dayjs';
 
 // eslint-disable-next-line import/prefer-default-export
 export const useCalendarStore = defineStore('calendars', () => {
+  const dj = inject(dayjsKey);
+
   // State
   const isLoaded = ref(false);
 
@@ -11,8 +15,12 @@ export const useCalendarStore = defineStore('calendars', () => {
   const calendars = ref<Calendar[]>([]);
   const unconnectedCalendars = computed((): Calendar[] => calendars.value.filter((cal) => !cal.connected));
   const connectedCalendars = computed((): Calendar[] => calendars.value.filter((cal) => cal.connected));
-
   const hasConnectedCalendars = computed(() => connectedCalendars.value.length > 0);
+
+  // List of remote events. Retrieved in batches per month.
+  const remoteEvents = ref<RemoteEvent[]>([]);
+  // List of month batches already called.
+  const remoteMonthsRetrieved = ref<string[]>([]);
 
   const connectGoogleCalendar = async (call: Fetch, email: string) => {
     const urlFriendlyEmail = encodeURIComponent(email);
@@ -45,6 +53,48 @@ export const useCalendarStore = defineStore('calendars', () => {
   };
 
   /**
+   * Get all cremote events from connected calendars for given time span
+   * @param call preconfigured API fetch function
+   * @param activeDate Dayjs object defining the current month
+   * @param force force a refetch
+   */
+  const getRemoteEvents = async (call: Fetch, activeDate: Dayjs, force = false) => {
+    // Get month identifier to remember this month's events are already retrieved
+    const month = activeDate.format('YYYY-MM');
+    
+    // Most calendar impl are non-inclusive of the last day, so just add one day to the end.
+    const from = activeDate.startOf('month').format('YYYY-MM-DD');
+    const to = activeDate.endOf('month').add(1, 'day').format('YYYY-MM-DD');
+  
+    // If retrieval is forced, delete cache and start with zero events again
+    if (force) {
+      remoteMonthsRetrieved.value = [];
+    }
+    const calendarEvents = force ? [] : [...remoteEvents.value];
+
+    // Only retrieve remote events if we don't have this month already cached
+    if (!remoteMonthsRetrieved.value.includes(month)) {
+      await Promise.all(connectedCalendars.value.map(async (calendar) => {
+        const { data }: RemoteEventListResponse = await call(`rmt/cal/${calendar.id}/${from}/${to}`).get().json();
+        if (Array.isArray(data.value)) {
+          calendarEvents.push(
+            ...data.value.map((event) => ({
+              ...event,
+              duration: dj(event.end).diff(dj(event.start), 'minutes'),
+            })),
+          );
+        }
+      }));
+    }
+
+    // Remember month
+    remoteMonthsRetrieved.value.push(month);
+    
+    // Update remote event list
+    remoteEvents.value = calendarEvents;
+  };
+
+  /**
    * Restore default state, empty and unload calendars
    */
   const $reset = () => {
@@ -55,9 +105,11 @@ export const useCalendarStore = defineStore('calendars', () => {
   const connectCalendar = async (call: Fetch, id: number) => {
     await call(`cal/${id}/connect`).post();
   };
+
   const disconnectCalendar = async (call: Fetch, id: number) => {
     await call(`cal/${id}/disconnect`).post();
   };
+
   const syncCalendars = async (call: Fetch) => {
     await call('rmt/sync').post();
   };
@@ -68,6 +120,7 @@ export const useCalendarStore = defineStore('calendars', () => {
     calendars,
     unconnectedCalendars,
     connectedCalendars,
+    remoteEvents,
     fetch,
     $reset,
     connectGoogleCalendar,
@@ -75,5 +128,6 @@ export const useCalendarStore = defineStore('calendars', () => {
     disconnectCalendar,
     syncCalendars,
     calendarById,
+    getRemoteEvents,
   };
 });

--- a/frontend/src/stores/schedule-store.ts
+++ b/frontend/src/stores/schedule-store.ts
@@ -1,10 +1,10 @@
 import { i18n } from '@/composables/i18n';
 import { defineStore } from 'pinia';
-import { ref, computed, inject } from 'vue';
+import { ref, computed, inject, Ref } from 'vue';
 import { useUserStore } from '@/stores/user-store';
 import { DateFormatStrings, MetricEvents } from '@/definitions';
 import {
-  Error, Fetch, Schedule, ScheduleListResponse, ScheduleResponse,
+  Error, Fetch, Schedule, ScheduleListResponse, ScheduleResponse, Exception, ExceptionDetail
 } from '@/models';
 import { dayjsKey } from '@/keys';
 import { posthog, usePosthog } from '@/composables/posthog';
@@ -51,11 +51,11 @@ export const useScheduleStore = defineStore('schedules', () => {
     isLoaded.value = false;
   };
 
-  const handleErrorResponse = (responseData) => {
+  const handleErrorResponse = (responseData: Ref<Exception>) => {
     const { value } = responseData;
 
-    if (value?.detail?.message) {
-      return value?.detail?.message;
+    if ((value?.detail as ExceptionDetail)?.message) {
+      return (value?.detail as ExceptionDetail)?.message;
     }
 
     if (value?.detail instanceof Array) {
@@ -109,7 +109,7 @@ export const useScheduleStore = defineStore('schedules', () => {
     if (error.value) {
       return {
         error: true,
-        message: handleErrorResponse(data),
+        message: handleErrorResponse(data as Ref<Exception>),
       } as Error;
     }
 
@@ -130,7 +130,7 @@ export const useScheduleStore = defineStore('schedules', () => {
     if (error.value) {
       return {
         error: true,
-        message: handleErrorResponse(data),
+        message: handleErrorResponse(data as Ref<Exception>),
       } as Error;
     }
 

--- a/frontend/src/stores/schedule-store.ts
+++ b/frontend/src/stores/schedule-store.ts
@@ -2,7 +2,13 @@ import { i18n } from '@/composables/i18n';
 import { defineStore } from 'pinia';
 import { ref, computed, inject, Ref } from 'vue';
 import { useUserStore } from '@/stores/user-store';
-import { DateFormatStrings, MetricEvents } from '@/definitions';
+import {
+  DateFormatStrings,
+  MetricEvents,
+  DEFAULT_SLOT_DURATION,
+  EventLocationType,
+  MeetingLinkProviderType,
+} from '@/definitions';
 import {
   Error, Fetch, Schedule, ScheduleListResponse, ScheduleResponse, Exception, ExceptionDetail
 } from '@/models';
@@ -13,6 +19,31 @@ import { timeFormat } from '@/utils';
 // eslint-disable-next-line import/prefer-default-export
 export const useScheduleStore = defineStore('schedules', () => {
   const dj = inject(dayjsKey);
+
+  const defaultSchedule = {
+    active: false,
+    name: '',
+    calendar_id: 0,
+    location_type: EventLocationType.InPerson,
+    location_url: '',
+    details: '',
+    start_date: dj().format(DateFormatStrings.QalendarFullDay),
+    end_date: null,
+    start_time: '09:00',
+    end_time: '17:00',
+    earliest_booking: 1440,
+    farthest_booking: 20160,
+    weekdays: [1, 2, 3, 4, 5],
+    slot_duration: DEFAULT_SLOT_DURATION,
+    meeting_link_provider: MeetingLinkProviderType.None,
+    booking_confirmation: true,
+    calendar: {
+      id: 0,
+      title: '',
+      color: '#000',
+      connected: true,
+    },
+  };
 
   // State
   const isLoaded = ref(false);
@@ -174,6 +205,7 @@ export const useScheduleStore = defineStore('schedules', () => {
 
   return {
     isLoaded,
+    defaultSchedule,
     schedules,
     firstSchedule,
     inactiveSchedules,

--- a/frontend/src/stores/schedule-store.ts
+++ b/frontend/src/stores/schedule-store.ts
@@ -19,11 +19,12 @@ export const useScheduleStore = defineStore('schedules', () => {
 
   // Data
   const schedules = ref<Schedule[]>([]);
+  const firstSchedule = computed((): Schedule => schedules.value?.length > 0 ? schedules.value[0] : null);
   const inactiveSchedules = computed((): Schedule[] => schedules.value.filter((schedule) => !schedule.active));
   const activeSchedules = computed((): Schedule[] => schedules.value.filter((schedule) => schedule.active));
 
   /**
-   * Get all calendars for current user
+   * Get all schedules for current user
    * @param call preconfigured API fetch function
    * @param force Force a fetch even if we already have data
    */
@@ -43,7 +44,7 @@ export const useScheduleStore = defineStore('schedules', () => {
   };
 
   /**
-   * Restore default state, empty and unload calendars
+   * Restore default state, empty and unload schedules
    */
   const $reset = () => {
     schedules.value = [];
@@ -172,6 +173,16 @@ export const useScheduleStore = defineStore('schedules', () => {
   };
 
   return {
-    isLoaded, schedules, inactiveSchedules, activeSchedules, fetch, $reset, createSchedule, updateSchedule, timeToBackendTime, timeToFrontendTime,
+    isLoaded,
+    schedules,
+    firstSchedule,
+    inactiveSchedules,
+    activeSchedules,
+    fetch,
+    $reset,
+    createSchedule,
+    updateSchedule,
+    timeToBackendTime,
+    timeToFrontendTime,
   };
 });

--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
 import {
-  BookingCalendarView,
   DateFormatStrings,
   DEFAULT_SLOT_DURATION, Dismissibles,
   EventLocationType,
   MeetingLinkProviderType,
 } from '@/definitions';
-import { ref, inject, onMounted } from 'vue';
+import { ref, inject, onMounted, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 import { storeToRefs } from 'pinia';
@@ -38,15 +37,12 @@ const { pendingAppointments } = storeToRefs(appointmentStore);
 const { connectedCalendars, remoteEvents } = storeToRefs(calendarStore);
 const { data: userActivityData } = storeToRefs(userActivityStore);
 
-// current selected date, if not in route: defaults to now
-const activeDate = ref(route.params.date ? dj(route.params.date as string) : dj());
-const activeDateRange = ref({
+// current selected date, defaults to now
+const activeDate = ref(dj());
+const activeDateRange = computed(() => ({
   start: activeDate.value.startOf('month'),
   end: activeDate.value.endOf('month'),
-});
-
-// active menu item for tab navigation of calendar views
-const tabActive = ref(BookingCalendarView.Month);
+}));
 
 // user configured schedules from db (only the first for now, later multiple schedules will be available)
 const schedulesReady = ref(false);
@@ -156,10 +152,7 @@ const dismiss = () => {
     <div class="text-4xl font-light">{{ t('label.dashboard') }}</div>
   </div>
   <!-- page content -->
-  <div
-    class="mt-8 flex flex-col-reverse items-stretch gap-2 md:flex-row-reverse lg:gap-4"
-    :class="{ 'lg:mt-10': tabActive === BookingCalendarView.Month }"
-  >
+  <div class="mt-8 flex flex-col-reverse items-stretch gap-2 md:flex-row-reverse lg:gap-4">
     <!-- schedule creation dialog -->
     <div class="mx-auto mb-10 w-3/4 min-w-80 sm:w-1/4 md:mb-0 xl:w-1/6">
       <schedule-creation
@@ -174,7 +167,6 @@ const dismiss = () => {
     <!-- main section: big calendar showing active month, week or day -->
     <calendar-qalendar
       class="w-full md:w-9/12 xl:w-10/12"
-      :selected="activeDate"
       :appointments="pendingAppointments"
       :events="remoteEvents"
       :schedules="schedulesPreviews"

--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -1,10 +1,5 @@
 <script setup lang="ts">
-import {
-  DateFormatStrings,
-  DEFAULT_SLOT_DURATION, Dismissibles,
-  EventLocationType,
-  MeetingLinkProviderType,
-} from '@/definitions';
+import { Dismissibles } from '@/definitions';
 import { ref, inject, onMounted, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
@@ -76,32 +71,8 @@ const onDateChange = async (dateObj: TimeFormatted) => {
 onMounted(async () => {
   // Don't actually load anything during the FTUE
   if (route.name === 'setup') {
-    // Setup a fake schedule so the schedule creation bar works correctly...
-    // TODO: move that to the schedule store as initial/default value
-    schedules.value = [{
-      active: false,
-      name: '',
-      calendar_id: 0,
-      location_type: EventLocationType.InPerson,
-      location_url: '',
-      details: '',
-      start_date: dj().format(DateFormatStrings.QalendarFullDay),
-      end_date: null,
-      start_time: '09:00',
-      end_time: '17:00',
-      earliest_booking: 1440,
-      farthest_booking: 20160,
-      weekdays: [1, 2, 3, 4, 5],
-      slot_duration: DEFAULT_SLOT_DURATION,
-      meeting_link_provider: MeetingLinkProviderType.None,
-      booking_confirmation: true,
-      calendar: {
-        id: 0,
-        title: '',
-        color: '#000',
-        connected: true,
-      },
-    }];
+    // Setup a default schedule so the schedule creation bar works correctly...
+    schedules.value = [scheduleStore.defaultSchedule];
     schedulesReady.value = true;
     return;
   }

--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -6,9 +6,7 @@ import {
   EventLocationType,
   MeetingLinkProviderType,
 } from '@/definitions';
-import {
-  ref, inject, computed, onMounted,
-} from 'vue';
+import { ref, inject, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 import { storeToRefs } from 'pinia';
@@ -16,8 +14,6 @@ import { dayjsKey, callKey, refreshKey } from '@/keys';
 import {
   RemoteEvent,
   RemoteEventListResponse,
-  Schedule,
-  ScheduleListResponse,
   ScheduleAppointment,
   TimeFormatted,
 } from '@/models';
@@ -141,6 +137,7 @@ onMounted(async () => {
     return;
   }
   await refresh();
+  scheduleStore.fetch(call);
   schedulesReady.value = true;
   const eventsFrom = dj(activeDate.value).startOf('month').format('YYYY-MM-DD');
   const eventsTo = dj(activeDate.value).endOf('month').format('YYYY-MM-DD');
@@ -199,7 +196,7 @@ const dismiss = () => {
         :calendars="connectedCalendars"
         :schedule="firstSchedule"
         :active-date="activeDate"
-        @created="scheduleStore.fetch"
+        @created="scheduleStore.fetch(call, true)"
         @updated="schedulePreview"
       />
     </div>


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This PR aims to improve performance of the dashboard (Schedule configuration page). The already existing schedule store got hooked up on the dashboard page. Still misses:

- [x] Adding remote event retrieval to the calendar store
- [x] Hook up stored events for the dashboard view

## Benefits

The dashboard now retrieves events per month, only if that month is navigated to the first time. The events will be remembered from this point making calendar navigation much faster and more convenient, when returning to views/months already visited.

## Applicable Issues

Closes #648 
