### PR TITLE
increased container size in prod

### DIFF
--- a/tofu/modules/services/backend-service/main.tf
+++ b/tofu/modules/services/backend-service/main.tf
@@ -26,8 +26,8 @@ resource "aws_ecs_task_definition" "backend" {
   execution_role_arn       = var.task_execution_role
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = "512"
-  memory                   = "1024"
+  cpu                      = var.app_env == "prod" ? "1024" : "512"
+  memory                   = var.app_env == "prod" ? "4096" : "1024"
   runtime_platform {
     cpu_architecture        = "X86_64"
     operating_system_family = "LINUX"


### PR DESCRIPTION
 Description of the Change

Increases backend container size in prod to 1vcpu/4GB while keeping stage on 0.5vcpu/1GB

## Benefits

More resources to support increased user base as we expand the beta
