### PR TITLE
Validate booking slot's weekday in schedule timezone. (Fixes #735)

### DIFF
--- a/backend/src/appointment/routes/schedule.py
+++ b/backend/src/appointment/routes/schedule.py
@@ -78,9 +78,11 @@ def is_this_a_valid_booking_time(schedule: models.Schedule, booking_slot: schema
 
     booking_slot_end = booking_slot.start + timedelta(minutes=schedule.slot_duration)
 
-    if booking_slot.start < datetime.combine(
-        today, schedule.start_time, tzinfo=timezone.utc
-    ) or booking_slot_end > datetime.combine(today, schedule.end_time, tzinfo=timezone.utc) + timedelta(days=add_day):
+    too_early = booking_slot.start < datetime.combine(today, schedule.start_time, tzinfo=timezone.utc)
+    too_late = booking_slot_end > (
+      datetime.combine(today, schedule.end_time, tzinfo=timezone.utc) + timedelta(days=add_day)
+    )
+    if too_early or too_late:
         return False
 
     return True

--- a/backend/test/unit/test_utils.py
+++ b/backend/test/unit/test_utils.py
@@ -83,14 +83,41 @@ class TestIsAValidBookingTime:
             end_time=0,  # 5PM PDT
             timezone='America/Vancouver',
             # This is not accurate, but it was probably saved before Nov 3rd.
-            time_updated=datetime.datetime(2024, 11, 1, 12, 0,0, tzinfo=datetime.UTC),
+            time_updated=datetime.datetime(2024, 11, 1, 12, 0, 0, tzinfo=datetime.UTC),
         )
 
         # Freeze on the datetime that the error occurred on
         with freeze_time('2024-11-04T09:09:29.530Z'):
-            is_valid = is_this_a_valid_booking_time(
-                schedule,
-                s_a.slot
-            )
+            is_valid = is_this_a_valid_booking_time(schedule, s_a.slot)
+
+        assert is_valid is True
+
+    def test_bug_735_case_2(self, make_schedule):
+        # Request data submitted from bug and anonymized.
+        request_data = {
+            's_a': {
+                'slot': {'start': '2024-11-17T22:00:00.000Z', 'duration': 30},
+                'attendee': {'name': 'melissa', 'email': 'melissa@example.org', 'timezone': 'Australia/Sydney'},
+            },
+            'url': 'http://localhost:8080/user/username/example/',
+        }
+
+        s_a = schemas.AvailabilitySlotAttendee(**request_data['s_a'])
+
+        schedule = make_schedule(
+            active=True,
+            start_date=datetime.date(2024, 11, 7),
+            end_date=None,
+            earliest_booking=0,
+            farthest_booking=10080,
+            weekdays=[1, 2, 3, 4, 5],
+            slot_duration=30,
+            start_time="22:00",  # 9AM AEDT
+            end_time="06:00",  # 5PM AEDT
+            timezone='Australia/Sydney',
+            time_updated=datetime.datetime(2024, 11, 15, 12, 0, 0, tzinfo=datetime.UTC),
+        )
+
+        is_valid = is_this_a_valid_booking_time(schedule, s_a.slot)
 
         assert is_valid is True

--- a/backend/test/unit/test_utils.py
+++ b/backend/test/unit/test_utils.py
@@ -60,6 +60,8 @@ class TestRetrieveUserUrlData:
 
 class TestIsAValidBookingTime:
     def test_bug_735(self, make_schedule):
+        """A test case to cover unsuccessfully capturing bug 735, which is the seemingly random slot not found issue.
+        Ref: https://github.com/thunderbird/appointment/issues/735"""
         # Request data submitted from bug and anonymized.
         request_data = {
             's_a': {
@@ -93,6 +95,8 @@ class TestIsAValidBookingTime:
         assert is_valid is True
 
     def test_bug_735_case_2(self, make_schedule):
+        """A test case to cover successfully capturing bug 735, which is the seemingly random slot not found issue.
+        Ref: https://github.com/thunderbird/appointment/issues/735"""
         # Request data submitted from bug and anonymized.
         request_data = {
             's_a': {


### PR DESCRIPTION
Fixes #735 

Fixes a case where the date could overflow to a day of the week which the schedule has disabled. Which would fail booking slot validation. 

This is because days of the week are saved based on the user/schedule's timezone rather than UTC. Which is a little confusing and we should maybe look into fixing that, but this is a quick fix for now. 