### PR TITLE
Handle missing vevent attributes

### DIFF
--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -397,11 +397,17 @@ class CalDavConnector(BaseConnector):
             if status == 'cancelled' or transparency == 'transparent':
                 continue
 
+            vevent = e.vobject_instance.vevent
+
+            # Ignore events with missing datetime data
+            if not vevent.dtstart or (not vevent.dtend and not vevent.duration):
+                continue
+
             # Mark tentative events
             tentative = status == 'tentative'
 
-            title = e.vobject_instance.vevent.summary.value
-            start = e.vobject_instance.vevent.dtstart.value
+            title = vevent.summary.value if vevent.summary else ''
+            start = vevent.dtstart.value
             # get_duration grabs either end or duration into a timedelta
             end = start + e.get_duration()
             # if start doesn't hold time information (no datetime), it's a whole day

--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -400,13 +400,13 @@ class CalDavConnector(BaseConnector):
             vevent = e.vobject_instance.vevent
 
             # Ignore events with missing datetime data
-            if not vevent.dtstart or (not vevent.dtend and not vevent.duration):
+            if not vevent or not vevent.dtstart or (not vevent.dtend and not vevent.duration):
                 continue
 
             # Mark tentative events
             tentative = status == 'tentative'
 
-            title = vevent.summary.value if vevent.summary else ''
+            title = vevent.summary.value if vevent.summary else l10n('event-summary-default')
             start = vevent.dtstart.value
             # get_duration grabs either end or duration into a timedelta
             end = start + e.get_duration()

--- a/backend/src/appointment/l10n/de/main.ftl
+++ b/backend/src/appointment/l10n/de/main.ftl
@@ -74,7 +74,7 @@ zoom-connect-to-continue = Bitte ein Zoom-Konto verbinden, einen benutzerdefinie
 ## Google Exceptions
 
 google-connection-error = Fehler bei der Verbindung mit Google API, bitte Verbindung erneut herstellen.
-google-scope-changed = Der Zugriff auf Kalender und Ereignisse muss aktiviert sein, um Thunderbird Appointment verwenden zu können.
+google-scope-changed = Der Zugriff auf Kalender und Termine muss aktiviert sein, um Thunderbird Appointment verwenden zu können.
 google-invalid-creds = Die Anmeldedaten für die Google-Authentifizierung sind nicht gültig.
 google-auth-fail = Google-Authentifizierung fehlgeschlagen.
 google-auth-expired = Die Google-Authentifizierungssitzung ist abgelaufen, bitte erneut versuchen.
@@ -85,7 +85,8 @@ google-connect-to-continue = Zum Fortfahren muss mindestens ein Google-Konto ver
 ## Frontend Facing Strings
 
 # If the calendar event does not have a title this will be used instead
-event-summary-not-found = Ereignis nicht gefunden!
+event-summary-not-found = Titel nicht gefunden!
+event-summary-default = Termin ohne Titel
 
 ## Event File Strings
 

--- a/backend/src/appointment/l10n/en/main.ftl
+++ b/backend/src/appointment/l10n/en/main.ftl
@@ -87,6 +87,7 @@ google-connect-to-continue = You must connect at least one Google account to con
 
 # If the calendar event does not have a title this will be used instead
 event-summary-not-found = Title not found!
+event-summary-default = Untitled Event
 
 ## Event File Strings
 


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change ignores all remote events, that don't have a `dtstart` or neither a `dtend` nor `duration`. Also the event title gets a default value, if `summary` is missing.

## Benefits

Wider range of supported caldav servers.

## Applicable Issues

Fixes #741
