### PR TITLE
Replace the content-type on ics files

### DIFF
--- a/backend/src/appointment/controller/mailer.py
+++ b/backend/src/appointment/controller/mailer.py
@@ -94,14 +94,24 @@ class Mailer:
 
         # add attachment(s) as multimedia parts
         for a in self._attachments():
-            # Attach it to the html payload
-            message.get_payload()[1].add_related(
-                a.data,
-                a.mime_main,
-                a.mime_sub,
-                cid=f'<{a.filename}>',
-                filename=a.filename,
-            )
+            # Handle ics files differently than inline images
+            if a.mime_main == 'text' and a.mime_sub == 'calendar':
+                message.add_attachment(
+                    a.data,
+                    maintype=a.mime_main, subtype=a.mime_sub,
+                    filename=a.filename
+                )
+                # Fix the header of the attachment
+                message.get_payload()[-1].replace_header('Content-Type', f'{a.mime_main}/{a.mime_sub}; charset="UTF-8"; method=REQUEST')
+            else:
+                # Attach it to the html payload
+                message.get_payload()[1].add_related(
+                    a.data,
+                    a.mime_main,
+                    a.mime_sub,
+                    cid=f'<{a.filename}>',
+                    filename=a.filename,
+                )
 
         return message
 


### PR DESCRIPTION
Should fix #773 

I can't really test it in thunderbird, but the header shows up in mailpit. 

I'm not sure if there's a better way to fix this header, the python api seems a little...light on implementation details outside of "Hey add an attachment to an email and send it!" 🤔 
