### PR TITLE
Add owner email as reply-to header

### DIFF
--- a/backend/src/appointment/controller/mailer.py
+++ b/backend/src/appointment/controller/mailer.py
@@ -223,6 +223,7 @@ class InvitationMail(BaseBookingMail):
             'plain': l10n('invite-mail-plain'),
         }
         super().__init__(*args, **default_kwargs, **kwargs)
+        self.reply_to = self.email
 
     def html(self):
         return get_template('invite.jinja2').render(
@@ -334,6 +335,7 @@ class NewBookingMail(BaseBookingMail):
         self.schedule_name = schedule_name
         default_kwargs = {'subject': l10n('new-booking-subject', {'name': name})}
         super().__init__(name=name, email=email, date=date, duration=duration, *args, **default_kwargs, **kwargs)
+        self.reply_to = email
 
     def text(self):
         return l10n(

--- a/backend/src/appointment/l10n/de/email.ftl
+++ b/backend/src/appointment/l10n/de/email.ftl
@@ -12,7 +12,9 @@
 
 mail-brand-contact-form = Kontaktformular
 mail-brand-support-hint = Du hast Fragen? Wir helfen gern. Nutze unser { $contact_form_link }, oder antworte einfach auf diese E-Mail für Support.
-mail-brand-reply-hint = Du hast Fragen? Wir helfen gern, Du erreichst uns über unser { $contact_form_link }. Du möchtest { $name } ({ $email }) kontaktieren? Antworte einfach auf diese E-Mail.
+mail-brand-reply-hint = Du hast Fragen? Wir helfen gern, Du erreichst uns über unser { $contact_form_link }.
+mail-brand-reply-hint-attendee-info = Du möchtest { $name } kontaktieren? Antworte einfach auf diese E-Mail.
+
 mail-brand-footer = Diese Nachricht wurde gesendet von:
                     {-brand-name}
                     {-brand-slogan} {-brand-sign-up-with-no-url}

--- a/backend/src/appointment/l10n/de/email.ftl
+++ b/backend/src/appointment/l10n/de/email.ftl
@@ -12,6 +12,7 @@
 
 mail-brand-contact-form = Kontaktformular
 mail-brand-support-hint = Du hast Fragen? Wir helfen gern. Nutze unser { $contact_form_link }, oder antworte einfach auf diese E-Mail für Support.
+mail-brand-reply-hint = Du hast Fragen? Wir helfen gern, Du erreichst uns über unser { $contact_form_link }. Du möchtest { $name } ({ $email }) kontaktieren? Antworte einfach auf diese E-Mail.
 mail-brand-footer = Diese Nachricht wurde gesendet von:
                     {-brand-name}
                     {-brand-slogan} {-brand-sign-up-with-no-url}

--- a/backend/src/appointment/l10n/en/email.ftl
+++ b/backend/src/appointment/l10n/en/email.ftl
@@ -12,6 +12,7 @@
 
 mail-brand-contact-form = contact form
 mail-brand-support-hint = Got questions? We're here to help. Fill out our { $contact_form_link }, or simply reply to this email for support.
+mail-brand-reply-hint = Got questions? We're here to help, you can reach us via our { $contact_form_link }. Need to get in touch with { $name } ({ $email })? Simply reply to this email.
 mail-brand-footer = This message was sent from:
                     {-brand-name}
                     {-brand-slogan} {-brand-sign-up-with-no-url}

--- a/backend/src/appointment/l10n/en/email.ftl
+++ b/backend/src/appointment/l10n/en/email.ftl
@@ -12,7 +12,9 @@
 
 mail-brand-contact-form = contact form
 mail-brand-support-hint = Got questions? We're here to help. Fill out our { $contact_form_link }, or simply reply to this email for support.
-mail-brand-reply-hint = Got questions? We're here to help, you can reach us via our { $contact_form_link }. Need to get in touch with { $name } ({ $email })? Simply reply to this email.
+mail-brand-reply-hint = Got questions? We're here to help, you can reach us via our { $contact_form_link }.
+mail-brand-reply-hint-attendee-info = Need to get in touch with { $name }? Simply reply to this email.
+
 mail-brand-footer = This message was sent from:
                     {-brand-name}
                     {-brand-slogan} {-brand-sign-up-with-no-url}

--- a/backend/src/appointment/templates/email/confirm.jinja2
+++ b/backend/src/appointment/templates/email/confirm.jinja2
@@ -1,5 +1,5 @@
 {% extends "includes/base.jinja2" %}
-{% set show_contact_form_hint = True %}
+{% set show_contact_form_support_hint = True %}
 {# Helper vars #}
 {% set clock_image_small = '<img style="width: 11px; height: 11px; position: relative; top: 2px;" alt="" src="cid:%(cid)s" />'|format(cid=clock_icon_cid) %}
 {% set clock_image = '<img style="width: 15px; height: 15px; position: relative; top: 2px;" alt="" src="cid:%(cid)s" />'|format(cid=clock_icon_cid) %}

--- a/backend/src/appointment/templates/email/errors/zoom_invite_failed.jinja2
+++ b/backend/src/appointment/templates/email/errors/zoom_invite_failed.jinja2
@@ -1,5 +1,5 @@
 {% extends "includes/base.jinja2" %}
-{% set show_contact_form_hint = True %}
+{% set show_contact_form_support_hint = True %}
 {# Code begins! #}
 {% block introduction %}
   <div style="color: {{ colour_text_base }}; text-align: center; line-height: 16px;">

--- a/backend/src/appointment/templates/email/includes/base.jinja2
+++ b/backend/src/appointment/templates/email/includes/base.jinja2
@@ -44,10 +44,16 @@
   {% block call_to_action %}{% endblock %}
 </div>
 {% endif %}
-{% if show_contact_form_hint %}
+{% if show_contact_form_support_hint %}
 {% set link = '<a href="%(url)s">%(label)s</a>'|format(url=homepage_url + '/contact', label=l10n('mail-brand-contact-form')) %}
 <div style="text-align: center; margin-left: auto; margin-right: auto; margin-bottom: 24px; padding: 12px; max-width: 310px;">
   {{ l10n('mail-brand-support-hint', {'contact_form_link': link})|safe }}
+</div>
+{% endif %}
+{% if show_contact_form_reply_hint %}
+{% set link = '<a href="%(url)s">%(label)s</a>'|format(url=homepage_url + '/contact', label=l10n('mail-brand-contact-form')) %}
+<div style="text-align: center; margin-left: auto; margin-right: auto; margin-bottom: 24px; padding: 12px; max-width: 310px;">
+  {{ l10n('mail-brand-reply-hint', {'contact_form_link': link, 'name': name, 'email': email })|safe }}
 </div>
 {% endif %}
 <div style="

--- a/backend/src/appointment/templates/email/includes/base.jinja2
+++ b/backend/src/appointment/templates/email/includes/base.jinja2
@@ -53,7 +53,9 @@
 {% if show_contact_form_reply_hint %}
 {% set link = '<a href="%(url)s">%(label)s</a>'|format(url=homepage_url + '/contact', label=l10n('mail-brand-contact-form')) %}
 <div style="text-align: center; margin-left: auto; margin-right: auto; margin-bottom: 24px; padding: 12px; max-width: 310px;">
-  {{ l10n('mail-brand-reply-hint', {'contact_form_link': link, 'name': name, 'email': email })|safe }}
+  {{ l10n('mail-brand-reply-hint-attendee-info', { 'name': name })|safe }}
+  <br/><br/>
+  {{ l10n('mail-brand-reply-hint', {'contact_form_link': link})|safe }}
 </div>
 {% endif %}
 <div style="

--- a/backend/src/appointment/templates/email/invite.jinja2
+++ b/backend/src/appointment/templates/email/invite.jinja2
@@ -3,6 +3,7 @@
 {% set clock_image_small = '<img style="width: 11px; height: 11px; position: relative; top: 2px;" alt="" src="cid:%(cid)s" />'|format(cid=clock_icon_cid) %}
 {% set clock_image = '<img style="width: 15px; height: 15px; position: relative; top: 2px;" alt="" src="cid:%(cid)s" />'|format(cid=clock_icon_cid) %}
 {% set calendar_image = '<img style="width: 14px; height: 14px; position: relative; top: 2px;" alt="" src="cid:%(cid)s" />'|format(cid=calendar_icon_cid) %}
+{% set show_contact_form_reply_hint = True %}
 {# Code begins! #}
 {% block introduction %}
   <div style="color: {{ colour_text_base }}; text-align: center; line-height: 16px;">

--- a/backend/src/appointment/templates/email/new_account.jinja2
+++ b/backend/src/appointment/templates/email/new_account.jinja2
@@ -1,5 +1,5 @@
 {% extends "includes/base.jinja2" %}
-{% set show_contact_form_hint = True %}
+{% set show_contact_form_support_hint = True %}
 {# Code begins! #}
 {% block introduction %}
   <div style="color: {{ colour_text_base }}; text-align: center; line-height: 16px;">

--- a/backend/src/appointment/templates/email/new_booking.jinja2
+++ b/backend/src/appointment/templates/email/new_booking.jinja2
@@ -3,7 +3,7 @@
 {% set clock_image_small = '<img style="width: 11px; height: 11px; position: relative; top: 2px;" alt="" src="cid:%(cid)s" />'|format(cid=clock_icon_cid) %}
 {% set clock_image = '<img style="width: 15px; height: 15px; position: relative; top: 2px;" alt="" src="cid:%(cid)s" />'|format(cid=clock_icon_cid) %}
 {% set calendar_image = '<img style="width: 14px; height: 14px; position: relative; top: 2px;" alt="" src="cid:%(cid)s" />'|format(cid=calendar_icon_cid) %}
-{% set show_contact_form_hint = True %}
+{% set show_contact_form_reply_hint = True %}
 {# Code begins! #}
 {% block introduction %}
   <div style="color: {{ colour_text_base }}; text-align: center; line-height: 16px;">


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This PR changes the default _reply-to_ (configured system or support email address) for the invitation mail (x has accepted your booking) and the new booking mail (x has just booked...).

## Benefits

The configuration is now like this:

- invitation mail (_... has accepted your booking_)
  - To: Bookee
  - Reply-To: Owner
- new booking mail (_... has just booked..._)
  - To: Owner
  - Reply-To: Bookee

## Applicable Issues

Closes #765 
