### PR TITLE
Check for slot status before confirming or rejecting a booking request

### DIFF
--- a/backend/src/appointment/routes/schedule.py
+++ b/backend/src/appointment/routes/schedule.py
@@ -467,6 +467,7 @@ def decide_on_schedule_availability_slot(
         not slot
         or not repo.schedule.has_slot(db, schedule.id, slot.id)
         or slot.booking_tkn != data.slot_token
+        or slot.booking_status != BookingStatus.requested
     ):
         raise validation.SlotNotFoundException()
 

--- a/backend/test/integration/test_schedule.py
+++ b/backend/test/integration/test_schedule.py
@@ -905,8 +905,7 @@ class TestDecideScheduleAvailabilitySlot:
             headers=auth_headers,
         )
 
-        with with_db() as db:
-            assert response.status_code == 404, response.text
+        assert response.status_code == 404, response.text
 
 
     def test_deny(
@@ -983,5 +982,4 @@ class TestDecideScheduleAvailabilitySlot:
             headers=auth_headers,
         )
 
-        with with_db() as db:
-            assert response.status_code == 404, response.text
+        assert response.status_code == 404, response.text

--- a/backend/test/integration/test_schedule.py
+++ b/backend/test/integration/test_schedule.py
@@ -698,6 +698,7 @@ class TestRequestScheduleAvailability:
                 headers=auth_headers,
             )
             assert response.status_code == 404, response.text
+
             data = response.json()
 
             assert data.get('detail', {}).get('id') == 'SLOT_NOT_FOUND'
@@ -726,6 +727,7 @@ class TestRequestScheduleAvailability:
                 headers=auth_headers,
             )
             assert response.status_code == 404, response.text
+
             data = response.json()
 
             assert data.get('detail', {}).get('id') == 'SLOT_NOT_FOUND'
@@ -755,6 +757,7 @@ class TestRequestScheduleAvailability:
                 headers=auth_headers,
             )
             assert response.status_code == 404, response.text
+
             data = response.json()
 
             assert data.get('detail', {}).get('id') == 'SLOT_NOT_FOUND'
@@ -783,6 +786,7 @@ class TestRequestScheduleAvailability:
                 headers=auth_headers,
             )
             assert response.status_code == 404, response.text
+
             data = response.json()
 
             assert data.get('detail', {}).get('id') == 'SLOT_NOT_FOUND'
@@ -811,6 +815,7 @@ class TestRequestScheduleAvailability:
                 headers=auth_headers,
             )
             assert response.status_code == 404, response.text
+
             data = response.json()
 
             assert data.get('detail', {}).get('id') == 'SLOT_NOT_FOUND'
@@ -893,6 +898,17 @@ class TestDecideScheduleAvailabilitySlot:
             assert slot.booking_status == models.BookingStatus.booked
             assert appointment.status == models.AppointmentStatus.closed
 
+        # Now try to confirm the same event again
+        response = with_client.put(
+            '/schedule/public/availability/booking',
+            json=availability,
+            headers=auth_headers,
+        )
+
+        with with_db() as db:
+            assert response.status_code == 404, response.text
+
+
     def test_deny(
         self,
         with_db,
@@ -959,3 +975,13 @@ class TestDecideScheduleAvailabilitySlot:
 
             assert slot is None
             assert appointment is None
+
+        # Now try to deny the same event again
+        response = with_client.put(
+            '/schedule/public/availability/booking',
+            json=availability,
+            headers=auth_headers,
+        )
+
+        with with_db() as db:
+            assert response.status_code == 404, response.text


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change
This PR adds a check for slot status before confirming or rejecting a booking request.

## Benefits
Prevents booking requests from being answered multiple times, each time sending a confirmation/rejection email to the bookee.

## Applicable Issues
Closes #791 