### PR TITLE
Add production sanity test to CI

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -233,3 +233,38 @@ jobs:
           terragrunt validate
           terragrunt plan -var "image=${{ steps.get_ecr_tag.outputs.ecr_tag }}" -out tfplan
           terragrunt apply tfplan
+
+  prod-sanity-browserstack:
+    name: prod-sanity-browserstack
+    needs: [deploy-prod-backend, deploy-prod-frontend]
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      APPT_PROD_LOGIN_EMAIL: ${{ secrets.E2E_APPT_PROD_LOGIN_EMAIL }}
+      APPT_PROD_LOGIN_PWORD: ${{ secrets.E2E_APPT_PROD_LOGIN_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'test/e2e/package-lock.json'
+
+      - name: Install dependencies
+        run: |
+          cd ./test/e2e
+          npm install
+
+      - name: BrowserStack Env Setup
+        uses: browserstack/github-actions/setup-env@master
+        with:
+          username:  ${{ secrets.BROWSERSTACK_USERNAME }}
+          access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          project-name: 'Thunderbird Appointment'
+
+      - name: Run Playwright Tests on Browserstack
+        run: |
+          cd ./test/e2e
+          cp .env.example .env
+          npm run prod-sanity-test-browserstack

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1,0 +1,50 @@
+name: nightly-tests
+
+concurrency:
+  group: nightly-tests
+  cancel-in-progress: true
+
+on:
+  schedule:
+    # run every day at 1am UTC (8PM EST)
+    - cron:  '0 1 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read    # This is required for actions/checkout
+
+jobs:
+  prod-sanity-browserstack:
+    name: prod-sanity-browserstack
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      APPT_PROD_LOGIN_EMAIL: ${{ secrets.E2E_APPT_PROD_LOGIN_EMAIL }}
+      APPT_PROD_LOGIN_PWORD: ${{ secrets.E2E_APPT_PROD_LOGIN_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'test/e2e/package-lock.json'
+
+      - name: Install dependencies
+        run: |
+          cd ./test/e2e
+          npm install
+
+      - name: BrowserStack Env Setup
+        uses: browserstack/github-actions/setup-env@master
+        with:
+          username:  ${{ secrets.BROWSERSTACK_USERNAME }}
+          access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          project-name: 'Thunderbird Appointment'
+
+      - name: Run Playwright Tests on Browserstack
+        run: |
+          cd ./test/e2e
+          cp .env.example .env
+          npm run prod-sanity-test-browserstack


### PR DESCRIPTION
Add a new GHA `nightly-tests` workflow which will run the Appointment production sanity test every night at 1AM UTC / 8PM EST via BrowserStack. It will be good to have the sanity test run once per day regardless on if there are any deployments; this will ensure any test issues or breaks will be caught ASAP and not at deployment time.

Also modifying the existing `deploy-production` workflow so that this same production sanity test will run automatically after each production deployment is completed.

Example of the nightly-tests.yml workflow running and working - the tests ran successfully in BrowserStack:

https://github.com/thunderbird/appointment/actions/runs/12400284448/job/34617094382

(See comment below for corresponding screenshots).