### PR TITLE
Add subscriber language and localize emails

### DIFF
--- a/backend/src/appointment/controller/mailer.py
+++ b/backend/src/appointment/controller/mailer.py
@@ -271,7 +271,8 @@ class ConfirmationMail(BaseBookingMail):
         self.confirmUrl = confirm_url
         self.denyUrl = deny_url
         self.schedule_name = schedule_name
-        default_kwargs = {'subject': l10n('confirm-mail-subject', {'name': name}, kwargs['lang'])}
+        lang = kwargs['lang'] if 'lang' in kwargs else None
+        default_kwargs = {'subject': l10n('confirm-mail-subject', {'name': name}, lang)}
         super().__init__(name=name, email=email, date=date, duration=duration, *args, **default_kwargs, **kwargs)
 
 
@@ -351,7 +352,8 @@ class NewBookingMail(BaseBookingMail):
            Reply-To: Bookee
         """
         self.schedule_name = schedule_name
-        default_kwargs = {'subject': l10n('new-booking-subject', {'name': name}, kwargs['lang'])}
+        lang = kwargs['lang'] if 'lang' in kwargs else None
+        default_kwargs = {'subject': l10n('new-booking-subject', {'name': name}, lang)}
         super(NewBookingMail, self).__init__(name=name, email=email, date=date, duration=duration, *args, **default_kwargs, **kwargs)
         self.reply_to = email
 

--- a/backend/src/appointment/controller/mailer.py
+++ b/backend/src/appointment/controller/mailer.py
@@ -56,7 +56,8 @@ class Mailer:
         html: str = '',
         plain: str = '',
         attachments: list[Attachment] = [],
-        method: str = 'REQUEST'
+        method: str = 'REQUEST',
+        lang: str = None
     ):
         self.sender = sender
         self.to = to
@@ -66,6 +67,7 @@ class Mailer:
         self.body_plain = plain
         self.attachments = attachments
         self.method = method
+        self.lang = lang
 
     def html(self):
         """provide email body as html per default"""
@@ -164,7 +166,9 @@ class Mailer:
 
 class BaseBookingMail(Mailer):
     def __init__(self, name, email, date, duration, *args, **kwargs):
-        """Base class for emails with name, email, and event information"""
+        """Base class for emails with name, email, and event information
+           Can have a different locale by providing a lang argument
+        """
         self.name = name
         self.email = email
         self.date = date
@@ -174,8 +178,8 @@ class BaseBookingMail(Mailer):
         super().__init__(*args, **kwargs)
 
         # Localize date and time range format
-        self.time_format = l10n('time-format')
-        self.date_format = l10n('date-format')
+        self.time_format = l10n('time-format', lang=self.lang)
+        self.date_format = l10n('date-format', lang=self.lang)
 
         # If value is key then there's no localization available, set a default.
         if self.time_format == 'time-format':
@@ -217,7 +221,10 @@ class BaseBookingMail(Mailer):
 
 class InvitationMail(BaseBookingMail):
     def __init__(self, *args, **kwargs):
-        """init Mailer with invitation specific defaults"""
+        """Init Mailer with invitation/booking-accepted specific defaults
+           To: Bookee
+           Reply-To: Event owner
+        """
         default_kwargs = {
             'subject': l10n('invite-mail-subject'),
             'plain': l10n('invite-mail-plain'),
@@ -236,14 +243,14 @@ class InvitationMail(BaseBookingMail):
             # Icon cids
             calendar_icon_cid=self._attachments()[0].filename,
             clock_icon_cid=self._attachments()[1].filename,
-            # Calendar ics cid
-            #invite_cid=self._attachments()[2].filename,
         )
 
 
 class ZoomMeetingFailedMail(Mailer):
     def __init__(self, appointment_title, *args, **kwargs):
-        """init Mailer with invitation specific defaults"""
+        """Init Mailer with zoom-meeting-failed specific defaults
+           To: Event owner
+        """
         default_kwargs = {'subject': l10n('zoom-invite-failed-subject')}
         super(ZoomMeetingFailedMail, self).__init__(*args, **default_kwargs, **kwargs)
 
@@ -258,11 +265,13 @@ class ZoomMeetingFailedMail(Mailer):
 
 class ConfirmationMail(BaseBookingMail):
     def __init__(self, confirm_url, deny_url, name, email, date, duration, schedule_name, *args, **kwargs):
-        """init Mailer with confirmation specific defaults"""
+        """Init Mailer with action-required:confirm/deny specific defaults
+           To: Event owner
+        """
         self.confirmUrl = confirm_url
         self.denyUrl = deny_url
         self.schedule_name = schedule_name
-        default_kwargs = {'subject': l10n('confirm-mail-subject', {'name': name})}
+        default_kwargs = {'subject': l10n('confirm-mail-subject', {'name': name}, kwargs['lang'])}
         super().__init__(name=name, email=email, date=date, duration=duration, *args, **default_kwargs, **kwargs)
 
 
@@ -292,6 +301,7 @@ class ConfirmationMail(BaseBookingMail):
             confirm=self.confirmUrl,
             deny=self.denyUrl,
             schedule_name=self.schedule_name,
+            lang=self.lang,
             # Icon cids
             calendar_icon_cid=self._attachments()[0].filename,
             clock_icon_cid=self._attachments()[1].filename,
@@ -300,7 +310,10 @@ class ConfirmationMail(BaseBookingMail):
 
 class RejectionMail(Mailer):
     def __init__(self, owner_name, date, *args, **kwargs):
-        """init Mailer with rejection specific defaults"""
+        """Init Mailer with rejection specific defaults
+           To: Bookee
+           Reply-To: Event owner
+        """
         self.owner_name = owner_name
         self.date = date
         default_kwargs = {'subject': l10n('reject-mail-subject')}
@@ -316,7 +329,9 @@ class RejectionMail(Mailer):
 
 class PendingRequestMail(Mailer):
     def __init__(self, owner_name, date, *args, **kwargs):
-        """init Mailer with pending specific defaults"""
+        """Init Mailer with pending-request specific defaults
+           To: Bookee
+        """
         self.owner_name = owner_name
         self.date = date
         default_kwargs = {'subject': l10n('pending-mail-subject')}
@@ -331,10 +346,13 @@ class PendingRequestMail(Mailer):
 
 class NewBookingMail(BaseBookingMail):
     def __init__(self, name, email, date, duration, schedule_name, *args, **kwargs):
-        """init Mailer with confirmation specific defaults"""
+        """Init Mailer with new-booking specific defaults
+           To: Event owner
+           Reply-To: Bookee
+        """
         self.schedule_name = schedule_name
-        default_kwargs = {'subject': l10n('new-booking-subject', {'name': name})}
-        super().__init__(name=name, email=email, date=date, duration=duration, *args, **default_kwargs, **kwargs)
+        default_kwargs = {'subject': l10n('new-booking-subject', {'name': name}, kwargs['lang'])}
+        super(NewBookingMail, self).__init__(name=name, email=email, date=date, duration=duration, *args, **default_kwargs, **kwargs)
         self.reply_to = email
 
     def text(self):
@@ -364,13 +382,17 @@ class NewBookingMail(BaseBookingMail):
 
 class SupportRequestMail(Mailer):
     def __init__(self, requestee_name, requestee_email, topic, details, *args, **kwargs):
-        """init Mailer with support specific defaults"""
+        """Init Mailer with support specific defaults
+           To: Support
+           Reply-To: Requestee
+        """
         self.requestee_name = requestee_name
         self.requestee_email = requestee_email
         self.topic = topic
         self.details = details
         default_kwargs = {'subject': l10n('support-mail-subject', {'topic': topic})}
         super(SupportRequestMail, self).__init__(os.getenv('SUPPORT_EMAIL', 'help@tb.net'), *args, **default_kwargs, **kwargs)
+        self.reply_to = requestee_email
 
     def text(self):
         return l10n(

--- a/backend/src/appointment/controller/mailer.py
+++ b/backend/src/appointment/controller/mailer.py
@@ -271,8 +271,7 @@ class ConfirmationMail(BaseBookingMail):
         self.confirmUrl = confirm_url
         self.denyUrl = deny_url
         self.schedule_name = schedule_name
-        lang = kwargs['lang'] if 'lang' in kwargs else None
-        default_kwargs = {'subject': l10n('confirm-mail-subject', {'name': name}, lang)}
+        default_kwargs = {'subject': l10n('confirm-mail-subject', {'name': name}, kwargs['lang'])}
         super().__init__(name=name, email=email, date=date, duration=duration, *args, **default_kwargs, **kwargs)
 
 

--- a/backend/src/appointment/database/models.py
+++ b/backend/src/appointment/database/models.py
@@ -134,7 +134,7 @@ class Subscriber(HasSoftDelete, Base):
 
     name = Column(encrypted_type(String), index=True)
     level = Column(Enum(SubscriberLevel), default=SubscriberLevel.basic, index=True)
-    language = Column(encrypted_type(String), nullable=False, server_default=FALLBACK_LOCALE, index=True)
+    language = Column(encrypted_type(String), nullable=False, default=FALLBACK_LOCALE, index=True)
     timezone = Column(encrypted_type(String), index=True)
     avatar_url = Column(encrypted_type(String, length=2048), index=False)
 

--- a/backend/src/appointment/database/models.py
+++ b/backend/src/appointment/database/models.py
@@ -16,6 +16,7 @@ from sqlalchemy_utils import StringEncryptedType, ChoiceType, UUIDType
 from sqlalchemy_utils.types.encrypted.encrypted_type import AesEngine
 from sqlalchemy.orm import relationship, as_declarative, declared_attr, Mapped
 from sqlalchemy.sql import func
+from appointment.defines import FALLBACK_LOCALE
 
 
 def secret():
@@ -133,6 +134,7 @@ class Subscriber(HasSoftDelete, Base):
 
     name = Column(encrypted_type(String), index=True)
     level = Column(Enum(SubscriberLevel), default=SubscriberLevel.basic, index=True)
+    language = Column(encrypted_type(String), index=True)
     timezone = Column(encrypted_type(String), index=True)
     avatar_url = Column(encrypted_type(String, length=2048), index=False)
 

--- a/backend/src/appointment/database/models.py
+++ b/backend/src/appointment/database/models.py
@@ -134,7 +134,7 @@ class Subscriber(HasSoftDelete, Base):
 
     name = Column(encrypted_type(String), index=True)
     level = Column(Enum(SubscriberLevel), default=SubscriberLevel.basic, index=True)
-    language = Column(encrypted_type(String), nullable=False, default=FALLBACK_LOCALE, index=True)
+    language = Column(encrypted_type(String), nullable=False, server_default=FALLBACK_LOCALE, index=True)
     timezone = Column(encrypted_type(String), index=True)
     avatar_url = Column(encrypted_type(String, length=2048), index=False)
 

--- a/backend/src/appointment/database/models.py
+++ b/backend/src/appointment/database/models.py
@@ -134,7 +134,7 @@ class Subscriber(HasSoftDelete, Base):
 
     name = Column(encrypted_type(String), index=True)
     level = Column(Enum(SubscriberLevel), default=SubscriberLevel.basic, index=True)
-    language = Column(encrypted_type(String), index=True)
+    language = Column(encrypted_type(String), nullable=False, default=FALLBACK_LOCALE, index=True)
     timezone = Column(encrypted_type(String), index=True)
     avatar_url = Column(encrypted_type(String, length=2048), index=False)
 

--- a/backend/src/appointment/database/schemas.py
+++ b/backend/src/appointment/database/schemas.py
@@ -12,7 +12,7 @@ from typing import Annotated, Optional, Self
 from pydantic import BaseModel, Field, EmailStr, model_validator
 from pydantic_core import PydanticCustomError
 
-from ..defines import DEFAULT_CALENDAR_COLOUR
+from ..defines import DEFAULT_CALENDAR_COLOUR, FALLBACK_LOCALE
 from ..l10n import l10n
 
 
@@ -307,6 +307,7 @@ class SubscriberIn(BaseModel):
     name: Optional[str] = Field(min_length=1, max_length=128, default=None)
     avatar_url: str | None = None
     secondary_email: str | None = None
+    language: str | None = FALLBACK_LOCALE
 
 
 class SubscriberBase(SubscriberIn):
@@ -499,4 +500,3 @@ class PageLoadIn(BaseModel):
 class FTUEStepIn(BaseModel):
     step_level: int
     step_name: str
-

--- a/backend/src/appointment/l10n.py
+++ b/backend/src/appointment/l10n.py
@@ -1,10 +1,18 @@
 from typing import Union, Dict, Any
 
 from starlette_context import context, errors
+from .middleware.l10n import get_fluent
 
 
-def l10n(msg_id: str, args: Union[Dict[str, Any], None] = None) -> str:
-    """Helper function to automatically call fluent.format_value from context"""
+def l10n(msg_id: str, args: Union[Dict[str, Any], None] = None, lang: str = None) -> str:
+    """Helper function to automatically call fluent.format_value from context.
+       If a lang parameter was given, no context to retrieve languages from is needed
+       and the translation can be directly loaded
+    """
+    if lang:
+        return get_fluent([lang])(msg_id, args)
+
+    # Get locale from context
     try:
         if 'l10n' not in context:
             return msg_id

--- a/backend/src/appointment/middleware/l10n.py
+++ b/backend/src/appointment/middleware/l10n.py
@@ -45,10 +45,12 @@ class L10n(Plugin):
 
         return parsed_locales
 
+
     def get_fluent_with_header(self, accept_languages):
         supported_locales = self.parse_accept_language(accept_languages)
 
         return get_fluent(supported_locales)
+
 
     async def process_request(self, request: Request):
         return self.get_fluent_with_header(request.headers.get('accept-language', FALLBACK_LOCALE))

--- a/backend/src/appointment/migrations/versions/2024_12_18_1226-b398005a40e7_add_language_to_subscriber_table.py
+++ b/backend/src/appointment/migrations/versions/2024_12_18_1226-b398005a40e7_add_language_to_subscriber_table.py
@@ -21,7 +21,18 @@ depends_on = None
 
 def upgrade() -> None:
     # Add language column to subscribers table
-    op.add_column('subscribers', sa.Column('language', models.encrypted_type(sa.String), nullable=False, server_default=FALLBACK_LOCALE, index=True))
+    op.add_column('subscribers', sa.Column('language', models.encrypted_type(sa.String), nullable=True, default=FALLBACK_LOCALE, index=True))
+
+    # Prefill new column with default value
+    session = Session(op.get_bind())
+    subscribers: list[models.Subscriber] = session.query(models.Subscriber).all()
+    for subscriber in subscribers:
+        subscriber.language = FALLBACK_LOCALE
+
+        # Add the subscriber to the database session and commit (update) it
+        session.add(subscriber)
+        session.commit()
+
 
 
 def downgrade() -> None:

--- a/backend/src/appointment/migrations/versions/2024_12_18_1226-b398005a40e7_add_language_to_subscriber_table.py
+++ b/backend/src/appointment/migrations/versions/2024_12_18_1226-b398005a40e7_add_language_to_subscriber_table.py
@@ -1,0 +1,37 @@
+"""Add language to subscriber table
+
+Revision ID: b398005a40e7
+Revises: d791a3f0e478
+Create Date: 2024-12-18 12:26:56.211080
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from appointment.database import models
+from appointment.defines import FALLBACK_LOCALE
+
+# revision identifiers, used by Alembic.
+revision = 'b398005a40e7'
+down_revision = 'd791a3f0e478'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add language column to subscribers table
+    op.add_column('subscribers', sa.Column('language', models.encrypted_type(sa.String), index=True))
+
+    # Prefill new column with default value
+    session = Session(op.get_bind())
+    subscribers: list[models.Subscriber] = session.query(models.Subscriber).all()
+    for subscriber in subscribers:
+        subscriber.language = FALLBACK_LOCALE
+
+        # Add the subscriber to the database session and commit (update) it
+        session.add(subscriber)
+        session.commit()
+
+def downgrade() -> None:
+    op.drop_column('subscribers', 'language')

--- a/backend/src/appointment/migrations/versions/2024_12_18_1226-b398005a40e7_add_language_to_subscriber_table.py
+++ b/backend/src/appointment/migrations/versions/2024_12_18_1226-b398005a40e7_add_language_to_subscriber_table.py
@@ -21,7 +21,7 @@ depends_on = None
 
 def upgrade() -> None:
     # Add language column to subscribers table
-    op.add_column('subscribers', sa.Column('language', models.encrypted_type(sa.String), nullable=False, default=FALLBACK_LOCALE, index=True))
+    op.add_column('subscribers', sa.Column('language', models.encrypted_type(sa.String), nullable=False, server_default=FALLBACK_LOCALE, index=True))
 
 
 def downgrade() -> None:

--- a/backend/src/appointment/migrations/versions/2024_12_18_1226-b398005a40e7_add_language_to_subscriber_table.py
+++ b/backend/src/appointment/migrations/versions/2024_12_18_1226-b398005a40e7_add_language_to_subscriber_table.py
@@ -21,17 +21,8 @@ depends_on = None
 
 def upgrade() -> None:
     # Add language column to subscribers table
-    op.add_column('subscribers', sa.Column('language', models.encrypted_type(sa.String), index=True))
+    op.add_column('subscribers', sa.Column('language', models.encrypted_type(sa.String), nullable=False, default=FALLBACK_LOCALE, index=True))
 
-    # Prefill new column with default value
-    session = Session(op.get_bind())
-    subscribers: list[models.Subscriber] = session.query(models.Subscriber).all()
-    for subscriber in subscribers:
-        subscriber.language = FALLBACK_LOCALE
-
-        # Add the subscriber to the database session and commit (update) it
-        session.add(subscriber)
-        session.commit()
 
 def downgrade() -> None:
     op.drop_column('subscribers', 'language')

--- a/backend/src/appointment/migrations/versions/2024_12_20_1733-0c99f6a02f3b_make_subscribers_language_not_.py
+++ b/backend/src/appointment/migrations/versions/2024_12_20_1733-0c99f6a02f3b_make_subscribers_language_not_.py
@@ -1,0 +1,25 @@
+"""make subscribers.language not nullable
+
+Revision ID: 0c99f6a02f3b
+Revises: b398005a40e7
+Create Date: 2024-12-20 17:33:19.666412
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from appointment.database import models
+
+# revision identifiers, used by Alembic.
+revision = '0c99f6a02f3b'
+down_revision = 'b398005a40e7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column('subscribers', 'language', type_=models.encrypted_type(sa.String), nullable=False)
+
+
+def downgrade() -> None:
+    op.alter_column('subscribers', 'language', type_=models.encrypted_type(sa.String), nullable=True)

--- a/backend/src/appointment/routes/api.py
+++ b/backend/src/appointment/routes/api.py
@@ -486,5 +486,3 @@ def terms():
     with open(f'{os.path.dirname(__file__)}/../templates/legal/en/terms.jinja2') as fh:
         contents = fh.read()
     return HTMLResponse(contents)
-
-

--- a/backend/src/appointment/routes/schedule.py
+++ b/backend/src/appointment/routes/schedule.py
@@ -375,8 +375,15 @@ def request_schedule_availability_slot(
     if schedule.booking_confirmation:
         # Sending confirmation email to owner
         background_tasks.add_task(
-            send_confirmation_email, url=url, attendee_name=attendee.name, attendee_email=attendee.email, date=date,
-            duration=slot.duration, to=subscriber.preferred_email, schedule_name=schedule.name
+            send_confirmation_email,
+            url=url,
+            attendee_name=attendee.name,
+            attendee_email=attendee.email,
+            date=date,
+            duration=slot.duration,
+            schedule_name=schedule.name,
+            to=subscriber.preferred_email,
+            lang=subscriber.language
         )
 
         # Create remote HOLD event
@@ -416,7 +423,8 @@ def request_schedule_availability_slot(
             date=date,
             duration=slot.duration,
             schedule_name=schedule.name,
-            to=subscriber.preferred_email
+            to=subscriber.preferred_email,
+            lang=subscriber.language
         )
 
     # Mini version of slot, so we can grab the newly created slot id for tests

--- a/backend/src/appointment/tasks/emails.py
+++ b/backend/src/appointment/tasks/emails.py
@@ -32,11 +32,11 @@ def send_invite_email(owner_name, owner_email, date, duration, to, attachment):
             sentry_sdk.capture_exception(e)
 
 
-def send_confirmation_email(url, attendee_name, attendee_email, date, duration, to, schedule_name):
+def send_confirmation_email(url, attendee_name, attendee_email, date, duration, to, schedule_name, lang):
     # send confirmation mail to owner
     try:
         mail = ConfirmationMail(
-            f'{url}/1', f'{url}/0', attendee_name, attendee_email, date, duration, schedule_name, to=to
+            f'{url}/1', f'{url}/0', attendee_name, attendee_email, date, duration, schedule_name, to=to, lang=lang
         )
         mail.send()
     except Exception as e:
@@ -47,10 +47,10 @@ def send_confirmation_email(url, attendee_name, attendee_email, date, duration, 
             sentry_sdk.capture_exception(e)
 
 
-def send_new_booking_email(name, email, date, duration, to, schedule_name):
+def send_new_booking_email(name, email, date, duration, to, schedule_name, lang):
     # send notice mail to owner
     try:
-        mail = NewBookingMail(name, email, date, duration, schedule_name, to=to)
+        mail = NewBookingMail(name, email, date, duration, schedule_name, to=to, lang=lang)
         mail.send()
     except Exception as e:
         if os.getenv('APP_ENV') == APP_ENV_DEV:

--- a/backend/src/appointment/templates/email/confirm.jinja2
+++ b/backend/src/appointment/templates/email/confirm.jinja2
@@ -8,13 +8,13 @@
 {% block introduction %}
   <div style="color: {{ colour_text_base }}; text-align: center; line-height: 16px;">
     <p style="font-weight: 700; margin: 0;">
-      {{ l10n('confirm-mail-html-heading-name', {'name': name}) }}
+      {{ l10n('confirm-mail-html-heading-name', {'name': name}, lang) }}
     </p>
     <p style="color: {{ colour_text_muted }}; font-size: 9px; line-height: 10px; font-weight: 700; margin: 0;">
-      {{ l10n('confirm-mail-html-heading-email', {'email': email}) }}
+      {{ l10n('confirm-mail-html-heading-email', {'email': email}, lang) }}
     </p>
     <p style="font-weight: 400; margin: 0;">
-      {{ l10n('confirm-mail-html-heading-text', {'schedule_name': schedule_name}) }}
+      {{ l10n('confirm-mail-html-heading-text', {'schedule_name': schedule_name}, lang) }}
     </p>
   </div>
 {% endblock %}
@@ -43,7 +43,7 @@
       font-weight: 700;
       height: 16px;
       ">
-      {{ clock_image_small|safe }} {{ l10n('confirm-mail-html-time', {'duration': duration}) }}
+      {{ clock_image_small|safe }} {{ l10n('confirm-mail-html-time', {'duration': duration}, lang) }}
     </div>
   </div>
 {% endblock %}
@@ -63,7 +63,7 @@
         text-decoration:none;
         white-space: nowrap;
         "
-    >{{ l10n('confirm-mail-html-confirm-action') }}</a>
+    >{{ l10n('confirm-mail-html-confirm-action', lang=lang) }}</a>
   </div>
   <div>
     <a
@@ -76,6 +76,6 @@
         text-decoration-line: underline;
         font-weight: 400;
         "
-    >{{ l10n('confirm-mail-html-deny-action') }}</a>
+    >{{ l10n('confirm-mail-html-deny-action', lang=lang) }}</a>
   </div>
 {% endblock %}

--- a/backend/src/appointment/templates/email/includes/base.jinja2
+++ b/backend/src/appointment/templates/email/includes/base.jinja2
@@ -8,7 +8,7 @@
 {% set colour_tbpro_apmt_primary = '#008080' %}
 {% set colour_tbpro_apmt_primary_hover = '#066769' %}
 {% set colour_tbpro_apmt_secondary = '#81D4B5' %}
-<html lang="{{ l10n('locale') }}" style="
+<html lang="{{ l10n('locale', lang=lang if lang else None) }}" style="
   font-size: 13px;
   color: {{ colour_text_base }};
   background-color: {{ colour_surface_base }};
@@ -45,17 +45,17 @@
 </div>
 {% endif %}
 {% if show_contact_form_support_hint %}
-{% set link = '<a href="%(url)s">%(label)s</a>'|format(url=homepage_url + '/contact', label=l10n('mail-brand-contact-form')) %}
+{% set link = '<a href="%(url)s">%(label)s</a>'|format(url=homepage_url + '/contact', label=l10n('mail-brand-contact-form', lang=lang if lang else None)) %}
 <div style="text-align: center; margin-left: auto; margin-right: auto; margin-bottom: 24px; padding: 12px; max-width: 310px;">
-  {{ l10n('mail-brand-support-hint', {'contact_form_link': link})|safe }}
+  {{ l10n('mail-brand-support-hint', {'contact_form_link': link}, lang if lang else None)|safe }}
 </div>
 {% endif %}
 {% if show_contact_form_reply_hint %}
-{% set link = '<a href="%(url)s">%(label)s</a>'|format(url=homepage_url + '/contact', label=l10n('mail-brand-contact-form')) %}
+{% set link = '<a href="%(url)s">%(label)s</a>'|format(url=homepage_url + '/contact', label=l10n('mail-brand-contact-form', lang=lang if lang else None)) %}
 <div style="text-align: center; margin-left: auto; margin-right: auto; margin-bottom: 24px; padding: 12px; max-width: 310px;">
-  {{ l10n('mail-brand-reply-hint-attendee-info', { 'name': name })|safe }}
+  {{ l10n('mail-brand-reply-hint-attendee-info', { 'name': name }, lang if lang else None)|safe }}
   <br/><br/>
-  {{ l10n('mail-brand-reply-hint', {'contact_form_link': link})|safe }}
+  {{ l10n('mail-brand-reply-hint', {'contact_form_link': link}, lang if lang else None)|safe }}
 </div>
 {% endif %}
 <div style="

--- a/backend/src/appointment/templates/email/includes/footer.jinja2
+++ b/backend/src/appointment/templates/email/includes/footer.jinja2
@@ -1,5 +1,5 @@
 {% set colour_text_muted = '#737584' %}
-{% set copy_list = l10n('mail-brand-footer').split("\n") %}
+{% set copy_list = l10n('mail-brand-footer', lang=lang if lang else None).split("\n") %}
 <div style="color: {{ colour_text_muted }}; font-size: 9px; line-height: 11px; font-weight: 700; text-align: center;">
 {% for copy in copy_list %}
   <p style="margin: 0;">

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -202,7 +202,7 @@ def with_l10n():
     Only supports English for now!
     """
     l10n_plugin = L10n()
-    l10n_fn = l10n_plugin.get_fluent('en')
+    l10n_fn = l10n_plugin.get_fluent_with_header('en')
 
     with request_cycle_context({'l10n': l10n_fn}):
         yield

--- a/backend/test/unit/test_mailer.py
+++ b/backend/test/unit/test_mailer.py
@@ -33,7 +33,7 @@ class TestMailer:
         now = datetime.datetime.now()
         attendee = schemas.AttendeeBase(email=faker.email(), name=faker.name(), timezone='Europe/Berlin')
 
-        mailer = ConfirmationMail(confirm_url, deny_url, attendee.name, attendee.email, now, to=fake_email, duration=30, schedule_name='test')
+        mailer = ConfirmationMail(confirm_url, deny_url, attendee.name, attendee.email, now, to=fake_email, duration=30, schedule_name='test', lang='en')
         assert mailer.html()
         assert mailer.text()
 
@@ -49,7 +49,7 @@ class TestMailer:
         now = datetime.datetime.now()
         attendee = schemas.AttendeeBase(email=faker.email(), name=faker.name(), timezone='Europe/Berlin')
 
-        mailer = NewBookingMail(attendee.name, attendee.email, now, 30, 'test schedule', to=fake_email)
+        mailer = NewBookingMail(attendee.name, attendee.email, now, 30, 'test schedule', lang='en', to=fake_email)
         assert mailer.html()
         assert mailer.text()
 

--- a/backend/test/unit/test_mailer.py
+++ b/backend/test/unit/test_mailer.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 
 from appointment.controller.mailer import ConfirmationMail, RejectionMail, ZoomMeetingFailedMail, InvitationMail, \
-    NewBookingMail, Attachment
+    NewBookingMail, PendingRequestMail, Attachment
 from appointment.database import schemas
 
 
@@ -57,6 +57,19 @@ class TestMailer:
             fault = 'text' if idx == 0 else 'html'
             assert attendee.name in content, fault
             assert attendee.email in content, fault
+
+    def test_pending(self, faker, with_l10n, make_pro_subscriber):
+        subscriber = make_pro_subscriber()
+        now = datetime.datetime.now()
+        fake_email = 'to@example.org'
+
+        mailer = PendingRequestMail(owner_name=subscriber.name, date=now, to=fake_email)
+        assert mailer.html()
+        assert mailer.text()
+
+        for idx, content in enumerate([mailer.text(), mailer.html()]):
+            fault = 'text' if idx == 0 else 'html'
+            assert subscriber.name in content, fault
 
     def test_reject(self, faker, with_l10n, make_pro_subscriber):
         subscriber = make_pro_subscriber()

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 This place holds all additional technical documentation for Thunderbird Appointment.
 
 ## Documents
+
 * [Updating Legal](./updating-legal.rst)
 
 ## API endpoints
@@ -77,6 +78,7 @@ erDiagram
     string secondary_email "Secondary email address"
     date time_deleted "UTC timestamp of deletion (soft delete)"
     int ftue_level "Version of the FTUE the user has completed"
+    string language "Lang code for subscribers preferred locale"
   }
   SUBSCRIBERS ||--o{ CALENDARS : own
   CALENDARS {


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This PR adds a new field `language` for the subscribers table and extends our l10n middleware for using a custom locale.
The tests were adjusted and extended accordingly.

## Benefits

Subscribers should see emails sent to them in their configured language now.

## Applicable Issues

Closes #766 
