### PR TITLE
Replace HttpExceptions with RedirectResponses with login err codes. (Fixes #801)

### DIFF
--- a/backend/src/appointment/routes/auth.py
+++ b/backend/src/appointment/routes/auth.py
@@ -1,7 +1,6 @@
 import json
 import os
 import secrets
-import uuid
 from datetime import timedelta, datetime, UTC
 from secrets import token_urlsafe
 from typing import Annotated
@@ -12,7 +11,7 @@ from fastapi.security import OAuth2PasswordRequestForm
 from sentry_sdk import capture_exception
 from sqlalchemy.orm import Session
 
-from fastapi import APIRouter, Depends, HTTPException, Request, BackgroundTasks
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse
 
 from .. import utils
@@ -28,9 +27,7 @@ from ..controller import auth
 from ..controller.apis.fxa_client import FxaClient
 from ..dependencies.fxa import get_fxa_client
 from ..exceptions import validation
-from ..exceptions.fxa_api import NotInAllowListException
 from ..l10n import l10n
-from ..tasks.emails import send_confirm_email
 from ..utils import get_password_hash
 
 router = APIRouter()
@@ -48,12 +45,15 @@ def create_access_token(data: dict, expires_delta: timedelta | None = None):
 
 
 def create_subscriber(db, email, password, timezone):
-    subscriber = repo.subscriber.create(db, schemas.SubscriberBase(
-        email=email.lower(), # Make sure to store the email address in lower case
-        username=email,
-        name=email.split('@')[0],
-        timezone=timezone
-    ))
+    subscriber = repo.subscriber.create(
+        db,
+        schemas.SubscriberBase(
+            email=email.lower(),  # Make sure to store the email address in lower case
+            username=email,
+            name=email.split('@')[0],
+            timezone=timezone,
+        ),
+    )
 
     # Update with password
     subscriber.password = get_password_hash(password)
@@ -66,11 +66,7 @@ def create_subscriber(db, email, password, timezone):
 
 
 @router.post('/can-login')
-def can_login(
-    data: schemas.CheckEmail,
-    db: Session = Depends(get_db),
-    fxa_client: FxaClient = Depends(get_fxa_client)
-):
+def can_login(data: schemas.CheckEmail, db: Session = Depends(get_db), fxa_client: FxaClient = Depends(get_fxa_client)):
     """Determines if a user can go through the login flow"""
     if os.getenv('AUTH_SCHEME') == 'fxa':
         # This checks if a subscriber exists, or is in allowed list
@@ -144,14 +140,26 @@ def fxa_callback(
         raise HTTPException(status_code=405)
 
     if 'fxa_state' not in request.session or request.session['fxa_state'] != state:
-        raise HTTPException(400, 'Invalid state.')
+        return RedirectResponse(f"{os.getenv('FRONTEND_URL', 'http://localhost:8080')}/login/?error=invalid-state")
     if 'fxa_user_email' not in request.session or request.session['fxa_user_email'] == '':
-        raise HTTPException(400, 'Email could not be retrieved.')
+        return RedirectResponse(
+            f"{os.getenv('FRONTEND_URL', 'http://localhost:8080')}/login/?error=email-not-in-session"
+        )
 
     email = request.session['fxa_user_email']
     # We only use timezone during subscriber creation, or if their timezone is None
     timezone = request.session['fxa_user_timezone']
     invite_code = request.session.get('fxa_user_invite_code')
+
+    # These are error keys on the frontend
+    # login.remoteError.<id>
+    errors = {
+        'email-mismatch': 'email-mismatch',
+        'invite-not-valid': 'invite-not-valid',
+        'unknown-error': 'unknown-error',
+        'disabled-account': 'disabled-account',
+        'invalid-credentials': 'invalid-credentials',
+    }
 
     # Clear session keys
     request.session.pop('fxa_state')
@@ -168,7 +176,9 @@ def fxa_callback(
 
     if profile['email'] != email:
         fxa_client.logout()
-        raise HTTPException(400, l10n('email-mismatch'))
+        return RedirectResponse(
+            f"{os.getenv('FRONTEND_URL', 'http://localhost:8080')}/login/?error={errors['email-mismatch']}"
+        )
 
     # Check if we have an existing fxa connection by profile's uid
     fxa_subscriber = repo.external_connection.get_subscriber_by_fxa_uid(db, profile['uid'])
@@ -185,9 +195,13 @@ def fxa_callback(
 
         if not is_in_allow_list:
             if not repo.invite.code_exists(db, invite_code):
-                raise HTTPException(404, l10n('invite-code-not-valid'))
+                return RedirectResponse(
+                    f"{os.getenv('FRONTEND_URL', 'http://localhost:8080')}/login/?error={errors['invite-not-valid']}"
+                )
             if not repo.invite.code_is_available(db, invite_code):
-                raise HTTPException(403, l10n('invite-code-not-valid'))
+                return RedirectResponse(
+                    f"{os.getenv('FRONTEND_URL', 'http://localhost:8080')}/login/?error={errors['invite-not-valid']}"
+                )
 
         subscriber = repo.subscriber.create(
             db,
@@ -208,14 +222,18 @@ def fxa_callback(
             # This shouldn't happen, but just in case!
             if not used:
                 repo.subscriber.hard_delete(db, subscriber)
-                raise HTTPException(500, l10n('unknown-error'))
+                return RedirectResponse(
+                    f"{os.getenv('FRONTEND_URL', 'http://localhost:8080')}/login/?error={errors['unknown-error']}"
+                )
 
     elif not subscriber:
         subscriber = fxa_subscriber
 
     # Only proceed if user account is enabled (which is the default case for new users)
     if subscriber.is_deleted:
-        raise HTTPException(status_code=403, detail=l10n('disabled-account'))
+        return RedirectResponse(
+            f"{os.getenv('FRONTEND_URL', 'http://localhost:8080')}/login/?error={errors['disabled-account']}"
+        )
 
     fxa_connections = repo.external_connection.get_by_type(db, subscriber.id, ExternalConnectionType.fxa)
 
@@ -227,7 +245,9 @@ def fxa_callback(
             e = Exception('Invalid Credentials, incoming profile uid does not match existing profile uid')
             capture_exception(e)
 
-        raise HTTPException(403, l10n('invalid-credentials'))
+        return RedirectResponse(
+            f"{os.getenv('FRONTEND_URL', 'http://localhost:8080')}/login/?error={errors['invalid-credentials']}"
+        )
 
     external_connection_schema = schemas.ExternalConnection(
         name=profile['email'],
@@ -262,10 +282,9 @@ def fxa_callback(
 
     # Generate our jwt token, we only store the username on the token
     access_token_expires = timedelta(minutes=float(10))
-    one_time_access_token = create_access_token(data={
-        'sub': f'uid-{subscriber.id}',
-        'jti': secrets.token_urlsafe(16)
-    }, expires_delta=access_token_expires)
+    one_time_access_token = create_access_token(
+        data={'sub': f'uid-{subscriber.id}', 'jti': secrets.token_urlsafe(16)}, expires_delta=access_token_expires
+    )
 
     return RedirectResponse(f"{os.getenv('FRONTEND_URL', 'http://localhost:8080')}/post-login/{one_time_access_token}")
 
@@ -278,9 +297,12 @@ def fxa_token(subscriber=Depends(get_subscriber_from_onetime_token)):
 
     # Generate our jwt token, we only store the username on the token
     access_token_expires = timedelta(minutes=float(os.getenv('JWT_EXPIRE_IN_MINS')))
-    access_token = create_access_token(data={
-        'sub': f'uid-{subscriber.id}',
-    }, expires_delta=access_token_expires)
+    access_token = create_access_token(
+        data={
+            'sub': f'uid-{subscriber.id}',
+        },
+        expires_delta=access_token_expires,
+    )
 
     return {'access_token': access_token, 'token_type': 'bearer'}
 
@@ -363,7 +385,7 @@ def me(
         avatar_url=subscriber.avatar_url,
         is_setup=subscriber.is_setup,
         schedule_links=schedule_links_by_subscriber(db, subscriber),
-        unique_hash=hash
+        unique_hash=hash,
     )
 
 

--- a/backend/test/integration/test_auth.py
+++ b/backend/test/integration/test_auth.py
@@ -319,8 +319,9 @@ class TestFXA:
         response = with_client.get(
             '/fxa', params={'code': FXA_CLIENT_PATCH.get('credentials_code'), 'state': state}, follow_redirects=False
         )
-        # 404, invite code not found
-        assert response.status_code == 404, response.text
+        # this could contain the invite not valid error
+        assert response.status_code == 307, response.text
+        assert '?error=invite-not-valid' in response.headers.get('location')
 
         with with_db() as db:
             subscriber = repo.subscriber.get_by_email(db, FXA_CLIENT_PATCH.get('subscriber_email'))
@@ -385,10 +386,9 @@ class TestFXA:
             '/fxa', params={'code': FXA_CLIENT_PATCH.get('credentials_code'), 'state': state}, follow_redirects=False
         )
 
-        # This should error out as a 403
-        assert response.status_code == 403, response.text
-        # This will just key match due to the lack of context.
-        assert response.json().get('detail') == l10n('invalid-credentials')
+        # This should contain the invalid-credentials error
+        assert response.status_code == 307, response.text
+        assert '?error=invalid-credentials' in response.headers.get('location')
 
     def test_fxa_token_success(self, make_basic_subscriber, with_client):
         os.environ['AUTH_SCHEME'] = 'fxa'

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -357,6 +357,15 @@
     "login": {
       "title": "Log dich ein oder erstelle ein Benutzerkonto"
     },
+    "remoteError": {
+      "email-mismatch": "Die E-Mail, mit der Du dich angemeldet hast, muss mit Deinem Mozilla-Konto übereinstimmen.",
+      "invite-not-valid": "Der eingegebene Einladungscode ist ungültig.",
+      "unknown-error": "Ein unbekannter Fehler ist aufgetreten.",
+      "disabled-account": "Dieses Konto ist deaktiviert.",
+      "invalid-credentials": "Es gab ein Problem mit Deinen Anmeldedaten.",
+      "invalid-state": "Die Anmeldesitzung ist abgelaufen. Bitte versuch es erneut.",
+      "email-not-in-session": "Es gab ein Problem mit der Anmeldesitzung. Bitte versuch es erneut."
+    },
     "signUp": {
       "title": "Du hast einen Einladungscode? Gib ihn hier ein"
     },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -362,7 +362,9 @@
       "invite-not-valid": "The invite code you've entered is not valid.",
       "unknown-error": "An unknown error occurred.",
       "disabled-account": "This account is disabled.",
-      "invalid-credentials": "There was a problem with your credentials."
+      "invalid-credentials": "There was a problem with your credentials.",
+      "invalid-state": "The login session has expired. Please try again.",
+      "email-not-in-session": "There was a problem with the login session. Please try again."
     },
     "signUp": {
       "title": "Have an invite code? Enter it here"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -357,6 +357,13 @@
     "login": {
       "title": "Sign in or create an account"
     },
+    "remoteError": {
+      "email-mismatch": "The email you've signed up and logged in with must be the same as your Mozilla Account.",
+      "invite-not-valid": "The invite code you've entered is not valid.",
+      "unknown-error": "An unknown error occurred.",
+      "disabled-account": "This account is disabled.",
+      "invalid-credentials": "There was a problem with your credentials."
+    },
     "signUp": {
       "title": "Have an invite code? Enter it here"
     },

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -52,7 +52,14 @@ const inviteCode = ref('');
 const loginStep = ref(LoginSteps.Login);
 const loginError = ref<string>(null);
 
-onMounted(() => {
+onMounted(async () => {
+  // Error should be a string value, so don't worry about any obj deconstruction.
+  if (route.query.error) {
+    const queryError = route.query.error as string;
+    loginError.value = t(`login.remoteError.${queryError}`);
+    await router.replace(route.path);
+  }
+
   if (route.name === 'join-the-waiting-list') {
     hideInviteField.value = true;
     loginStep.value = LoginSteps.SignUp;


### PR DESCRIPTION
Instead of displaying raw json or text, we now redirect them back to the login page with an error code. That error code is used to look up a proper error message.

This removes the confusing "Email mismatch" message and a few others.

## Screenshots
<img width="823" alt="image" src="https://github.com/user-attachments/assets/e80fa078-a859-4201-964b-9b1443fef073" />
<img width="885" alt="image" src="https://github.com/user-attachments/assets/e07ae408-498b-418d-821d-6454495d6c41" />

cc @malini for copy check.