### PR TITLE
Fix incorrect endtime in schedule validation message (Fixes #778)

### DIFF
--- a/backend/src/appointment/database/models.py
+++ b/backend/src/appointment/database/models.py
@@ -282,8 +282,8 @@ class Schedule(Base):
     details: str = Column(encrypted_type(String))
     start_date: datetime.date = Column(encrypted_type(Date), index=True)
     end_date: datetime.date = Column(encrypted_type(Date), index=True)
-    start_time: datetime.time = Column(encrypted_type(Time), index=True)
-    end_time: datetime.time = Column(encrypted_type(Time), index=True)
+    start_time: datetime.time = Column(encrypted_type(Time), index=True)  # in utc
+    end_time: datetime.time = Column(encrypted_type(Time), index=True)  # in utc
     earliest_booking: int = Column(Integer, default=1440)  # in minutes, defaults to 24 hours
     farthest_booking: int = Column(Integer, default=20160)  # in minutes, defaults to 2 weeks
     weekdays: str | dict = Column(JSON, default='[1,2,3,4,5]')  # list of ISO weekdays, Mo-Su => 1-7

--- a/backend/src/appointment/database/schemas.py
+++ b/backend/src/appointment/database/schemas.py
@@ -220,16 +220,16 @@ class ScheduleValidationIn(ScheduleBase):
         start_time = datetime.combine(self.start_date, self.start_time, tzinfo=timezone.utc).astimezone(zoneinfo.ZoneInfo(tz))
         end_time = datetime.combine(self.start_date, self.end_time, tzinfo=timezone.utc).astimezone(zoneinfo.ZoneInfo(tz))
 
-        start_time = (start_time + timedelta(minutes=self.slot_duration)).time()
-        end_time = end_time.time()
+        start_time = (start_time + timedelta(minutes=self.slot_duration))
+        end_time = end_time
         # Compare time objects!
-        if start_time > end_time:
+        if start_time.time() > end_time.time():
             msg = l10n('error-minimum-value')
 
             # These can't be field or value because that will auto-format the msg? Weird feature but okay.
             raise PydanticCustomError(defines.END_TIME_BEFORE_START_TIME_ERR, msg, {
                 'err_field': 'end_time',
-                'err_value': start_time
+                'err_value': start_time.astimezone(timezone.utc).time()
             })
 
         return self

--- a/backend/test/integration/test_schedule.py
+++ b/backend/test/integration/test_schedule.py
@@ -31,6 +31,7 @@ class TestSchedule:
             'farthest_booking': 20160,
             'weekdays': [1, 2, 3, 4, 5],
             'slot_duration': 30,
+            'timezone': 'America/Vancouver'
         }
 
     def test_create_schedule_on_connected_calendar(self, with_client, make_caldav_calendar, schedule_input):
@@ -68,8 +69,10 @@ class TestSchedule:
         generated_calendar = make_caldav_calendar(connected=True)
 
         schedule_data = schedule_input
-        schedule_data['start_time'] = '09:00'
-        schedule_data['end_time'] = '06:00'
+        # start_time and end_time are always in UTC
+        # 9am and 8am PT
+        schedule_data['start_time'] = '17:00'
+        schedule_data['end_time'] = '16:00'
 
         response = with_client.post(
             '/schedule',
@@ -86,7 +89,7 @@ class TestSchedule:
         assert data.get('detail')[0]['type'] == defines.END_TIME_BEFORE_START_TIME_ERR
         assert data.get('detail')[0]['msg'] == '{field} should be at least {value}.'
         assert data.get('detail')[0]['ctx']['err_field'] == 'end_time'
-        assert data.get('detail')[0]['ctx']['err_value'] == '09:30:00'
+        assert data.get('detail')[0]['ctx']['err_value'] == '17:30:00'
 
 
 

--- a/frontend/src/components/ScheduleCreation.vue
+++ b/frontend/src/components/ScheduleCreation.vue
@@ -285,6 +285,8 @@ const saveSchedule = async (withConfirmation = true) => {
     .tz(user.data.timezone ?? dj.tz.guess(), true)
     .utc()
     .format('HH:mm');
+  // Update the start_date with the current date
+  obj.start_date = dj().format(dateFormat);
   // remove unwanted properties
   delete obj.availabilities;
   delete obj.time_created;


### PR DESCRIPTION
#778 

This should fix the incorrect endtime displayed in the schedule time validation error message. The backend was incorrectly returning it as a non-UTC time which then the frontend used to convert it from UTC to the schedule's timezone. (So double conversion.)

This should also fix an issue with daylight savings and this error message by always saving the current date as the start_date, as we don't actually expose that value to the end-user. (And it's used for daylight savings conversion.)

And finally I've adjusted the schedule creation test to use a timezone, and to use pacific time-converted values for the time so it's actually accurate. 

## Screenshots
<img width="356" alt="image" src="https://github.com/user-attachments/assets/e7e8c1e1-439a-4dc9-964b-3b1c82899193" />
<img width="353" alt="image" src="https://github.com/user-attachments/assets/dedc6856-8113-466a-940c-2547d981ff43" />


cc @rwood-moz 
