### PR TITLE
Fix browserstack session name

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -262,9 +262,10 @@ jobs:
           username:  ${{ secrets.BROWSERSTACK_USERNAME }}
           access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           project-name: 'Thunderbird Appointment'
+          build-name: 'Production Deployment Tests: BUILD_INFO'
 
       - name: Run Playwright Tests on Browserstack
         run: |
           cd ./test/e2e
           cp .env.example .env
-          npm run prod-sanity-test-browserstack
+          npm run prod-sanity-test-browserstack-gha

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -42,9 +42,10 @@ jobs:
           username:  ${{ secrets.BROWSERSTACK_USERNAME }}
           access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           project-name: 'Thunderbird Appointment'
+          build-name: 'Nightly Tests: BUILD_INFO'
 
       - name: Run Playwright Tests on Browserstack
         run: |
           cd ./test/e2e
           cp .env.example .env
-          npm run prod-sanity-test-browserstack
+          npm run prod-sanity-test-browserstack-gha

--- a/test/e2e/browserstack.yml
+++ b/test/e2e/browserstack.yml
@@ -17,7 +17,7 @@ buildName: Build
 # ${BUILD_NUMBER} (Default): Generates an incremental counter with every execution
 # ${DATE_TIME}: Generates a Timestamp with every execution. Eg. 05-Nov-19:30
 # Read more about buildIdentifiers here -> https://www.browserstack.com/docs/automate/selenium/organize-tests
-buildIdentifier: '#${BUILD_NUMBER}' # Supports strings along with either/both ${expression}
+buildIdentifier: '${DATE_TIME}'
 
 # =======================================
 # Platforms (Browsers / Devices to test)

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -7,6 +7,7 @@
     "prod-sanity-test-ui": "npx playwright test --grep prod-sanity --project=firefox --headed",
     "prod-sanity-test-debug": "npx playwright test --grep prod-sanity --project=firefox --headed --ui",
     "prod-sanity-test-browserstack": "npx browserstack-node-sdk playwright test --grep prod-sanity --browserstack.buildName 'Production Sanity Test'",
+    "prod-sanity-test-browserstack-gha": "npx browserstack-node-sdk playwright test --grep prod-sanity",
     "postinstall": "npm update browserstack-node-sdk"
   },
   "keywords": [],


### PR DESCRIPTION
Currently when the production sanity test is ran via github actions, the same browserstack build name is used each time (every test run is added to the same browserstack Automate build). This change updates the test configuration so that we will have a separate browserstack build for each time the test runs. See comment below for new screenshots from BrowserStack.