### PR TITLE
Expand the production sanity test

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -242,6 +242,9 @@ jobs:
     env:
       APPT_PROD_LOGIN_EMAIL: ${{ secrets.E2E_APPT_PROD_LOGIN_EMAIL }}
       APPT_PROD_LOGIN_PWORD: ${{ secrets.E2E_APPT_PROD_LOGIN_PASSWORD }}
+      APPT_PROD_DISPLAY_NAME: ${{ secrets.E2E_APPT_PROD_DISPLAY_NAME }}
+      APPT_PROD_MY_SHARE_LINK: ${{ secrets.E2E_APPT_PROD_MY_SHARE_LINK }}
+      APPT_BOOKING_REQUESTER_EMAIL: ${{ secrets.E2E_APPT_PROD_BOOKING_REQUESTER_EMAIL }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -22,6 +22,9 @@ jobs:
     env:
       APPT_PROD_LOGIN_EMAIL: ${{ secrets.E2E_APPT_PROD_LOGIN_EMAIL }}
       APPT_PROD_LOGIN_PWORD: ${{ secrets.E2E_APPT_PROD_LOGIN_PASSWORD }}
+      APPT_PROD_DISPLAY_NAME: ${{ secrets.E2E_APPT_PROD_DISPLAY_NAME }}
+      APPT_PROD_MY_SHARE_LINK: ${{ secrets.E2E_APPT_PROD_MY_SHARE_LINK }}
+      APPT_BOOKING_REQUESTER_EMAIL: ${{ secrets.E2E_APPT_PROD_BOOKING_REQUESTER_EMAIL }}
     steps:
       - uses: actions/checkout@v4
 

--- a/test/e2e/.env.example
+++ b/test/e2e/.env.example
@@ -2,7 +2,20 @@
 
 # URLs
 APPT_PROD_URL=https://appointment.day/
+APPT_PROD_SHORT_SHARE_LINK_PREFIX=https://apmt.day/
+APPT_PROD_LONG_SHARE_LINK_PREFIX=https://appointment.day/user/
 
 # Production sign-in (FxA) credentials
 APPT_PROD_LOGIN_EMAIL=
 APPT_PROD_LOGIN_PWORD=
+
+# Appointment user display name (settings => account => display name) for above user
+APPT_PROD_DISPLAY_NAME=
+
+# Production booking share link for the existing user above (settings => account => my link)
+APPT_PROD_MY_SHARE_LINK=
+
+# Booking requester's name and email address (used when a booking slot is requested via the
+# share link). Important: real appointment booking emails will be sent to the provided email.
+APPT_BOOKING_REQUESTER_NAME='Automated-Test-Bot'
+APPT_BOOKING_REQUESTER_EMAIL=

--- a/test/e2e/.gitignore
+++ b/test/e2e/.gitignore
@@ -1,6 +1,11 @@
 .env
 node_modules/
+
+# PlayWright logging etc.
 /test-results/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# BrowserStack logging
+/log

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -6,6 +6,8 @@ Guide for running the Thunderbird Appointment E2E tests.
 
 You must have a pre-existing Appointment user test account (using FxA credentials) on the platform where you are running the tests. ie. For the production sanity test you must have an Appointment test account on production (using production FxA credentials) already set up.
 
+The tests expect that default Appointment application settings exist for the provided test user; for example the user scheduling availability hasn't been changed from the default settings; and the default calendar view is the current month view. This is important so that the tests can find an available booking slot, etc.
+
 ## Installation
 
 First install the E2E suite (includes Playwright):
@@ -23,17 +25,29 @@ npx playwright install
 
 ## Running Locally
 
-The E2E tests require credentials for an existing Appointment (FxA) account and reads these from your local env vars. First copy over the provided `.example.env` to a local `.env`:
+The E2E tests require credentials for an existing Appointment (FxA) account and reads these from your local env vars.
+This includes the existing Appointment account's email address, password, user's display name and share link.
+<br><br>
+The display name is found in Appointment => Settings => Account => Display name.
+<br><br>
+The share link is found in Appointment => Settings => Account => My Link.
+<br><br>
+The tests also require an email address to be used when actually requesting bookings. This is the email address entered on the `Book selection` dialog (after an appoitment slot was selected on the booking share link page). Note that real Appointment emails will be sent to this email address.
+<br><br>
+First copy over the provided `.example.env` to a local `.env`:
 
 ```bash
 cd test/e2e
 cp .env.example .env
 ```
 
-Then edit your local `.env` file and provide the credentials for your Appointment test account:
+Then edit your local `.env` file and provide the following values:
 ```dotenv
 APPT_PROD_LOGIN_EMAIL=<existing-test-FxA-user-email>
 APPT_PROD_LOGIN_PWORD=<exisiting-test-FxA-user-password>
+APPT_PROD_DISPLAY_NAME=<appointment-user-display-name>
+APPT_PROD_MY_SHARE_LINK=<apointment-user-share-link>
+APPT_BOOKING_REQUESTER_EMAIL=<booking-requesters-email>
 ```
 
 To run the production sanity test headless (still in `test/e2e`):
@@ -60,11 +74,14 @@ You can run the E2E tests from your local machine but against browsers provided 
 
 <b>For security reasons when running the tests on BrowserStack I recommend that you use a dedicated test Appointment FxA account / credentials (NOT your own personal Appointment (FxA) credentials).</b>
 
-Once you have credentials for an existing Appointemnt test account, edit your local `.env` file and add the credentials:
+Once you have credentials for an existing Appointemnt test account, edit your local `.env` file and add these details (more information found above):
 
 ```dotenv
 APPT_PROD_LOGIN_EMAIL=<existing-test-FxA-user-email>
 APPT_PROD_LOGIN_PWORD=<exisiting-test-FxA-user-password>
+APPT_PROD_DISPLAY_NAME=<appointment-user-display-name>
+APPT_PROD_MY_SHARE_LINK=<apointment-user-share-link>
+APPT_BOOKING_REQUESTER_EMAIL=<booking-requesters-email>
 ```
 
 Also in order to run on BrowserStack you need to provide your BrowserStack credentials. Sign into your BrowserStack account and navigate to your `User Profile` and find your auth username and access key. In your local terminal export the following env vars to set the BrowserStack credentials that the tests will use:

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -27,13 +27,9 @@ npx playwright install
 
 The E2E tests require credentials for an existing Appointment (FxA) account and reads these from your local env vars.
 This includes the existing Appointment account's email address, password, user's display name and share link.
-<br><br>
 The display name is found in Appointment => Settings => Account => Display name.
-<br><br>
 The share link is found in Appointment => Settings => Account => My Link.
-<br><br>
 The tests also require an email address to be used when actually requesting bookings. This is the email address entered on the `Book selection` dialog (after an appoitment slot was selected on the booking share link page). Note that real Appointment emails will be sent to this email address.
-<br><br>
 First copy over the provided `.example.env` to a local `.env`:
 
 ```bash

--- a/test/e2e/browserstack.yml
+++ b/test/e2e/browserstack.yml
@@ -67,8 +67,7 @@ browserstackLocal: false # <boolean> (Default false)
 # ===================
 debug: false # <boolean> # Set to true if you need screenshots for every selenium command ran
 networkLogs: false # <boolean> Set to true to enable HAR logs capturing; off as may contain sensitive info like login API requests
-consoleLogs: info # <string> Remote browser's console debug levels to be printed (Default: errors)
-# Available options are `disable`, `errors`, `warnings`, `info`, `verbose` (Default: errors)
+consoleLogs: info # <string> Remote browser's console debug levels to be printed (`disable`, `errors`, `warnings`, `info`, or `verbose`)
 framework: playwright
 browserstack.playwrightLogs: false # disable playwright logs appearing on browserstack builds as may contain sensitive info like credentials
 # CUSTOM_TAG_<INT>: # <string> (Default: parent folder name of the test file) Custom tag for your test suite

--- a/test/e2e/browserstack.yml
+++ b/test/e2e/browserstack.yml
@@ -29,10 +29,14 @@ platforms:
     osVersion: Sequoia
     browserName: playwright-firefox
     browserVersion: latest
+    playwrightConfigOptions:
+      name: Firefox-OSX
   - os: OS X
     osVersion: Sequoia
     browserName: playwright-chromium
     browserVersion: latest
+    playwrightConfigOptions:
+      name: Chromium-OSX
 
 # =======================
 # Parallels per Platform
@@ -63,7 +67,7 @@ browserstackLocal: false # <boolean> (Default false)
 # ===================
 debug: false # <boolean> # Set to true if you need screenshots for every selenium command ran
 networkLogs: false # <boolean> Set to true to enable HAR logs capturing; off as may contain sensitive info like login API requests
-consoleLogs: errors # <string> Remote browser's console debug levels to be printed (Default: errors)
+consoleLogs: info # <string> Remote browser's console debug levels to be printed (Default: errors)
 # Available options are `disable`, `errors`, `warnings`, `info`, `verbose` (Default: errors)
 framework: playwright
 browserstack.playwrightLogs: false # disable playwright logs appearing on browserstack builds as may contain sensitive info like credentials

--- a/test/e2e/const/constants.ts
+++ b/test/e2e/const/constants.ts
@@ -1,10 +1,20 @@
 // appointment urls
-export const APPT_PROD_URL = process.env.APPT_PROD_URL;
+export const APPT_PROD_URL = String(process.env.APPT_PROD_URL);
+export const APPT_PROD_MY_SHARE_LINK = String(process.env.APPT_PROD_MY_SHARE_LINK);
+export const APPT_PROD_SHORT_SHARE_LINK_PREFIX = String(process.env.APPT_PROD_SHORT_SHARE_LINK_PREFIX);
+export const APPT_PROD_LONG_SHARE_LINK_PREFIX = String(process.env.APPT_PROD_LONG_SHARE_LINK_PREFIX);
 
 // page titles
 export const APPT_PAGE_TITLE = 'Thunderbird Appointment';
 export const FXA_PAGE_TITLE = 'Mozilla accounts';
 
-// production sign-in credentials
-export const PROD_LOGIN_EMAIL = process.env.APPT_PROD_LOGIN_EMAIL;
-export const PROD_LOGIN_PWORD = process.env.APPT_PROD_LOGIN_PWORD;
+// production sign-in credentials and corresponding account display name
+export const PROD_LOGIN_EMAIL = String(process.env.APPT_PROD_LOGIN_EMAIL);
+export const PROD_LOGIN_PWORD = String(process.env.APPT_PROD_LOGIN_PWORD);
+
+// appointment user display name (settings => account) for above user
+export const PROD_DISPLAY_NAME = String(process.env.APPT_PROD_DISPLAY_NAME);
+
+// appointment requester's name and email address
+export const APPT_BOOKING_REQUESTER_NAME = String(process.env.APPT_BOOKING_REQUESTER_NAME);
+export const APPT_BOOKING_REQUESTER_EMAIL = String(process.env.APPT_BOOKING_REQUESTER_EMAIL);

--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@playwright/test": "^1.49.0",
         "@types/node": "^22.10.1",
-        "browserstack-node-sdk": "^1.34.29",
+        "browserstack-node-sdk": "^1.34.34",
         "dotenv": "^16.3.1"
       }
     },
@@ -1082,9 +1082,9 @@
       }
     },
     "node_modules/browserstack-node-sdk": {
-      "version": "1.34.29",
-      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.34.29.tgz",
-      "integrity": "sha512-f0rpHfDkmKPMRaxnBcB3U1wc4Wr66nHfbSVXRmRvnZbunNGc90SKFnxoYY96AFiWjIlO+mgd2UoTE/BnLRwkjg==",
+      "version": "1.34.34",
+      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.34.34.tgz",
+      "integrity": "sha512-A16W7xDLc4n3i4GIwegQsNp90qoByIG+rlJpLnBGaQ+MZNknTOwKuX/JP0o8E4rq1aVLv6hx5v6aDKDVcDmNSw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@playwright/test": "^1.49.0",
     "@types/node": "^22.10.1",
-    "browserstack-node-sdk": "^1.34.29",
+    "browserstack-node-sdk": "^1.34.34",
     "dotenv": "^16.3.1"
   }
 }

--- a/test/e2e/pages/booking-page.ts
+++ b/test/e2e/pages/booking-page.ts
@@ -1,0 +1,166 @@
+import { expect } from '@playwright/test';
+import { type Page, type Locator } from '@playwright/test';
+import { APPT_PROD_MY_SHARE_LINK, APPT_PROD_SHORT_SHARE_LINK_PREFIX, APPT_PROD_LONG_SHARE_LINK_PREFIX } from '../const/constants';
+import { DashboardPage } from './dashboard-page';
+
+export class BookingPage {
+  readonly page: Page;
+  readonly titleText: Locator;
+  readonly invitingText: Locator;
+  readonly confirmBtn: Locator;
+  readonly bookingCalendar: Locator;
+  readonly calendarHeader: Locator;
+  readonly nextMonthArrow: Locator;
+  readonly availableBookingSlot: Locator;
+  readonly bookSelectionNameInput: Locator;
+  readonly bookSelectionEmailInput: Locator;
+  readonly bookSelectionBookBtn: Locator;
+  readonly requestSentTitleText: Locator;
+  readonly requestSentAvailabilityText: Locator;
+  readonly requestSentBookingSlot: Locator;
+  readonly requestSentCloseBtn: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.titleText = this.page.getByTestId('booking-view-title-text');
+    this.invitingText = this.page.getByTestId('booking-view-inviting-you-text');
+    this.bookingCalendar = this.page.getByTestId('booking-view-calendar-div');
+    this.confirmBtn = this.page.getByTestId('booking-view-confirm-selection-button');
+    this.calendarHeader = this.page.locator('.calendar-header__period-name');
+    this.nextMonthArrow = this.page.locator('[data-icon="chevron-right"]');
+    this.availableBookingSlot = this.page.locator('[data-test="day-event"]', { hasNotText: 'Busy'});
+    this.bookSelectionNameInput = this.page.getByPlaceholder('First and last name');
+    this.bookSelectionEmailInput = this.page.getByPlaceholder('john.doe@example.com');
+    this.bookSelectionBookBtn = this.page.getByRole('button', { name: 'Book' });
+    this.requestSentTitleText = this.page.getByText('Booking request sent');
+    this.requestSentAvailabilityText = this.page.getByText("'s Availability");
+    this.requestSentBookingSlot = this.page.locator('.todo');
+    this.requestSentCloseBtn = this.page.getByRole('button', { name: 'Close' });
+  }
+
+  /**
+   * Navigate to the booking page using the share link short URL.
+   */
+  async gotoBookingPageShortUrl() {
+    // the default share link is a short URL
+    await this.page.goto(APPT_PROD_MY_SHARE_LINK);
+    await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  /**
+   * Navigatge to the booking page using the share link long URL.
+   */
+  async gotoBookingPageLongUrl() {
+    // the share link is short by default; build the corresponding long link first
+    const prodShareLinkUser: string = APPT_PROD_MY_SHARE_LINK.split(APPT_PROD_SHORT_SHARE_LINK_PREFIX)[1];
+    const longLink: string = `${APPT_PROD_LONG_SHARE_LINK_PREFIX}${prodShareLinkUser}`;
+    await this.page.goto(longLink);
+    await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  /**
+   * Go to the booking page week view (via the booking share link)
+   */
+  async gotoBookingPageWeekView() {
+    const weekLink: string = `${APPT_PROD_MY_SHARE_LINK}#week`;
+    await this.page.goto(weekLink);
+    await this.page.waitForLoadState('domcontentloaded');
+    await expect(this.confirmBtn).toBeVisible({ timeout: 30_000 });
+  }
+
+  /**
+   * With the booking page week view already displayed, go forward to the next week.
+   */
+  async goForwardOneWeek() {
+    await this.nextMonthArrow.click();
+    await this.page.waitForLoadState('domcontentloaded');
+    await expect(this.confirmBtn).toBeVisible({ timeout: 30_000 });
+  }
+
+  /**
+   * With the booking page week view already displayed, select the first available booking slot.
+   * If there is no slot available on the current week, this methond will skip to the next week
+   * and look for slots there. If no slots are avaible on the next week either, then an error
+   * will be raised.
+   * @param userDisplayName String containing the display name of the Appointment user
+   * @returns String containing the reference text for the time slot that was requested
+   * as retrieved from the DOM ie. 'event-2025-01-08 09:30'.
+   */
+  async selectAvailableBookingSlot(userDisplayName: string): Promise<string> {
+    // let's check if a non-busy appointment slot exists in the current week view
+    const slotCount: number = await this.availableBookingSlot.count();
+    console.log(`available slot count: ${slotCount}`);
+
+    // if no slots are available in current week view then fast forward to next week
+    if (slotCount === 0) {
+      console.log('no slots available in current week, skipping ahead to the next week');
+      await this.goForwardOneWeek();
+      // now check again for available slots; if none then fail out the test (safety catch but shouldn't happen)
+      const newSlotCount: number = await this.availableBookingSlot.count();
+      console.log(`available slot count: ${newSlotCount}`);
+      expect(newSlotCount, `no booking slots available, please check availability settings for ${userDisplayName}`).toBeGreaterThan(0);
+    }
+
+    // slots are available in current week view so get the first one
+    const firstSlot: Locator = this.availableBookingSlot.first();
+    let slotRef = await firstSlot.getAttribute('data-ref'); // ie. 'event-2025-01-08 09:30'
+    if (!slotRef)
+      slotRef = 'none';
+    expect(slotRef).toContain('event-');
+
+    // now that we've found an availalbe slot select it and confirm
+    await firstSlot.click();
+    return slotRef;
+  }
+
+  /**
+   * Fill out the 'book selection' dialog with the given values.
+   * The 'book selection' dialog appears after an appointment slot has been selected (on the
+   * booking page provided by the share link). This method will fill in the booking requester's
+   * name and email address and then click the 'book' button to finalize the booking request.
+   * @param bookerName String to fill in as the booking requester's name
+   * @param bookerEmail String to fill in as the booking requester's email
+   */
+  async finishBooking(bookerName: string, bookerEmail: string) {
+    await this.bookSelectionNameInput.fill(bookerName);
+    await this.bookSelectionEmailInput.fill(bookerEmail);
+    await this.bookSelectionBookBtn.click();
+  }
+
+  /**
+   * Verify the given appointment time slot text is displayed in the current page
+   * @param expSlotDateStr Expected slot date string formatted as 'Friday, January 10, 2025'
+   * @param expSlotTimeStr Expected time slot time string formatted as '14:30' (24 hr time)
+   */
+  async verifyRequestedSlotTextDisplayed(expSlotDateStr: string, expSlotTimeStr: string) {
+    // due to the way the element is we must locate by the date text only
+    const slotDisplayText: Locator = this.page.getByText(expSlotDateStr);
+    await expect(slotDisplayText).toBeVisible();
+    // the slot text has been found so now verify it contains both the given date and time
+    await expect(slotDisplayText).toHaveText(`${expSlotDateStr} ${expSlotTimeStr}`);
+  }
+
+  /**
+   * Utility to return a string containing the date abstracted from a given time slot string 
+   * @param timeSlotString Slot string read from DOM (ie. 'event-2025-01-14 14:30')
+   * @returns Formatted date string (ie. 'Tuesday, January 14, 2025')
+   */
+  async getDateFromSlotString(timeSlotString: string): Promise<string> {
+    const selectedSlotDateTime = new Date(timeSlotString.substring(6));
+    return selectedSlotDateTime.toLocaleDateString('default', { dateStyle: 'full' });
+  }
+
+  /**
+   * Utility to return a string containg the time abstracted from a given time slot string.
+   * The time in the given time slot string is in 24 hour format (i.e. 14:30), but we want
+   * it to be like '02:30 PM'
+   * @param timeSlotString Slot string read from DOM (ie. 'event-2025-01-14 14:30')
+   * @returns Formatted time string (ie. '02:30 PM')
+   */
+  async getTimeFromSlotString(timeSlotString: string): Promise<string> {
+    const selectedSlotDateTime = new Date(timeSlotString.substring(6));
+    const expTimeStr = selectedSlotDateTime.toLocaleTimeString('default', { hour12: true, hour: '2-digit', minute: '2-digit' });
+    // now expTimeStr looks like this, for example: '04:30 p.m.' but need it to be like '04:30 PM'
+    return expTimeStr.toUpperCase().replace('.', '').replace('.', '');
+  }
+}

--- a/test/e2e/pages/booking-page.ts
+++ b/test/e2e/pages/booking-page.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
 import { type Page, type Locator } from '@playwright/test';
 import { APPT_PROD_MY_SHARE_LINK, APPT_PROD_SHORT_SHARE_LINK_PREFIX, APPT_PROD_LONG_SHARE_LINK_PREFIX } from '../const/constants';
-import { DashboardPage } from './dashboard-page';
 
 export class BookingPage {
   readonly page: Page;
@@ -17,7 +16,6 @@ export class BookingPage {
   readonly bookSelectionBookBtn: Locator;
   readonly requestSentTitleText: Locator;
   readonly requestSentAvailabilityText: Locator;
-  readonly requestSentBookingSlot: Locator;
   readonly requestSentCloseBtn: Locator;
 
   constructor(page: Page) {
@@ -34,7 +32,6 @@ export class BookingPage {
     this.bookSelectionBookBtn = this.page.getByRole('button', { name: 'Book' });
     this.requestSentTitleText = this.page.getByText('Booking request sent');
     this.requestSentAvailabilityText = this.page.getByText("'s Availability");
-    this.requestSentBookingSlot = this.page.locator('.todo');
     this.requestSentCloseBtn = this.page.getByRole('button', { name: 'Close' });
   }
 

--- a/test/e2e/pages/dashboard-page.ts
+++ b/test/e2e/pages/dashboard-page.ts
@@ -1,5 +1,4 @@
 import { expect, type Page, type Locator } from '@playwright/test';
-import exp from 'constants';
 
 export class DashboardPage {
   readonly page: Page;
@@ -7,6 +6,7 @@ export class DashboardPage {
   readonly userMenuAvatar: Locator;
   readonly logOutMenuItem: Locator;
   readonly shareMyLink: Locator;
+  readonly nextMonthArrow: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -14,5 +14,57 @@ export class DashboardPage {
     this.userMenuAvatar = this.page.getByTestId('user-menu-avatar');
     this.logOutMenuItem = this.page.getByTestId('user-nav-logout-menu');
     this.shareMyLink = this.page.getByTestId('dashboard-share-quick-link-btn');
+    this.nextMonthArrow = this.page.locator('[data-icon="chevron-right"]');
+  }
+
+  /**
+   * With the booking page week view already displayed, go forward to the next week.
+   */
+  async goForwardOneMonth() {
+    console.log('skipping ahead to the next calendar month');
+    await this.nextMonthArrow.click();
+    await this.page.waitForLoadState('domcontentloaded');
+    await expect(this.shareMyLink).toBeVisible({ timeout: 30_000 });
+  }
+
+  /**
+   * Given a requested booking's time slot reference, verify that a corresponding hold event
+   * was created in the host calendar dashboard month view.
+   * @param requestedBookingTimeSlotRef String containing the requested booking time slot ref
+   * taken from the DOM on the share link page at the time when the slot was chosen. Will be in
+   * the format of: 'event-2025-01-14 14:30'.
+   * @param hostUserDisplayName String containing the host account's user display name
+   * @param requsterName String containing the name of the requester (provided at booking request)
+   */
+  async verifyHoldEventCreated(requestedBookingTimeSlotRef: string, hostUserDisplayName: string, requsterName: string) {
+    // on the host calendar view, hold appointment dom elements contain ids that look like this:
+    // 'calendar-month__event-HOLD: Appointment - tbautomation1 and Automated-Test-Bot2025-01-09'
+    // in this case 'tbautomation1' is the appointment host user who shares the booking link; and
+    // `Automated-Test-Bot` is the booking requester's name. First build a search string to match.
+    const eventDate = requestedBookingTimeSlotRef.substring(6, 16); // i.e. '2025-01-14'
+    const eventSearchId = `calendar-month__event-HOLD: Appointment - ${hostUserDisplayName} and ${requsterName}${eventDate}`;
+    console.log(`searching for calendar event with dom element id: ${eventSearchId}`);
+
+    // todo: the hold event dom element id only contains the event date and not time slot so if we
+    // search we will get all events on that date for the given users but won't be able to tell if
+    // hold event was created for the correct time slot; for now just ensure at lest one hold event
+    // was created on the booking request date, but update this later (see github issue #820).
+
+    // check if the hold event is found on current month view
+    const holdEvent: Locator = this.page.locator(`id=${eventSearchId}`);
+    const firstHoldEvent: Locator = holdEvent.first();
+    var eventText = await firstHoldEvent.innerText();
+    if (!eventText) {
+      // hold event not found in current month view so skip ahead to the next month and check again
+      console.log('no matching hold event found in current month');
+      await this.goForwardOneMonth();
+      eventText = await firstHoldEvent.innerText();
+      expect(eventText.length, 'matching hold event was not found on host calendar!').toBeGreaterThan(4);
+    }
+
+    // at least one matching hold event found
+    console.log(`matching hold event found, has text: ${eventText}`);
+    const expHoldEventText = `HOLD: Appointment - ${hostUserDisplayName} and ${requsterName}`;
+    expect(eventText).toContain(expHoldEventText);
   }
 }

--- a/test/e2e/pages/splashscreen-page.ts
+++ b/test/e2e/pages/splashscreen-page.ts
@@ -17,7 +17,8 @@ export class SplashscreenPage {
   }
 
   async gotoProd() {
-    await this.page.goto(String(APPT_PROD_URL));
+    await this.page.goto(APPT_PROD_URL);
+    await this.page.waitForLoadState('domcontentloaded');
   }
 
   async clickLoginBtn() {

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : 1, // actualy don't run in parallel locally either, for now
   // Tests will timeout if still running after this time (ms)
-  timeout: 3 * 60 * 1000,
+  timeout: 2 * 60 * 1000,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [['list']],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/test/e2e/tests/book-appointment.spec.ts
+++ b/test/e2e/tests/book-appointment.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test';
+import { BookingPage } from '../pages/booking-page';
+import { DashboardPage } from '../pages/dashboard-page';
+import { navigateToAppointmentProdAndSignIn } from '../utils/utils';
+import { PROD_DISPLAY_NAME, APPT_BOOKING_REQUESTER_NAME, APPT_BOOKING_REQUESTER_EMAIL } from '../const/constants';
+
+var bookingPage: BookingPage;
+var dashboardPage: DashboardPage;
+
+// verify booking page loaded successfully
+const verifyBookingPageLoaded = async () => {
+  await expect(bookingPage.titleText).toBeVisible({ timeout: 60_000 });
+  await expect(bookingPage.titleText).toContainText(PROD_DISPLAY_NAME);
+  await expect(bookingPage.invitingText).toBeVisible();
+  await expect(bookingPage.invitingText).toContainText(PROD_DISPLAY_NAME);
+  await expect(bookingPage.bookingCalendar).toBeVisible();
+  // calendar header should contain current MMM YYYY
+  const today: Date = new Date();
+  const curMonth: string = today.toLocaleString('default', { month: 'short' });
+  const curYear: string = String(today.getFullYear());
+  await expect(bookingPage.calendarHeader).toHaveText(`${curMonth} ${curYear}`);
+  // confirm button is disabled by default until a slot is selected
+  await expect(bookingPage.confirmBtn).toBeDisabled();
+}
+
+test.beforeEach(async ({ page }) => {
+  bookingPage = new BookingPage(page);
+  dashboardPage = new DashboardPage(page);
+});
+
+// verify we are able to book an appointment using existing user's share link
+test.describe('book an appointment', {
+  tag: '@prod-sanity'
+}, () => {
+  test('able to access booking page via short link', async ({ page }) => {
+    await bookingPage.gotoBookingPageShortUrl();
+    await verifyBookingPageLoaded();
+  });
+
+  test('able to access booking page via long link', async ({ page }) => {
+    await bookingPage.gotoBookingPageLongUrl();
+    await verifyBookingPageLoaded();
+  });
+
+  test('able to request a booking', async ({ page }) => {
+    // in order to ensure we find an available slot we can click on, first switch to week view URL
+    await bookingPage.gotoBookingPageWeekView();
+    await expect(bookingPage.titleText).toBeVisible({ timeout: 30_000 });
+
+    // now select an available booking time slot  
+    const selectedSlot: string|null = await bookingPage.selectAvailableBookingSlot(PROD_DISPLAY_NAME);
+    console.log(`selected appointment time slot: ${selectedSlot}`);
+
+    // now we have an availble booking time slot selected, click confirm button
+    await bookingPage.confirmBtn.click();
+
+    // now fill out the book selection dialog with booking requester's info and book it
+    await bookingPage.finishBooking(APPT_BOOKING_REQUESTER_NAME, APPT_BOOKING_REQUESTER_EMAIL);
+
+    // 'boooking request sent' text appears twice, once in the pop-up and once in underlying page
+    await expect(bookingPage.requestSentTitleText.first()).toBeVisible({ timeout: 60_000 });
+    await expect(bookingPage.requestSentTitleText.nth(1)).toBeVisible();
+
+    // booking request sent dialog availability text contains correct user name
+    // this text also appears twice, once in the pop-up and once in underlying page
+    await expect(bookingPage.requestSentAvailabilityText.first()).toBeVisible();
+    await expect(bookingPage.requestSentAvailabilityText.nth(1)).toBeVisible();
+    const expectedText: string = `${PROD_DISPLAY_NAME}'s Availability`;
+    expect(bookingPage.requestSentAvailabilityText.first()).toContainText(expectedText);
+    expect(bookingPage.requestSentAvailabilityText.nth(1)).toContainText(expectedText);
+
+    // booking request sent dialog should display the correct time slot that was requested
+    // our requested time slot is stored in this format, as example: 'event-2025-01-14 14:30'
+    // the dialog reports the slot in this format, as example: 'Tuesday, January 14, 2025 02:30 PM'
+    // first convert our selected slot value to same format as displayed so we can verify
+    const expDateStr = await bookingPage.getDateFromSlotString(selectedSlot);
+    const expTimeStr = await bookingPage.getTimeFromSlotString(selectedSlot);
+
+    // now verify the correct date/time is dispalyed on the booking request sent pop-up
+    await bookingPage.verifyRequestedSlotTextDisplayed(expDateStr, expTimeStr);  
+
+    // now close out the 'booking request sent' pop-up dialog
+    await bookingPage.requestSentCloseBtn.click();
+
+    // navigate to and sign into appointment (host account whom we requested a booking with/owns the share link)
+    await navigateToAppointmentProdAndSignIn(page);
+
+    // now verify a 'hold' now exists on the host calendar at the time slot that was requested
+    await dashboardPage.verifyHoldEventCreated(selectedSlot, PROD_DISPLAY_NAME, APPT_BOOKING_REQUESTER_NAME);
+  });
+});

--- a/test/e2e/tests/sign-in.spec.ts
+++ b/test/e2e/tests/sign-in.spec.ts
@@ -1,19 +1,19 @@
 import { test, expect } from '@playwright/test';
 import { SplashscreenPage } from '../pages/splashscreen-page';
 import { FxAPage } from '../pages/fxa-page';
-import { FXA_PAGE_TITLE, APPT_PAGE_TITLE } from '../const/constants';
+import { APPT_PAGE_TITLE } from '../const/constants';
 import { DashboardPage } from '../pages/dashboard-page';
 
-let splashscreen: SplashscreenPage;
-let fxa_sign_in: FxAPage;
-let dashboard_page: DashboardPage;
+let splashscreenPage: SplashscreenPage;
+let signInPage: FxAPage;
+let dashboardPage: DashboardPage;
 
 test.beforeEach(async ({ page }) => {
   // navigate to the main appointment page (splashscreen)
-  splashscreen = new SplashscreenPage(page);
-  fxa_sign_in = new FxAPage(page);
-  dashboard_page = new DashboardPage(page);
-  await splashscreen.gotoProd();
+  splashscreenPage = new SplashscreenPage(page);
+  signInPage = new FxAPage(page);
+  dashboardPage = new DashboardPage(page);
+  await splashscreenPage.gotoProd();
 });
 
 // verify we are able to sign-in
@@ -21,19 +21,19 @@ test.describe('sign-in', {
   tag: '@prod-sanity'
 }, () => {
   test('able to sign-in', async ({ page }) => {
-    await splashscreen.getToFxA();
+    await splashscreenPage.getToFxA();
 
-    await expect(fxa_sign_in.signInHeaderText).toBeVisible({ timeout: 30_000 }); // generous time for fxa to appear
-    await expect(fxa_sign_in.userAvatar).toBeVisible({ timeout: 30_000});
-    await expect(fxa_sign_in.signInButton).toBeVisible();
+    await expect(signInPage.signInHeaderText).toBeVisible({ timeout: 30_000 }); // generous time for fxa to appear
+    await expect(signInPage.userAvatar).toBeVisible({ timeout: 30_000});
+    await expect(signInPage.signInButton).toBeVisible();
 
-    await fxa_sign_in.signIn();
+    await signInPage.signIn();
 
     await page.waitForLoadState('domcontentloaded');
 
     await expect(page).toHaveTitle(APPT_PAGE_TITLE, { timeout: 30_000 }); // give generous time for fxa sign-in
-    await expect(dashboard_page.userMenuAvatar).toBeVisible({ timeout: 30_000 });
-    await expect(dashboard_page.navBarDashboardBtn).toBeVisible({ timeout: 30_000 });
-    await expect(dashboard_page.shareMyLink).toBeVisible({ timeout: 30_000 });
+    await expect(dashboardPage.userMenuAvatar).toBeVisible({ timeout: 30_000 });
+    await expect(dashboardPage.navBarDashboardBtn).toBeVisible({ timeout: 30_000 });
+    await expect(dashboardPage.shareMyLink).toBeVisible({ timeout: 30_000 });
   });
 });

--- a/test/e2e/tests/splashscreen.spec.ts
+++ b/test/e2e/tests/splashscreen.spec.ts
@@ -2,12 +2,12 @@ import { test, expect } from '@playwright/test';
 import { SplashscreenPage } from '../pages/splashscreen-page';
 import { APPT_PAGE_TITLE } from '../const/constants';
 
-let splashscreen: SplashscreenPage;
+let splashscreenPage: SplashscreenPage;
 
 test.beforeEach(async ({ page }) => {
   // navigate to the main appointment page (splashscreen)
-  splashscreen = new SplashscreenPage(page);
-  await splashscreen.gotoProd();
+  splashscreenPage = new SplashscreenPage(page);
+  await splashscreenPage.gotoProd();
 });
 
 // verify main appointment splash screen appears correctly
@@ -16,7 +16,7 @@ test.describe('splash screen', {
 }, () => {
   test('appears correctly', async ({ page }) => {
     await expect(page).toHaveTitle(APPT_PAGE_TITLE);
-    await expect(splashscreen.loginBtn).toBeVisible();
-    await expect(splashscreen.signUpBetaBtn).toBeVisible();
+    await expect(splashscreenPage.loginBtn).toBeVisible();
+    await expect(splashscreenPage.signUpBetaBtn).toBeVisible();
   });
 });

--- a/test/e2e/utils/utils.ts
+++ b/test/e2e/utils/utils.ts
@@ -1,0 +1,24 @@
+// utility functions that may be used by any tests
+import { SplashscreenPage } from "../pages/splashscreen-page";
+import { FxAPage } from "../pages/fxa-page";
+import { DashboardPage } from "../pages/dashboard-page";
+import { expect, type Page } from '@playwright/test';
+import { APPT_PROD_URL, APPT_PAGE_TITLE } from "../const/constants";
+
+/**
+ * Navigate to and sign into the Appointment application using the production URL and
+ * production credentials provided in the .env file.
+ */
+export const navigateToAppointmentProdAndSignIn = async (page: Page) => {
+    console.log(`navigating to appointment production (${APPT_PROD_URL}) and signing in`);
+    const homePage = new SplashscreenPage(page);
+    const signInPage = new FxAPage(page);
+    const dashboardPage = new DashboardPage(page);
+    await homePage.gotoProd();
+    await homePage.getToFxA();
+    await signInPage.signIn();
+    // now that we're signed into the appointment dashboard give it time to load
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page).toHaveTitle(APPT_PAGE_TITLE, { timeout: 30_000 }); // give generous time
+    await expect(dashboardPage.shareMyLink).toBeVisible({ timeout: 30_000 });
+}


### PR DESCRIPTION
Add the following scenarios to the production sanity playwright E2E test:

- able to access the booking page via short link
- able to access the booking page via long link
- able to request a new booking

Here is a link to the new [updated test running via GitHub actions](https://github.com/thunderbird/appointment/actions/runs/12682709711) on this branch.

And here is the corresponding [recorded video of the test running in BrowserStack](https://automate.browserstack.com/dashboard/v2/builds/5a013832e5e5a6887bd38c4c95a293087035b9aa/sessions/a82f4bd488bd554f38515e4b949676952b98695c) (if you need BrowserStack credentials just let me know and I can set you up!).