### PR TITLE
Don't name inline attachments. (Fixes #816)

### DIFF
--- a/backend/src/appointment/controller/mailer.py
+++ b/backend/src/appointment/controller/mailer.py
@@ -118,7 +118,6 @@ class Mailer:
                     a.mime_main,
                     a.mime_sub,
                     cid=f'<{a.filename}>',
-                    filename=a.filename,
                 )
 
         return message


### PR DESCRIPTION
Fixes #816 

Previously Condition-Disposition was being set to attachment because we named the file. But we want it as an inline file, so don't name the file. 

<img width="648" alt="image" src="https://github.com/user-attachments/assets/ee5260a8-5da7-4c2e-aafd-a732ac44f187" />
