### PR TITLE
Expand the integration tests

### DIFF
--- a/backend/test/integration/test_account.py
+++ b/backend/test/integration/test_account.py
@@ -1,4 +1,5 @@
 import json, os
+from uuid import uuid4
 from appointment.database.models import ExternalConnectionType
 from defines import auth_headers, TEST_USER_ID
 
@@ -6,8 +7,7 @@ from defines import auth_headers, TEST_USER_ID
 class TestAccount:
     def test_account_get_external_connections(self, with_client, make_external_connections):
         # add a couple of external connections to our test user
-        username = 'username'
-        type_id = json.dumps(['url', username])
+        type_id = str(uuid4())
         zoom_ec = make_external_connections(TEST_USER_ID, type=ExternalConnectionType.zoom, type_id=type_id)
         assert zoom_ec.type_id == type_id
         google_ec = make_external_connections(TEST_USER_ID, type=ExternalConnectionType.google, type_id=type_id)
@@ -44,7 +44,7 @@ class TestAccount:
         assert email_list_ret == user_email_list
 
         # now add another email/name via a google connection
-        type_id = json.dumps(['url', test_user_email])
+        type_id = str(uuid4())
         google_ec = make_external_connections(TEST_USER_ID, type=ExternalConnectionType.google, type_id=type_id)
         user_email_list.append(google_ec.name)
 

--- a/backend/test/integration/test_account.py
+++ b/backend/test/integration/test_account.py
@@ -1,0 +1,58 @@
+import json, os
+from appointment.database.models import ExternalConnectionType
+from defines import auth_headers, TEST_USER_ID
+
+
+class TestAccount:
+    def test_account_get_external_connections(self, with_client, make_external_connections):
+        # add a couple of external connections to our test user
+        username = 'username'
+        type_id = json.dumps(['url', username])
+        zoom_ec = make_external_connections(TEST_USER_ID, type=ExternalConnectionType.zoom, type_id=type_id)
+        assert zoom_ec.type_id == type_id
+        google_ec = make_external_connections(TEST_USER_ID, type=ExternalConnectionType.google, type_id=type_id)
+        assert google_ec.type_id == type_id
+
+        # now get the list of our external connections and verify
+        response = with_client.get(
+            '/account/external-connections', headers=auth_headers
+        )
+
+        assert response.status_code == 200, response.text
+        ext_connections = response.json()
+        zoom_connections = ext_connections.get('zoom', None)
+        assert len(zoom_connections) == 1
+        assert zoom_connections[0]['owner_id'] == TEST_USER_ID
+        assert zoom_connections[0]['name'] == zoom_ec.name
+        google_connections = ext_connections.get('google', None)
+        assert len(google_connections) == 1
+        assert google_connections[0]['owner_id'] == TEST_USER_ID
+        assert google_connections[0]['name'] == google_ec.name
+
+    def test_account_available_emails(self, with_client, make_external_connections):
+        # currently we have one email available
+        test_user_email = os.environ.get('TEST_USER_EMAIL')
+        user_email_list = [ test_user_email ]
+
+        # get available emails and confirm
+        response = with_client.get(
+            '/account/available-emails', headers=auth_headers
+        )
+
+        assert response.status_code == 200, response.text
+        email_list_ret = response.json()    
+        assert email_list_ret == user_email_list
+
+        # now add another email/name via a google connection
+        type_id = json.dumps(['url', test_user_email])
+        google_ec = make_external_connections(TEST_USER_ID, type=ExternalConnectionType.google, type_id=type_id)
+        user_email_list.append(google_ec.name)
+
+        # get available emails again and confirm new one was added
+        response = with_client.get(
+            '/account/available-emails', headers=auth_headers
+        )
+
+        assert response.status_code == 200, response.text
+        email_list_ret = response.json()
+        assert email_list_ret == user_email_list

--- a/backend/test/integration/test_appointment.py
+++ b/backend/test/integration/test_appointment.py
@@ -20,7 +20,6 @@ class TestAppointment:
             end = dateutil.parser.parse(end)
             from appointment.database import schemas
 
-            print('list events!')
             return [
                 schemas.Event(
                     title=generated_appointment.title,
@@ -36,7 +35,6 @@ class TestAppointment:
         monkeypatch.setattr(CalDavConnector, 'list_events', list_events)
 
         path = f'/rmt/cal/{generated_appointment.calendar_id}/' + DAY1 + '/' + DAY3
-        print(f'>>> {path}')
         response = with_client.get(path, headers=auth_headers)
         assert response.status_code == 200, response.text
         data = response.json()
@@ -49,7 +47,6 @@ class TestAppointment:
         generated_appointment = make_appointment()
 
         path = f'/rmt/cal/{generated_appointment.calendar_id + 999}/' + DAY1 + '/' + DAY3
-        print(f'>>> {path}')
         response = with_client.get(path, headers=auth_headers)
         assert response.status_code == 404, response.text
         data = response.json()

--- a/backend/test/integration/test_appointment.py
+++ b/backend/test/integration/test_appointment.py
@@ -45,6 +45,16 @@ class TestAppointment:
         assert data[0]['start'] == generated_appointment.slots[0].start.isoformat()
         assert data[0]['end'] == dateutil.parser.parse(DAY3).isoformat()
 
+    def test_get_remote_caldav_events_inavlid_calendar(self, with_client, make_appointment):
+        generated_appointment = make_appointment()
+
+        path = f'/rmt/cal/{generated_appointment.calendar_id + 999}/' + DAY1 + '/' + DAY3
+        print(f'>>> {path}')
+        response = with_client.get(path, headers=auth_headers)
+        assert response.status_code == 404, response.text
+        data = response.json()
+        assert data['detail']['id'] == 'CALENDAR_NOT_FOUND'
+
     def test_get_invitation_ics_file(self, with_client, make_appointment):
         generated_appointment = make_appointment()
 

--- a/backend/test/integration/test_auth.py
+++ b/backend/test/integration/test_auth.py
@@ -1,7 +1,6 @@
-import json
-import os
-import secrets
+import os, json, secrets
 from datetime import timedelta
+from uuid import uuid4
 from unittest.mock import patch
 
 from appointment.dependencies import auth
@@ -567,8 +566,7 @@ class TestCalDAV:
 class TestGoogle:
     def test_disconnect(self, with_db, with_client, make_external_connections, make_google_calendar):
         """Ensure we remove the external google connection and any related calendars"""
-        username = 'username'
-        type_id = json.dumps(['url', username])
+        type_id = str(uuid4())
         ec = make_external_connections(TEST_USER_ID, type=models.ExternalConnectionType.google, type_id=type_id)
         calendar = make_google_calendar(subscriber_id=TEST_USER_ID)
 

--- a/backend/test/integration/test_general.py
+++ b/backend/test/integration/test_general.py
@@ -1,4 +1,4 @@
-import os
+import os, pytest
 from defines import DAY1, DAY5, auth_headers
 
 
@@ -29,76 +29,51 @@ class TestGeneral:
         assert response.status_code == 200
         assert response.json() == 'Zustand in Ordnung'
 
-    def test_access_without_authentication_token(self, with_client):
-        # response = client.get("/login")
-        # assert response.status_code == 401
-        response = with_client.get('/me')
-        assert response.status_code == 401        
-        response = with_client.put('/me')
-        assert response.status_code == 401
-        response = with_client.get('/me/calendars')
-        assert response.status_code == 401
-        response = with_client.get('/me/appointments')
-        assert response.status_code == 401
-        response = with_client.get('/me/signature')
-        assert response.status_code == 401
-        response = with_client.post('/me/signature')
-        assert response.status_code == 401
-        response = with_client.post('/cal')
-        assert response.status_code == 401
-        response = with_client.get('/cal/1')
-        assert response.status_code == 401
-        response = with_client.put('/cal/1')
-        assert response.status_code == 401
-        response = with_client.post('/cal/1/connect')
-        assert response.status_code == 401
-        response = with_client.delete('/cal/1')
-        assert response.status_code == 401
-        response = with_client.post('/caldav/auth')
-        assert response.status_code == 401
-        response = with_client.post('/caldav/disconnect')
-        assert response.status_code == 401
-        response = with_client.post('/rmt/calendars')
-        assert response.status_code == 401
-        response = with_client.get('/rmt/cal/1/' + DAY1 + '/' + DAY5)
-        assert response.status_code == 401
-        response = with_client.post('/rmt/sync')
-        assert response.status_code == 401
-        response = with_client.get('/account/available-emails')
-        assert response.status_code == 401
-        response = with_client.get('/account/download')
-        assert response.status_code == 401
-        response = with_client.get('/account/external-connections/')
-        assert response.status_code == 401
-        response = with_client.delete('/account/delete')
-        assert response.status_code == 401
-        response = with_client.get('/google/auth')
-        assert response.status_code == 401
-        response = with_client.post('/google/disconnect')
-        assert response.status_code == 401
-        response = with_client.post('/schedule')
-        assert response.status_code == 401
-        response = with_client.get('/schedule')
-        assert response.status_code == 401
-        response = with_client.get('/schedule/0')
-        assert response.status_code == 401
-        response = with_client.put('/schedule/0')
-        assert response.status_code == 401        
-        response = with_client.get('/invite')
-        assert response.status_code == 401
-        response = with_client.post('/invite/generate/1')
-        assert response.status_code == 401
-        response = with_client.put('/invite/revoke/1')
-        assert response.status_code == 401
-        response = with_client.get('/subscriber')
-        assert response.status_code == 401
-        response = with_client.put('/subscriber/enable/someemail@email.com')
-        assert response.status_code == 401
-        response = with_client.put('/subscriber/disable/someemail@email.com')
-        assert response.status_code == 401
-        response = with_client.post('/subscriber/setup')
-        assert response.status_code == 401
-        response = with_client.post('/waiting-list/invite')
+    @pytest.mark.parametrize('api_method, api_route', [
+        ('get', '/me'),
+        ('put', '/me'),
+        ('get', '/me/calendars'),
+        ('get', '/me/appointments'),
+        ('get', '/me/signature'),
+        ('post', '/me/signature'),
+        ('post', '/cal'),
+        ('get', '/cal/1'),
+        ('put', '/cal/1'),
+        ('post', '/cal/1/connect'),
+        ('delete', '/cal/1'),
+        ('post', '/caldav/auth'),
+        ('post', '/caldav/disconnect'),
+        ('post', '/rmt/calendars'),
+        ('get', '/rmt/cal/1/' + DAY1 + '/' + DAY5),
+        ('post', '/rmt/sync'),
+        ('get', '/account/available-emails'),
+        ('get', '/account/download'),
+        ('get', '/account/external-connections/'),
+        ('delete', '/account/delete'),
+        ('get', '/google/auth'),
+        ('post', '/google/disconnect'),
+        ('post', '/schedule'),
+        ('get', '/schedule'),
+        ('get', '/schedule/0'),
+        ('put', '/schedule/0'),
+        ('get', '/invite'),
+        ('post', '/invite/generate/1'),
+        ('put', '/invite/revoke/1'),
+        ('get', '/subscriber'),
+        ('put', '/subscriber/enable/someemail@email.com'),
+        ('put', '/subscriber/disable/someemail@email.com'),
+        ('post', '/subscriber/setup'),
+        ('post', '/waiting-list/invite'),
+    ])
+    def test_access_without_authentication_token(self, with_client, api_method, api_route):
+        if api_method == 'post':
+            response = with_client.post(f'{api_route}')
+        elif api_method == 'get':
+            response = with_client.get(f'{api_route}')
+        elif api_method == 'put':
+            response = with_client.put(f'{api_route}')
+        else:
+            response = with_client.delete(f'{api_route}')
         assert response.status_code == 401
 
     def test_send_feedback(self, with_client):

--- a/backend/test/integration/test_general.py
+++ b/backend/test/integration/test_general.py
@@ -32,6 +32,8 @@ class TestGeneral:
     def test_access_without_authentication_token(self, with_client):
         # response = client.get("/login")
         # assert response.status_code == 401
+        response = with_client.get('/me')
+        assert response.status_code == 401        
         response = with_client.put('/me')
         assert response.status_code == 401
         response = with_client.get('/me/calendars')
@@ -52,17 +54,51 @@ class TestGeneral:
         assert response.status_code == 401
         response = with_client.delete('/cal/1')
         assert response.status_code == 401
+        response = with_client.post('/caldav/auth')
+        assert response.status_code == 401
+        response = with_client.post('/caldav/disconnect')
+        assert response.status_code == 401
         response = with_client.post('/rmt/calendars')
         assert response.status_code == 401
         response = with_client.get('/rmt/cal/1/' + DAY1 + '/' + DAY5)
         assert response.status_code == 401
         response = with_client.post('/rmt/sync')
         assert response.status_code == 401
+        response = with_client.get('/account/available-emails')
+        assert response.status_code == 401
         response = with_client.get('/account/download')
+        assert response.status_code == 401
+        response = with_client.get('/account/external-connections/')
         assert response.status_code == 401
         response = with_client.delete('/account/delete')
         assert response.status_code == 401
         response = with_client.get('/google/auth')
+        assert response.status_code == 401
+        response = with_client.post('/google/disconnect')
+        assert response.status_code == 401
+        response = with_client.post('/schedule')
+        assert response.status_code == 401
+        response = with_client.get('/schedule')
+        assert response.status_code == 401
+        response = with_client.get('/schedule/0')
+        assert response.status_code == 401
+        response = with_client.put('/schedule/0')
+        assert response.status_code == 401        
+        response = with_client.get('/invite')
+        assert response.status_code == 401
+        response = with_client.post('/invite/generate/1')
+        assert response.status_code == 401
+        response = with_client.put('/invite/revoke/1')
+        assert response.status_code == 401
+        response = with_client.get('/subscriber')
+        assert response.status_code == 401
+        response = with_client.put('/subscriber/enable/someemail@email.com')
+        assert response.status_code == 401
+        response = with_client.put('/subscriber/disable/someemail@email.com')
+        assert response.status_code == 401
+        response = with_client.post('/subscriber/setup')
+        assert response.status_code == 401
+        response = with_client.post('/waiting-list/invite')
         assert response.status_code == 401
 
     def test_send_feedback(self, with_client):
@@ -70,3 +106,13 @@ class TestGeneral:
             '/support', json={'topic': 'Hello World', 'details': 'Hello World but longer'}, headers=auth_headers
         )
         assert response.status_code == 200
+
+    def test_send_feedback_no_email_configured(self, with_client):
+        """Attempt to send feedback with no support email configured; expect error"""
+        saved_email = os.environ['SUPPORT_EMAIL']
+        os.environ['SUPPORT_EMAIL'] = ''
+        response = with_client.post(
+            '/support', json={'topic': 'Hello World', 'details': 'Hello World but longer'}, headers=auth_headers
+        )
+        os.environ['SUPPORT_EMAIL'] = saved_email
+        assert response.status_code == 500

--- a/backend/test/integration/test_invite.py
+++ b/backend/test/integration/test_invite.py
@@ -1,7 +1,8 @@
 import os
+from datetime import datetime
 from defines import auth_headers, TEST_USER_ID
 from appointment.database import repo
-
+from appointment.database.models import InviteStatus
 
 class TestInvite:
     def test_send_invite_email_requires_admin(self, with_db, with_client):
@@ -49,6 +50,138 @@ class TestInvite:
         with with_db() as db:
             subscriber = repo.subscriber.get_by_email(db, invite_email)
             assert subscriber is not None
+
+    def test_send_invite_email_subscriber_already_exists(self, with_db, with_client, make_pro_subscriber):
+        """Ensures send_invite_email fails if subscriber already exists"""
+
+        os.environ['APP_ADMIN_ALLOW_LIST'] = '@example.org'
+
+        the_other_guy = make_pro_subscriber()
+
+        response = with_client.post(
+            '/invite/send',
+            json={'email': the_other_guy.email},
+            headers=auth_headers,
+        )
+        assert response.status_code == 400, response.text
+        data = response.json()
+        assert data['detail']['id'] == 'CREATE_SUBSCRIBER_ALREADY_EXISTS'
+
+    def test_send_invite_email_subscriber_fails(self, with_db, with_client):
+        """Ensures send_invite_email fails if invite email is invalid"""
+
+        os.environ['APP_ADMIN_ALLOW_LIST'] = '@example.org'
+
+        invite_email = 'hi'
+
+        response = with_client.post(
+            '/invite/send',
+            json={'email': invite_email},
+            headers=auth_headers,
+        )
+        assert response.status_code == 422, response.text
+        data = response.json()
+        assert 'not a valid email address' in data['detail'][0]['msg']
+
+    def test_get_all_invites_requires_admin(self, with_db, with_client):
+        """Ensures getting all invites requires an admin user"""
+
+        os.environ['APP_ADMIN_ALLOW_LIST'] = '@notexample.org'
+
+        response = with_client.get(
+            '/invite',
+            headers=auth_headers,
+        )
+        assert response.status_code == 401, response.text
+        data = response.json()
+        assert data['detail']['id'] == 'INVALID_PERMISSION_LEVEL'
+
+    def test_get_all_invites(self, with_db, with_client, make_invite):
+        """Ensures we can get all invites"""
+        os.environ['APP_ADMIN_ALLOW_LIST'] = '@example.org'
+
+        invites = [make_invite(owner_id=TEST_USER_ID) for _ in range(2)]
+
+        response = with_client.get(
+            '/invite',
+            headers=auth_headers,
+        )
+        assert response.status_code == 200, response.text
+        invite_list = response.json()
+        assert len(invite_list) == 2
+        today = datetime.today().strftime('%Y-%m-%d')
+        for next_invite in invite_list:
+            assert next_invite['owner_id'] == TEST_USER_ID
+            assert today in next_invite['time_created']
+            assert next_invite['code'] is not None
+        assert invite_list[0]['code'] != invite_list[1]['code']
+
+    def test_generate_invites(self, with_client):
+        """Ensures we can generate new invites"""
+        response = with_client.post(
+            '/invite/generate/5',
+            headers=auth_headers,
+        )
+        assert response.status_code == 200, response.text
+        invite_list = response.json()
+        assert len(invite_list) == 5
+        today = datetime.today().strftime('%Y-%m-%d')
+        for next_invite in invite_list:
+            assert today in next_invite['time_created']
+            assert next_invite['status'] == InviteStatus.active.value
+            assert next_invite['code'] is not None
+
+        response = with_client.get(
+            '/invite',
+            headers=auth_headers,
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert len(data) == 5
+
+    def test_revoke_invite(self, with_db, with_client, make_invite):
+        """Ensures we can revoke an invite code"""
+        os.environ['APP_ADMIN_ALLOW_LIST'] = '@example.org'
+
+        test_invite = make_invite(owner_id=TEST_USER_ID)
+        assert test_invite.status == InviteStatus.active
+
+        response = with_client.put(
+            f'/invite/revoke/{test_invite.code}',
+            headers=auth_headers,
+        )
+        assert response.status_code == 200, response.text
+
+        # verify our invite now has a status of revoked
+        response = with_client.get(
+            '/invite',
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200, response.text
+        invite_list = response.json()
+        assert len(invite_list) == 1
+        assert invite_list[0]['status'] == InviteStatus.revoked.value
+
+        # attempt to revoke the same already-revoked invite code, expect fail
+        response = with_client.put(
+            f'/invite/revoke/{test_invite.code}',
+            headers=auth_headers,
+        )
+        assert response.status_code == 403, response.text
+        data = response.json()
+        assert data['detail']['id'] == 'INVITE_CODE_NOT_AVAILABLE'
+
+
+    def test_revoke_invite_not_found(self, with_db, with_client, make_invite):
+        """Ensures revoking an invite code fails if code is invalid"""
+        response = with_client.put(
+            '/invite/revoke/99999',
+            headers=auth_headers,
+        )
+        assert response.status_code == 404, response.text
+        data = response.json()
+        assert data['detail']['id'] == 'INVITE_CODE_NOT_FOUND'
 
 
 class TestPublicInvites:

--- a/backend/test/integration/test_profile.py
+++ b/backend/test/integration/test_profile.py
@@ -52,3 +52,18 @@ class TestProfile:
         assert response.status_code == 200, response.text
         url_new = response.json()['url']
         assert url_old != url_new
+
+    def test_update_me_username_taken(self, with_db, with_client, make_pro_subscriber):
+        """Attempt to update current subscriber's profile with already existing username"""
+        other_subscriber = make_pro_subscriber(username='thunderbird1')
+
+        response = with_client.put(
+            '/me',
+            json={
+                'username': 'thunderbird1',
+                'name': 'Changed Name',
+                'secondary_email': 'adifferentone@example.org',
+            },
+            headers=auth_headers,
+        )
+        assert response.status_code == 403, response.text

--- a/backend/test/integration/test_subscriber.py
+++ b/backend/test/integration/test_subscriber.py
@@ -1,0 +1,193 @@
+import os
+from datetime import datetime
+from defines import auth_headers, TEST_USER_ID
+from appointment.database.models import SubscriberLevel
+
+
+class TestSubscriber:
+    def test_get_all_subscribers(self, with_client, make_basic_subscriber):
+        # make our current subscriber admin
+        os.environ['APP_ADMIN_ALLOW_LIST'] = '@example.org'
+
+        response = with_client.get(
+            '/subscriber', headers=auth_headers
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        number_of_subscribers = len(data)
+        assert number_of_subscribers > 0
+
+        # verify values
+        test_subscriber = data[TEST_USER_ID -1]
+        assert test_subscriber['username'] == os.getenv('TEST_USER_EMAIL')
+        assert test_subscriber['email'] == os.getenv('TEST_USER_EMAIL')
+        assert test_subscriber['preferred_email'] == os.getenv('TEST_USER_EMAIL')
+        assert test_subscriber['name'] == 'Test Account'
+        assert test_subscriber['short_link_hash'] == 'abc1234'
+        assert test_subscriber['id'] == TEST_USER_ID
+        assert test_subscriber['language'] == 'en'
+        assert test_subscriber['timezone'] == None
+        assert test_subscriber['is_setup'] == False
+        assert test_subscriber['ftue_level'] == 0
+        assert test_subscriber['level'] == SubscriberLevel.pro.value
+
+        # now make a new basic subscriber
+        new_subscriber = make_basic_subscriber()
+
+        # get subscribers again
+        response = with_client.get(
+            '/subscriber', headers=auth_headers
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+
+        # the last subscriber in the returned list is the latest one we created, verify values
+        assert len(data) == number_of_subscribers + 1
+        subscriber_ret = data[len(data) -1]
+        assert subscriber_ret['username'] == new_subscriber.username
+        assert subscriber_ret['email'] == new_subscriber.email
+        assert subscriber_ret['preferred_email'] == new_subscriber.preferred_email
+        assert subscriber_ret['name'] == new_subscriber.name
+        assert subscriber_ret['short_link_hash'] == new_subscriber.short_link_hash
+        assert subscriber_ret['id'] == number_of_subscribers + 1
+        assert subscriber_ret['language'] == new_subscriber.language
+        assert subscriber_ret['timezone'] == new_subscriber.timezone
+        assert subscriber_ret['is_setup'] == new_subscriber.is_setup
+        assert subscriber_ret['ftue_level'] == new_subscriber.ftue_level
+        assert subscriber_ret['level'] == new_subscriber.level.value
+
+    def test_get_all_subscribers_no_admin(self, with_client):
+        # ensure our current subscriber is not admin
+        os.environ['APP_ADMIN_ALLOW_LIST'] = '@notexample.org'
+
+        response = with_client.get(
+            '/subscriber', headers=auth_headers
+        )
+        assert response.status_code == 401, response.text
+        data = response.json()
+        assert data['detail']['id'] == 'INVALID_PERMISSION_LEVEL'
+
+    def test_disable_enable_subscriber(self, with_client, make_basic_subscriber):
+        # make our current subscriber admin
+        os.environ['APP_ADMIN_ALLOW_LIST'] = '@example.org'
+
+        # make a new subscriber
+        new_subscriber = make_basic_subscriber()
+        assert new_subscriber.time_deleted is None
+
+        # disable our new subscriber and verify
+        response = with_client.put(
+            f'/subscriber/disable/{new_subscriber.email}', headers=auth_headers
+        )
+
+        assert response.status_code == 200, response.text
+        response = with_client.get(
+            '/subscriber', headers=auth_headers
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        subscriber_ret = data[len(data) -1]
+        assert subscriber_ret['time_deleted'] is not None
+        today = datetime.today().strftime('%Y-%m-%d')
+        assert today in subscriber_ret['time_deleted']
+
+        # attempt to disable same subscriber again, expect fail
+        response = with_client.put(
+            f'/subscriber/disable/{new_subscriber.email}', headers=auth_headers
+        )
+
+        assert response.status_code == 400, response.text
+        data = response.json()
+        assert data['detail']['id'] == 'SUBSCRIBER_ALREADY_DELETED'
+
+        # now enable the deleted subscriber and verify
+        response = with_client.put(
+            f'/subscriber/enable/{new_subscriber.email}', headers=auth_headers
+        )
+
+        assert response.status_code == 200, response.text
+        response = with_client.get(
+            '/subscriber', headers=auth_headers
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        subscriber_ret = data[len(data) -1]
+        assert subscriber_ret['time_deleted'] is None
+
+        # attempt to enable the same subscriber again, expect fail
+        response = with_client.put(
+            f'/subscriber/enable/{new_subscriber.email}', headers=auth_headers
+        )
+
+        assert response.status_code == 400, response.text
+        data = response.json()
+        assert data['detail']['id'] == 'SUBSCRIBER_ALREADY_ENABLED'
+
+    def test_disable_subscriber_self_delete_failure(self, with_client):
+        # make our current subscriber admin
+        os.environ['APP_ADMIN_ALLOW_LIST'] = '@example.org'
+
+        # disable our current subscriber and verify
+        response = with_client.put(
+            f'/subscriber/disable/{os.getenv('TEST_USER_EMAIL')}', headers=auth_headers
+        )
+
+        assert response.status_code == 403, response.text
+        data = response.json()
+        assert data['detail']['id'] == 'SUBSCRIBER_SELF_DELETE'
+
+    def test_disable_subscriber_not_found(self, with_client, make_basic_subscriber):
+        # make our current subscriber admin
+        os.environ['APP_ADMIN_ALLOW_LIST'] = '@example.org'
+
+        # disable a subscriber that doesn't exist
+        response = with_client.put(
+            '/subscriber/disable/this-user-does-not-exist@someemail.com', headers=auth_headers
+        )
+
+        assert response.status_code == 404, response.text
+        data = response.json()
+        assert data['detail']['id'] == 'SUBSCRIBER_NOT_FOUND'
+
+    def test_disable_subscriber_no_admin(self, with_client):
+        # ensure our current subscriber is not admin
+        os.environ['APP_ADMIN_ALLOW_LIST'] = '@notexample.org'
+
+        response = with_client.put(
+            f'/subscriber/disable/{os.getenv('TEST_USER_EMAIL')}', headers=auth_headers
+        )
+
+        assert response.status_code == 401, response.text
+        data = response.json()
+        assert data['detail']['id'] == 'INVALID_PERMISSION_LEVEL'
+
+
+    def test_enable_subscriber_not_found(self, with_client, make_basic_subscriber):
+        # make our current subscriber admin
+        os.environ['APP_ADMIN_ALLOW_LIST'] = '@example.org'
+
+        # disable a subscriber that doesn't exist
+        response = with_client.put(
+            '/subscriber/enable/this-user-does-not-exist@someemail.com', headers=auth_headers
+        )
+
+        assert response.status_code == 404, response.text
+        data = response.json()
+        assert data['detail']['id'] == 'SUBSCRIBER_NOT_FOUND'
+
+
+    def test_enable_subscriber_no_admin(self, with_client):
+        # ensure our current subscriber is not admin
+        os.environ['APP_ADMIN_ALLOW_LIST'] = '@notexample.org'
+
+        response = with_client.put(
+            f'/subscriber/enable/{os.getenv('TEST_USER_EMAIL')}', headers=auth_headers
+        )
+
+        assert response.status_code == 401, response.text
+        data = response.json()
+        assert data['detail']['id'] == 'INVALID_PERMISSION_LEVEL'

--- a/backend/test/integration/test_subscriber.py
+++ b/backend/test/integration/test_subscriber.py
@@ -91,8 +91,10 @@ class TestSubscriber:
         data = response.json()
         subscriber_ret = data[len(data) -1]
         assert subscriber_ret['time_deleted'] is not None
-        today = datetime.today().strftime('%Y-%m-%d')
-        assert today in subscriber_ret['time_deleted']
+
+        today = today = datetime.today().date()
+        date_deleted = datetime.fromisoformat(subscriber_ret['time_deleted']).date()
+        assert date_deleted == today
 
         # attempt to disable same subscriber again, expect fail
         response = with_client.put(


### PR DESCRIPTION
I analyzed the existing integration tests against the backend API (and created [this google sheet](https://docs.google.com/spreadsheets/d/1tbfXML-FsBRns_ayibhf6R_uHbTL_pWDGTJpRdldMdI/edit?usp=sharing)). This PR adds new integration tests to expand test coverage and fill in some of the gaps that I noticed. Sorry it's a bit of a larger PR than I had originally anticipated.

I tested by running all of the tests locally (and also they're green in CI on this PR's related `validate-backend` checks).