### PR TITLE
Fix RemoteCalendarConnectionError init

### DIFF
--- a/backend/src/appointment/exceptions/validation.py
+++ b/backend/src/appointment/exceptions/validation.py
@@ -207,7 +207,7 @@ class RemoteCalendarConnectionError(APIException):
     status_code = 400
     reason = None
 
-    def __init__(self, reason: str|None, **kwargs):
+    def __init__(self, reason: str|None = None, **kwargs):
         if reason:
             self.reason = reason
         super().__init__(**kwargs)


### PR DESCRIPTION
When a `RemoteCalendarConnectionError()` is raised and no reason is provided the result is a TypeErrror:

```
>               raise RemoteCalendarConnectionError()
E               TypeError: RemoteCalendarConnectionError.__init__() missing 1 required positional argument: 'reason'
```

The fix is to have the RemoteCalendarConnectionError() reason parameter to have a default value of None.