### PR TITLE
Upgrade sentry-sdk

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,7 +20,7 @@ python-dotenv==1.0.1
 python-multipart==0.0.18
 PyJWT==2.6.0
 pydantic[email]==2.9.2
-sentry-sdk==2.10.0
+sentry-sdk==2.20.0
 starlette-context==0.3.6
 sqlalchemy-utils==0.41.2
 sqlalchemy==2.0.36


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This PR just upgrades sentry-sdk from 2.10.0 to 2.20.0.

## Benefits

This seems to fix issues on calling `sentry_sdk.capture_exception(e)`.

## Applicable Issues

Closes #825 
