### PR TITLE
Enable linting in CI, and add frontend build step in validate

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -158,6 +158,10 @@ jobs:
         run: |
           coverage report
 
+      - name: Backend lint check
+        run: |
+          cd ./backend && ruff check
+
 
   validate-frontend:
     needs: detect-changes
@@ -177,7 +181,15 @@ jobs:
         run: |
           cd ./frontend
           npm install
-          
+
+      - name: Build frontend
+        run: |
+          cd ./frontend && npm run build
+
       - name: Test with vitest
         run: |
           cd ./frontend && npm run test -- --run
+
+      - name: Frontend lint check
+        run: |
+          cd ./frontend && npm run lint

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -146,6 +146,10 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e .'[test]'
 
+      - name: Backend lint check
+        run: |
+          cd ./backend && ruff check
+
       - name: Test with pytest
         working-directory: ./backend
         run: |
@@ -157,11 +161,6 @@ jobs:
         continue-on-error: true
         run: |
           coverage report
-
-      - name: Backend lint check
-        run: |
-          cd ./backend && ruff check
-
 
   validate-frontend:
     needs: detect-changes
@@ -182,6 +181,10 @@ jobs:
           cd ./frontend
           npm install
 
+      - name: Frontend lint check
+        run: |
+          cd ./frontend && npm run lint
+
       - name: Build frontend
         run: |
           cd ./frontend && npm run build
@@ -189,7 +192,3 @@ jobs:
       - name: Test with vitest
         run: |
           cd ./frontend && npm run test -- --run
-
-      - name: Frontend lint check
-        run: |
-          cd ./frontend && npm run lint

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -25,6 +25,7 @@ test = [
     "pytest==8.2.2",
     "freezegun==1.5.1",
     "coverage==7.6.1",
+    "ruff==0.9.3",
 ]
 deploy = ['appointment[cli]', 'appointment[db]']
 


### PR DESCRIPTION
This PR does a few things:

- Adds a frontend ESLINT `npm run lint` linting step in the GHA frontend validation 
- Adds a backend `ruff check` linting step in the GHA backend validation
- Adds a frontend build step (`npm run build`) during the frontend GHA validation as previously the frontend tests were run but no actual build was done, so build errors were not caught

**Note: Once this lands, the GHA validate job will start failing if there are linting errors. Therefore my other PRs must land first (which fix existing lint errors): #836  and #843.**