### PR TITLE
Remove references to prod in env var names

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -240,10 +240,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     env:
-      APPT_PROD_LOGIN_EMAIL: ${{ secrets.E2E_APPT_PROD_LOGIN_EMAIL }}
-      APPT_PROD_LOGIN_PWORD: ${{ secrets.E2E_APPT_PROD_LOGIN_PASSWORD }}
-      APPT_PROD_DISPLAY_NAME: ${{ secrets.E2E_APPT_PROD_DISPLAY_NAME }}
-      APPT_PROD_MY_SHARE_LINK: ${{ secrets.E2E_APPT_PROD_MY_SHARE_LINK }}
+      APPT_LOGIN_EMAIL: ${{ secrets.E2E_APPT_PROD_LOGIN_EMAIL }}
+      APPT_LOGIN_PWORD: ${{ secrets.E2E_APPT_PROD_LOGIN_PASSWORD }}
+      APPT_DISPLAY_NAME: ${{ secrets.E2E_APPT_PROD_DISPLAY_NAME }}
+      APPT_MY_SHARE_LINK: ${{ secrets.E2E_APPT_PROD_MY_SHARE_LINK }}
       APPT_BOOKING_REQUESTER_EMAIL: ${{ secrets.E2E_APPT_PROD_BOOKING_REQUESTER_EMAIL }}
     steps:
       - uses: actions/checkout@v4
@@ -270,5 +270,5 @@ jobs:
       - name: Run Playwright Tests on Browserstack
         run: |
           cd ./test/e2e
-          cp .env.example .env
+          cp .env.prod.example .env
           npm run prod-sanity-test-browserstack-gha

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     env:
-      APPT_PROD_LOGIN_EMAIL: ${{ secrets.E2E_APPT_PROD_LOGIN_EMAIL }}
-      APPT_PROD_LOGIN_PWORD: ${{ secrets.E2E_APPT_PROD_LOGIN_PASSWORD }}
-      APPT_PROD_DISPLAY_NAME: ${{ secrets.E2E_APPT_PROD_DISPLAY_NAME }}
-      APPT_PROD_MY_SHARE_LINK: ${{ secrets.E2E_APPT_PROD_MY_SHARE_LINK }}
+      APPT_LOGIN_EMAIL: ${{ secrets.E2E_APPT_PROD_LOGIN_EMAIL }}
+      APPT_LOGIN_PWORD: ${{ secrets.E2E_APPT_PROD_LOGIN_PASSWORD }}
+      APPT_DISPLAY_NAME: ${{ secrets.E2E_APPT_PROD_DISPLAY_NAME }}
+      APPT_MY_SHARE_LINK: ${{ secrets.E2E_APPT_PROD_MY_SHARE_LINK }}
       APPT_BOOKING_REQUESTER_EMAIL: ${{ secrets.E2E_APPT_PROD_BOOKING_REQUESTER_EMAIL }}
     steps:
       - uses: actions/checkout@v4
@@ -50,5 +50,5 @@ jobs:
       - name: Run Playwright Tests on Browserstack
         run: |
           cd ./test/e2e
-          cp .env.example .env
+          cp .env.prod.example .env
           npm run prod-sanity-test-browserstack-gha

--- a/test/e2e/.env.prod.example
+++ b/test/e2e/.env.prod.example
@@ -1,19 +1,19 @@
 # Appointment E2E Test Configuration
 
 # URLs
-APPT_PROD_URL=https://appointment.day/
-APPT_PROD_SHORT_SHARE_LINK_PREFIX=https://apmt.day/
-APPT_PROD_LONG_SHARE_LINK_PREFIX=https://appointment.day/user/
+APPT_URL=https://appointment.day/
+APPT_SHORT_SHARE_LINK_PREFIX=https://apmt.day/
+APPT_LONG_SHARE_LINK_PREFIX=https://appointment.day/user/
 
-# Production sign-in (FxA) credentials
-APPT_PROD_LOGIN_EMAIL=
-APPT_PROD_LOGIN_PWORD=
+# Sign-in (FxA) credentials
+APPT_LOGIN_EMAIL=
+APPT_LOGIN_PWORD=
 
 # Appointment user display name (settings => account => display name) for above user
-APPT_PROD_DISPLAY_NAME=
+APPT_DISPLAY_NAME=
 
-# Production booking share link for the existing user above (settings => account => my link)
-APPT_PROD_MY_SHARE_LINK=
+# Booking share link for the existing user above (settings => account => my link)
+APPT_MY_SHARE_LINK=
 
 # Booking requester's name and email address (used when a booking slot is requested via the
 # share link). Important: real appointment booking emails will be sent to the provided email.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -30,19 +30,19 @@ This includes the existing Appointment account's email address, password, user's
 The display name is found in Appointment => Settings => Account => Display name.
 The share link is found in Appointment => Settings => Account => My Link.
 The tests also require an email address to be used when actually requesting bookings. This is the email address entered on the `Book selection` dialog (after an appoitment slot was selected on the booking share link page). Note that real Appointment emails will be sent to this email address.
-First copy over the provided `.example.env` to a local `.env`:
+First copy over the provided `.env.prod.example` to a local `.env`:
 
 ```bash
 cd test/e2e
-cp .env.example .env
+cp .env.prod.example .env
 ```
 
 Then edit your local `.env` file and provide the following values:
 ```dotenv
-APPT_PROD_LOGIN_EMAIL=<existing-test-FxA-user-email>
-APPT_PROD_LOGIN_PWORD=<exisiting-test-FxA-user-password>
-APPT_PROD_DISPLAY_NAME=<appointment-user-display-name>
-APPT_PROD_MY_SHARE_LINK=<apointment-user-share-link>
+APPT_LOGIN_EMAIL=<existing-test-FxA-user-email>
+APPT_LOGIN_PWORD=<exisiting-test-FxA-user-password>
+APPT_DISPLAY_NAME=<appointment-user-display-name>
+APPT_MY_SHARE_LINK=<apointment-user-share-link>
 APPT_BOOKING_REQUESTER_EMAIL=<booking-requesters-email>
 ```
 
@@ -73,10 +73,10 @@ You can run the E2E tests from your local machine but against browsers provided 
 Once you have credentials for an existing Appointemnt test account, edit your local `.env` file and add these details (more information found above):
 
 ```dotenv
-APPT_PROD_LOGIN_EMAIL=<existing-test-FxA-user-email>
-APPT_PROD_LOGIN_PWORD=<exisiting-test-FxA-user-password>
-APPT_PROD_DISPLAY_NAME=<appointment-user-display-name>
-APPT_PROD_MY_SHARE_LINK=<apointment-user-share-link>
+APPT_LOGIN_EMAIL=<existing-test-FxA-user-email>
+APPT_LOGIN_PWORD=<exisiting-test-FxA-user-password>
+APPT_DISPLAY_NAME=<appointment-user-display-name>
+APPT_MY_SHARE_LINK=<apointment-user-share-link>
 APPT_BOOKING_REQUESTER_EMAIL=<booking-requesters-email>
 ```
 

--- a/test/e2e/const/constants.ts
+++ b/test/e2e/const/constants.ts
@@ -1,20 +1,20 @@
 // appointment urls
-export const APPT_PROD_URL = String(process.env.APPT_PROD_URL);
-export const APPT_PROD_MY_SHARE_LINK = String(process.env.APPT_PROD_MY_SHARE_LINK);
-export const APPT_PROD_SHORT_SHARE_LINK_PREFIX = String(process.env.APPT_PROD_SHORT_SHARE_LINK_PREFIX);
-export const APPT_PROD_LONG_SHARE_LINK_PREFIX = String(process.env.APPT_PROD_LONG_SHARE_LINK_PREFIX);
-export const APPT_PROD_PENDING_BOOKINGS_PAGE = `${process.env.APPT_PROD_URL}bookings/pending`;
+export const APPT_URL = String(process.env.APPT_URL);
+export const APPT_MY_SHARE_LINK = String(process.env.APPT_MY_SHARE_LINK);
+export const APPT_SHORT_SHARE_LINK_PREFIX = String(process.env.APPT_SHORT_SHARE_LINK_PREFIX);
+export const APPT_LONG_SHARE_LINK_PREFIX = String(process.env.APPT_LONG_SHARE_LINK_PREFIX);
+export const APPT_PROD_PENDING_BOOKINGS_PAGE = `${process.env.APPT_URL}bookings/pending`;
 
 // page titles
 export const APPT_PAGE_TITLE = 'Thunderbird Appointment';
 export const FXA_PAGE_TITLE = 'Mozilla accounts';
 
 // production sign-in credentials and corresponding account display name
-export const PROD_LOGIN_EMAIL = String(process.env.APPT_PROD_LOGIN_EMAIL);
-export const PROD_LOGIN_PWORD = String(process.env.APPT_PROD_LOGIN_PWORD);
+export const PROD_LOGIN_EMAIL = String(process.env.APPT_LOGIN_EMAIL);
+export const PROD_LOGIN_PWORD = String(process.env.APPT_LOGIN_PWORD);
 
 // appointment user display name (settings => account) for above user
-export const PROD_DISPLAY_NAME = String(process.env.APPT_PROD_DISPLAY_NAME);
+export const PROD_DISPLAY_NAME = String(process.env.APPT_DISPLAY_NAME);
 
 // appointment requester's name and email address
 export const APPT_BOOKING_REQUESTER_NAME = String(process.env.APPT_BOOKING_REQUESTER_NAME);

--- a/test/e2e/pages/booking-page.ts
+++ b/test/e2e/pages/booking-page.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import { type Page, type Locator } from '@playwright/test';
-import { APPT_PROD_MY_SHARE_LINK, APPT_PROD_SHORT_SHARE_LINK_PREFIX, APPT_PROD_LONG_SHARE_LINK_PREFIX } from '../const/constants';
+import { APPT_MY_SHARE_LINK, APPT_SHORT_SHARE_LINK_PREFIX, APPT_LONG_SHARE_LINK_PREFIX } from '../const/constants';
 
 export class BookingPage {
   readonly page: Page;
@@ -40,7 +40,7 @@ export class BookingPage {
    */
   async gotoBookingPageShortUrl() {
     // the default share link is a short URL
-    await this.page.goto(APPT_PROD_MY_SHARE_LINK);
+    await this.page.goto(APPT_MY_SHARE_LINK);
     await this.page.waitForLoadState('domcontentloaded');
   }
 
@@ -49,8 +49,8 @@ export class BookingPage {
    */
   async gotoBookingPageLongUrl() {
     // the share link is short by default; build the corresponding long link first
-    const prodShareLinkUser: string = APPT_PROD_MY_SHARE_LINK.split(APPT_PROD_SHORT_SHARE_LINK_PREFIX)[1];
-    const longLink: string = `${APPT_PROD_LONG_SHARE_LINK_PREFIX}${prodShareLinkUser}`;
+    const prodShareLinkUser: string = APPT_MY_SHARE_LINK.split(APPT_SHORT_SHARE_LINK_PREFIX)[1];
+    const longLink: string = `${APPT_LONG_SHARE_LINK_PREFIX}${prodShareLinkUser}`;
     await this.page.goto(longLink);
     await this.page.waitForLoadState('domcontentloaded');
   }
@@ -59,7 +59,7 @@ export class BookingPage {
    * Go to the booking page week view (via the booking share link)
    */
   async gotoBookingPageWeekView() {
-    const weekLink: string = `${APPT_PROD_MY_SHARE_LINK}#week`;
+    const weekLink: string = `${APPT_MY_SHARE_LINK}#week`;
     await this.page.goto(weekLink);
     await this.page.waitForLoadState('domcontentloaded');
     await expect(this.confirmBtn).toBeVisible({ timeout: 30_000 });

--- a/test/e2e/pages/fxa-page.ts
+++ b/test/e2e/pages/fxa-page.ts
@@ -17,7 +17,7 @@ export class FxAPage {
   }
 
   async signIn() {
-    expect(PROD_LOGIN_PWORD, 'getting APPT_PROD_LOGIN_PWORD env var').toBeTruthy();
+    expect(PROD_LOGIN_PWORD, 'getting APPT_LOGIN_PWORD env var').toBeTruthy();
     await this.passwordInput.fill(String(PROD_LOGIN_PWORD));
     await this.signInButton.click();
   }

--- a/test/e2e/pages/splashscreen-page.ts
+++ b/test/e2e/pages/splashscreen-page.ts
@@ -1,5 +1,5 @@
 import { expect, type Page, type Locator } from '@playwright/test';
-import { APPT_PROD_URL, PROD_LOGIN_EMAIL, FXA_PAGE_TITLE } from '../const/constants';
+import { APPT_URL, PROD_LOGIN_EMAIL, FXA_PAGE_TITLE } from '../const/constants';
 
 export class SplashscreenPage {
   readonly page: Page;
@@ -17,7 +17,7 @@ export class SplashscreenPage {
   }
 
   async gotoProd() {
-    await this.page.goto(APPT_PROD_URL);
+    await this.page.goto(APPT_URL);
     await this.page.waitForLoadState('domcontentloaded');
   }
 
@@ -38,7 +38,7 @@ export class SplashscreenPage {
     await this.clickLoginBtn();
     await expect(this.loginEmailInput).toBeVisible();
     await expect(this.loginContinueBtn).toBeVisible();
-    expect(PROD_LOGIN_EMAIL, 'getting APPT_PROD_LOGIN_EMAIL env var').toBeTruthy();
+    expect(PROD_LOGIN_EMAIL, 'getting APPT_LOGIN_EMAIL env var').toBeTruthy();
     await this.enterLoginEmail(String(PROD_LOGIN_EMAIL))
     await this.clickLoginContinueBtn();
     await expect(this.page).toHaveTitle(FXA_PAGE_TITLE, { timeout: 30_000 }); // be generous in case FxA is slow to load

--- a/test/e2e/utils/utils.ts
+++ b/test/e2e/utils/utils.ts
@@ -3,14 +3,14 @@ import { SplashscreenPage } from "../pages/splashscreen-page";
 import { FxAPage } from "../pages/fxa-page";
 import { DashboardPage } from "../pages/dashboard-page";
 import { expect, type Page } from '@playwright/test';
-import { APPT_PROD_URL, APPT_PAGE_TITLE } from "../const/constants";
+import { APPT_URL, APPT_PAGE_TITLE } from "../const/constants";
 
 /**
  * Navigate to and sign into the Appointment application using the production URL and
  * production credentials provided in the .env file.
  */
 export const navigateToAppointmentProdAndSignIn = async (page: Page) => {
-    console.log(`navigating to appointment production (${APPT_PROD_URL}) and signing in`);
+    console.log(`navigating to appointment production (${APPT_URL}) and signing in`);
     const homePage = new SplashscreenPage(page);
     const signInPage = new FxAPage(page);
     const dashboardPage = new DashboardPage(page);


### PR DESCRIPTION
In order to allow the E2E tests to run on environments other than production, the first step is to rename the environment variables to be generic (remove `prod` references) and also make a new `.env.prod.example` env vars file. This will clear the way to add more supported environments (i.e. stage).