### PR TITLE
Calculate the cipher length and base64 length ahead of time. (Fixes #853)

### DIFF
--- a/backend/src/appointment/database/models.py
+++ b/backend/src/appointment/database/models.py
@@ -96,9 +96,17 @@ class TimeMode(enum.Enum):
     h24 = 24
 
 
+def calculate_encrypted_length(length: int):
+    """Calculate the length of the string after it's been encrypted and encoded."""
+    cipher_length = length + 16 - (length % 16)  # Fixed block size of 16 for Aes
+    return int((cipher_length + 2) / 3) << 2  # Base64 with padding
+
+
 def encrypted_type(column_type, length: int = 255, **kwargs) -> StringEncryptedType:
     """Helper to reduce visual noise when creating model columns"""
-    return StringEncryptedType(column_type, secret, AesEngine, 'pkcs5', length=length, **kwargs)
+    return StringEncryptedType(
+        column_type, secret, AesEngine, 'pkcs5', length=calculate_encrypted_length(length), **kwargs
+    )
 
 
 @as_declarative()
@@ -441,6 +449,7 @@ class Invite(Base):
 
 class WaitingList(Base):
     """Holds a list of hopefully future-Appointment users"""
+
     __tablename__ = 'waiting_list'
 
     id = Column(Integer, primary_key=True, index=True)

--- a/backend/src/appointment/database/schemas.py
+++ b/backend/src/appointment/database/schemas.py
@@ -166,8 +166,8 @@ class ScheduleBase(BaseModel):
     slug: Optional[str] = None
     calendar_id: int
     location_type: LocationType | None = LocationType.inperson
-    location_url: str | None = None
-    details: str | None = None
+    location_url: str | None = Field(max_length=2048)
+    details: str | None = Field(max_length=250)
     start_date: date | None = None
     end_date: date | None = None
     start_time: time | None = None

--- a/backend/src/appointment/migrations/versions/2025_02_05_1839-645fd31f827d_clean_invalid_schedule_details.py
+++ b/backend/src/appointment/migrations/versions/2025_02_05_1839-645fd31f827d_clean_invalid_schedule_details.py
@@ -1,0 +1,40 @@
+"""clean invalid schedule details
+
+Revision ID: 645fd31f827d
+Revises: 4a15d01919b8
+Create Date: 2025-02-05 18:39:12.277713
+
+"""
+import binascii
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+import base64
+
+# revision identifiers, used by Alembic.
+revision = '645fd31f827d'
+down_revision = '4a15d01919b8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    session = Session(op.get_bind())
+    bad_fields_found = 0
+    rows = session.execute(sa.text('SELECT id, details FROM schedules WHERE details is not null;')).all()
+    for row in rows:
+        id, details = row
+        try:
+            base64.b64decode(details)
+        except binascii.Error:
+            bad_fields_found += 1
+            statement = sa.text('UPDATE schedules SET details = NULL WHERE id = :id')
+            statement = statement.bindparams(id=id)
+            op.execute(statement)
+
+    print(f'Nulled {bad_fields_found} schedules.details fields.')
+
+
+def downgrade() -> None:
+    pass

--- a/backend/src/appointment/migrations/versions/2025_02_05_1859-16c0299eff23_update_enc_field_lengths.py
+++ b/backend/src/appointment/migrations/versions/2025_02_05_1859-16c0299eff23_update_enc_field_lengths.py
@@ -1,0 +1,411 @@
+"""update enc field lengths
+
+Revision ID: 16c0299eff23
+Revises: 645fd31f827d
+Create Date: 2025-02-05 18:59:31.214328
+
+"""
+import sqlalchemy_utils
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import String
+from sqlalchemy.dialects import mysql
+
+from appointment.database.models import calculate_encrypted_length
+
+# revision identifiers, used by Alembic.
+revision = '16c0299eff23'
+down_revision = '645fd31f827d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column('appointments', 'title',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('appointments', 'location_name',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('appointments', 'location_url',
+               existing_type=mysql.VARCHAR(length=2048),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(2048)),
+               existing_nullable=True)
+    op.alter_column('appointments', 'location_phone',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('appointments', 'details',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('appointments', 'slug',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('appointments', 'external_id',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('appointments', 'meeting_link_provider',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('attendees', 'email',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('attendees', 'name',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('availabilities', 'day_of_week',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('availabilities', 'start_time',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('availabilities', 'end_time',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('availabilities', 'min_time_before_meeting',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('calendars', 'title',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('calendars', 'color',
+               existing_type=mysql.VARCHAR(length=32),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(32)),
+               existing_nullable=True)
+    op.alter_column('calendars', 'url',
+               existing_type=mysql.VARCHAR(length=2048),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(2048)),
+               existing_nullable=True)
+    op.alter_column('calendars', 'user',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('calendars', 'password',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('external_connections', 'name',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('external_connections', 'type',
+               existing_type=mysql.ENUM('zoom', 'google', 'fxa', 'caldav'),
+               nullable=True)
+    op.alter_column('external_connections', 'type_id',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('external_connections', 'token',
+               existing_type=mysql.VARCHAR(length=2048),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(2048)),
+               existing_nullable=True)
+    op.alter_column('invites', 'code',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('schedules', 'name',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('schedules', 'slug',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('schedules', 'location_url',
+               existing_type=mysql.VARCHAR(length=2048),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(2048)),
+               existing_nullable=True)
+    op.alter_column('schedules', 'details',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('schedules', 'start_date',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('schedules', 'end_date',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('schedules', 'start_time',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('schedules', 'end_time',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('schedules', 'timezone',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('schedules', 'meeting_link_provider',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('slots', 'meeting_link_id',
+               existing_type=mysql.VARCHAR(length=1024),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(1024)),
+               existing_nullable=True)
+    op.alter_column('slots', 'meeting_link_url',
+               existing_type=mysql.VARCHAR(length=2048),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(2048)),
+               existing_nullable=True)
+    op.alter_column('slots', 'booking_tkn',
+               existing_type=mysql.VARCHAR(length=512),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(512)),
+               existing_nullable=True)
+    op.alter_column('subscribers', 'username',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('subscribers', 'password',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('subscribers', 'email',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('subscribers', 'secondary_email',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('subscribers', 'name',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('subscribers', 'avatar_url',
+               existing_type=mysql.VARCHAR(length=2048),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(2048)),
+               existing_nullable=True)
+    op.alter_column('subscribers', 'short_link_hash',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('subscribers', 'language',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=False)
+    op.alter_column('subscribers', 'timezone',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('subscribers', 'minimum_valid_iat_time',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=True)
+    op.alter_column('waiting_list', 'email',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               existing_nullable=False)
+    # ### end Alembic commands ###
+
+
+def downgrade() -> None:
+    # ### commands auto generated by Alembic - please adjust! ###
+    op.alter_column('waiting_list', 'email',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=False)
+    op.alter_column('subscribers', 'minimum_valid_iat_time',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('subscribers', 'timezone',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('subscribers', 'language',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=False)
+    op.alter_column('subscribers', 'short_link_hash',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('subscribers', 'avatar_url',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(2048)),
+               type_=mysql.VARCHAR(length=2048),
+               existing_nullable=True)
+    op.alter_column('subscribers', 'name',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('subscribers', 'secondary_email',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('subscribers', 'email',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('subscribers', 'password',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('subscribers', 'username',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('slots', 'booking_tkn',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(512)),
+               type_=mysql.VARCHAR(length=512),
+               existing_nullable=True)
+    op.alter_column('slots', 'meeting_link_url',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(2048)),
+               type_=mysql.VARCHAR(length=2048),
+               existing_nullable=True)
+    op.alter_column('slots', 'meeting_link_id',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(1024)),
+               type_=mysql.VARCHAR(length=1024),
+               existing_nullable=True)
+    op.alter_column('schedules', 'meeting_link_provider',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('schedules', 'timezone',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('schedules', 'end_time',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('schedules', 'start_time',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('schedules', 'end_date',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('schedules', 'start_date',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('schedules', 'details',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('schedules', 'location_url',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(2048)),
+               type_=mysql.VARCHAR(length=2048),
+               existing_nullable=True)
+    op.alter_column('schedules', 'slug',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('schedules', 'name',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('invites', 'code',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('external_connections', 'token',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(2048)),
+               type_=mysql.VARCHAR(length=2048),
+               existing_nullable=True)
+    op.alter_column('external_connections', 'type_id',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('external_connections', 'type',
+               existing_type=mysql.ENUM('zoom', 'google', 'fxa', 'caldav'),
+               nullable=False)
+    op.alter_column('external_connections', 'name',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('calendars', 'password',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('calendars', 'user',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('calendars', 'url',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(2048)),
+               type_=mysql.VARCHAR(length=2048),
+               existing_nullable=True)
+    op.alter_column('calendars', 'color',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(32)),
+               type_=mysql.VARCHAR(length=32),
+               existing_nullable=True)
+    op.alter_column('calendars', 'title',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('availabilities', 'min_time_before_meeting',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('availabilities', 'end_time',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('availabilities', 'start_time',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('availabilities', 'day_of_week',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('attendees', 'name',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('attendees', 'email',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('appointments', 'meeting_link_provider',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('appointments', 'external_id',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('appointments', 'slug',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('appointments', 'details',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('appointments', 'location_phone',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('appointments', 'location_url',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(2048)),
+               type_=mysql.VARCHAR(length=2048),
+               existing_nullable=True)
+    op.alter_column('appointments', 'location_name',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.alter_column('appointments', 'title',
+               existing_type=mysql.VARCHAR(length=calculate_encrypted_length(255)),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    # ### end Alembic commands ###

--- a/backend/test/unit/test_models.py
+++ b/backend/test/unit/test_models.py
@@ -1,6 +1,32 @@
 import pytest
 from sqlalchemy.exc import IntegrityError
 from appointment.database import models, repo, schemas
+from appointment.database.models import calculate_encrypted_length
+from appointment.utils import encrypt
+
+
+class TestMisc:
+    def test_calculate_encrypted_length(self, faker):
+        """Ensures an encrypted string is equal to our length calc method.
+        We have a list of clear_strs which are random bits of text with variable length.
+        We encrypt it (same method used for db fields) and run it through our calculate method,
+        and assert they are the same length"""
+        clear_strs = [
+            'a',
+            faker.text(max_nb_chars=7),
+            faker.text(max_nb_chars=32),
+            faker.text(max_nb_chars=64),
+            faker.text(max_nb_chars=82),
+            faker.text(max_nb_chars=128),
+            faker.text(max_nb_chars=250),
+            faker.text(max_nb_chars=256),
+            faker.text(max_nb_chars=300),
+            faker.text(max_nb_chars=512),
+            faker.text(max_nb_chars=1024),
+            faker.text(max_nb_chars=2048),
+        ]
+        for i, clear_str in enumerate(clear_strs):
+            assert len(encrypt(clear_str)) == calculate_encrypted_length(len(clear_str))
 
 
 class TestAppointment:


### PR DESCRIPTION
Fixes #853

I also added a clean-up migration right before the field length change to fix an existing user's schedules.details field which is currently erroring out. I'm not sure how that happened because I got a mysql truncate error on submitting 250 characters, but maybe prod is setup in non-strict mode. (spooky if true)

I've tested lengths manually via the application, and added a test to automate some existing cases we have. 

The type length migration was generated via alembic's autogenerate command (with a small edit to env.py that I didn't commit.) and tweaked to fix the autogen errors. It's a scary migration, but the function is tested, and we have stage to potentially nuke if needed.  