### PR TITLE
Fix inline icons in invitation email

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -97,10 +97,10 @@ When running locally and looking into code coverage further you may wish to gene
 ```bash
 coverage html
 ```
+
 Then open the resulting `backend/htmlcov/index.html` file in your browser and you can click down into individual source files to see which statements were (and were not) executed during the test session.
 
 Note that the code coverage report will contain the coverage generated for all the tests that were ran in your pytest session; so if you want to measure the code coverage for a subset of tests just provide the test path on the `coverage run -m pytest` command as you normally would, then generate the coverage report(s).
-
 
 ## Database Migrations
 

--- a/backend/src/appointment/controller/mailer.py
+++ b/backend/src/appointment/controller/mailer.py
@@ -251,8 +251,8 @@ class InvitationMail(BaseBookingMail):
             duration=self.duration,
             # Image cids
             tbpro_logo_cid=self._attachments()[0].filename,
-            calendar_icon_cid=self._attachments()[1].filename,
-            clock_icon_cid=self._attachments()[2].filename,
+            calendar_icon_cid=self._attachments()[2].filename,
+            clock_icon_cid=self._attachments()[3].filename,
         )
 
 


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This PR fixes indices of inline images in the invitation email. Maybe for the future it's better to work with dictionary keys instead of positional list keys for attachements.

## Benefits

Fixes a broken icon image.

## Applicable Issues

Closes #856 
