### PR TITLE
Fix grammatical mistake in frontend English messages

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -450,7 +450,7 @@
     "recipientsCanScheduleBetween": "Recipients can schedule a {duration} appointment between {earliest} and {farthest} ahead of time.",
     "redirectedNotice": "You are being redirected to {url}.",
     "refreshLinkNotice": "This refreshes your link. Your old links will no longer work.",
-    "requestInformationSentToOwner": "An information about this booking request has been emailed to the owner.",
+    "requestInformationSentToOwner": "Information about this booking request has been emailed to the owner.",
     "scheduleSettings": {
       "clickHereToConnect": "Click here to connect a calendar!",
       "create": "Select a calendar under Scheduling details and click save to get started!",


### PR DESCRIPTION
## Description of the Change

Quick change fixing a typo in one of the UI messages. "Information" is usually an uncountable noun in English, including in this case.

## Benefits

Minor improvement in user experience

## Applicable Issues

N/A
