### PR TITLE
Update the download data readme and make filenames consistent

### DIFF
--- a/backend/src/appointment/controller/data.py
+++ b/backend/src/appointment/controller/data.py
@@ -71,10 +71,10 @@ def download(db, subscriber: Subscriber):
     with ZipFile(zip_buffer, 'w') as data_zip:
         data_zip.writestr('attendees.csv', attendee_buffer.getvalue())
         data_zip.writestr('appointments.csv', appointment_buffer.getvalue())
-        data_zip.writestr('calendar.csv', calendar_buffer.getvalue())
+        data_zip.writestr('calendars.csv', calendar_buffer.getvalue())
         data_zip.writestr('subscriber.csv', subscriber_buffer.getvalue())
-        data_zip.writestr('slot.csv', slot_buffer.getvalue())
-        data_zip.writestr('external_connection.csv', external_connections_buffer.getvalue())
+        data_zip.writestr('slots.csv', slot_buffer.getvalue())
+        data_zip.writestr('external_connections.csv', external_connections_buffer.getvalue())
         data_zip.writestr('schedules.csv', schedules_buffer.getvalue())
         data_zip.writestr('availability.csv', availability_buffer)
         data_zip.writestr('invite.csv', invite_buffer.getvalue())

--- a/backend/src/appointment/l10n/de/main.ftl
+++ b/backend/src/appointment/l10n/de/main.ftl
@@ -143,14 +143,14 @@ account-data-readme = ===============================================
                       Hinweis: Wenn eine Datei leer ist, ist diese Art von Daten nicht vorhanden.
 
                       Die folgenden Dateien sind enthalten:
-                       - appointments.csv : Eine Liste vereinbarter Termine aus unserer Datenbank
-                       - attendees.csv : Eine Liste von Termin-Teilnehmern aus unserer Datenbank
-                       - availability.csv : Daten zu Verfügbarkeiten aus unserer Datenbank
-                       - calendars.csv : Eine Liste von Kalendern aus unserer Datenbank
-                       - external_connections.csv : Eine Liste von Verbindungen zu externen Diensten aus unserer Datenbank
+                       - appointments.csv : Eine Liste Deiner vereinbarten Termine
+                       - attendees.csv : Eine Liste von Teilnehmern Deiner Termine
+                       - availability.csv : Daten zu Verfügbarkeiten
+                       - calendars.csv : Eine Liste Deiner Kalender
+                       - external_connections.csv : Eine Liste eingerichteter Verbindungen zu externen Diensten
                        - invite.csv : Daten zu Termineinladungen und Einladungscodes
-                       - schedules.csv : Die von uns gespeicherten Informationen zum Zeitplan
-                       - slots.csv : Eine Liste generierter Zeitfenster aus unserer Datenbank
+                       - schedules.csv : Die von uns gespeicherten Informationen Deines Zeitplans
+                       - slots.csv : Eine Liste generierter Zeitfenster Deines Zeitplans
                        - subscriber.csv : Deine Profil- und Kontoinformationen
                        - waiting_list.csv : Von uns gespeicherte Informationen zur Warteliste für Termine
                        - readme.txt : Diese Datei

--- a/backend/src/appointment/l10n/de/main.ftl
+++ b/backend/src/appointment/l10n/de/main.ftl
@@ -143,14 +143,14 @@ account-data-readme = ===============================================
                       Hinweis: Wenn eine Datei leer ist, ist diese Art von Daten nicht vorhanden.
 
                       Die folgenden Dateien sind enthalten:
-                       - appointments.csv : Eine Liste von Terminen aus unserer Datenbank
+                       - appointments.csv : Eine Liste vereinbarter Termine aus unserer Datenbank
                        - attendees.csv : Eine Liste von Termin-Teilnehmern aus unserer Datenbank
-                       - availability.csv : Planen Sie Verfügbarkeitsdaten aus unserer Datenbank
+                       - availability.csv : Daten zu Verfügbarkeiten aus unserer Datenbank
                        - calendars.csv : Eine Liste von Kalendern aus unserer Datenbank
-                       - external_connections.csv : Eine Liste Ihrer externen Terminverbindungen aus unserer Datenbank
-                       - invite.csv : Daten zu Ihrer Termineinladung und Einladungscodes
-                       - schedules.csv : Die von uns gespeicherten Informationen zu Ihrem Terminplan
-                       - slots.csv : Eine Liste von Zeitfenstern aus unserer Datenbank.
-                       - subscriber.csv : Die persönlichen Informationen, die wir von Benutzern in unserer Datenbank speichern
+                       - external_connections.csv : Eine Liste von Verbindungen zu externen Diensten aus unserer Datenbank
+                       - invite.csv : Daten zu Termineinladungen und Einladungscodes
+                       - schedules.csv : Die von uns gespeicherten Informationen zum Zeitplan
+                       - slots.csv : Eine Liste generierter Zeitfenster aus unserer Datenbank
+                       - subscriber.csv : Deine Profil- und Kontoinformationen
                        - waiting_list.csv : Von uns gespeicherte Informationen zur Warteliste für Termine
                        - readme.txt : Diese Datei

--- a/backend/src/appointment/l10n/de/main.ftl
+++ b/backend/src/appointment/l10n/de/main.ftl
@@ -145,7 +145,12 @@ account-data-readme = ===============================================
                       Die folgenden Dateien sind enthalten:
                        - appointments.csv : Eine Liste von Terminen aus unserer Datenbank
                        - attendees.csv : Eine Liste von Termin-Teilnehmern aus unserer Datenbank
+                       - availability.csv : Planen Sie Verfügbarkeitsdaten aus unserer Datenbank
                        - calendars.csv : Eine Liste von Kalendern aus unserer Datenbank
+                       - external_connections.csv : Eine Liste Ihrer externen Terminverbindungen aus unserer Datenbank
+                       - invite.csv : Daten zu Ihrer Termineinladung und Einladungscodes
+                       - schedules.csv : Die von uns gespeicherten Informationen zu Ihrem Terminplan
                        - slots.csv : Eine Liste von Zeitfenstern aus unserer Datenbank.
-                       - subscriber.csv : Die persönlichen Informationen, die wir von Benutzern in unserer Datenbank speichern.
+                       - subscriber.csv : Die persönlichen Informationen, die wir von Benutzern in unserer Datenbank speichern
+                       - waiting_list.csv : Von uns gespeicherte Informationen zur Warteliste für Termine
                        - readme.txt : Diese Datei

--- a/backend/src/appointment/l10n/en/main.ftl
+++ b/backend/src/appointment/l10n/en/main.ftl
@@ -145,7 +145,12 @@ account-data-readme = ============================================
                       The following files are included:
                        - appointments.csv : A list of Appointments from our database
                        - attendees.csv : A list of Appointment Slot Attendees from our database
+                       - availability.csv : Schedule availability data from our database
                        - calendars.csv : A list of Calendars from our database
-                       - slots.csv : A list of Appointment Slots from our database.
-                       - subscriber.csv : The personal information we store about you from our database.
+                       - external_connections.csv : A list of your Appointment external connections from our database
+                       - invite.csv : Data pertaining to your Appointment invite and invite codes
+                       - schedules.csv : The information we store pertaining to your Appointment schedule
+                       - slots.csv : A list of Appointment Slots from our database
+                       - subscriber.csv : The personal information we store about you from our database
+                       - waiting_list.csv : Information we store regarding the Appointment waiting list
                        - readme.txt : This file!

--- a/backend/src/appointment/l10n/en/main.ftl
+++ b/backend/src/appointment/l10n/en/main.ftl
@@ -143,14 +143,14 @@ account-data-readme = ============================================
                       Note: If a file is empty or blank then we don't have that type of data on record for you.
 
                       The following files are included:
-                       - appointments.csv : A list of Appointments from our database
-                       - attendees.csv : A list of Appointment Slot Attendees from our database
-                       - availability.csv : Schedule availability data from our database
-                       - calendars.csv : A list of Calendars from our database
-                       - external_connections.csv : A list of your Appointment external connections from our database
+                       - appointments.csv : A list of your Appointments
+                       - attendees.csv : A list of your Appointment Slot Attendees
+                       - availability.csv : Schedule availability data
+                       - calendars.csv : A list of your Appointment Calendars
+                       - external_connections.csv : A list of your Appointment external connections
                        - invite.csv : Data pertaining to your Appointment invite and invite codes
                        - schedules.csv : The information we store pertaining to your Appointment schedule
-                       - slots.csv : A list of Appointment Slots from our database
-                       - subscriber.csv : The personal information we store about you from our database
+                       - slots.csv : A list of your Appointment meeting slots
+                       - subscriber.csv : The personal information we store about you
                        - waiting_list.csv : Information we store regarding the Appointment waiting list
                        - readme.txt : This file!


### PR DESCRIPTION
While trying out the `download your data` feature I noticed the downloaded data readme is out of date, and the files are not named consistently (some are plural and some aren't). Update the readme and change the name of some of the data csv files so they are more consistent.

Here are the resulting csv files downloaded:

![Screenshot 2025-02-26 at 4 45 15 PM](https://github.com/user-attachments/assets/1d04f34f-9f42-4a8a-ad4f-6f55ab567f92)
