### PR TITLE
Fix calendar popup width in week view

### DIFF
--- a/frontend/src/components/CalendarQalendar.vue
+++ b/frontend/src/components/CalendarQalendar.vue
@@ -574,6 +574,11 @@ This was a fancy layer class, but @apply in sfc with custom layer classes is a n
   @apply opacity-50 shadow-none
 }
 
+/* Fix date selection width on week view */
+.calendar-root-wrapper .date-picker__week-picker {
+  min-width: min-content;
+}
+
 /*
 Loading bar, mostly works but needs some work and maybe a div relocation
 .calendar-root-wrapper .calendar-root .top-bar-loader {


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This PR fixes the mini-calendar popup in week view to respect the content width again.

![image](https://github.com/user-attachments/assets/dd158fab-543d-4c9b-97ab-e36004847b53)


## Benefits

Prevent content bleeding.

## Applicable Issues

Closes #886 
