### PR TITLE
Fix tooltip in schedule creation sidebar

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,7 +8,6 @@ import { storeToRefs } from 'pinia';
 import {
   apiUrlKey, callKey, refreshKey, isPasswordAuthKey, isFxaAuthKey, fxaEditProfileUrlKey,
 } from '@/keys';
-import { defaultLocale } from '@/utils';
 import { StringResponse } from '@/models';
 import { usePosthog, posthog } from '@/composables/posthog';
 import UAParser from 'ua-parser-js';
@@ -165,7 +164,7 @@ const onPageLoad = async () => {
     resolution: deviceRes,
     effective_resolution: effectiveDeviceRes,
     user_agent: navigator.userAgent,
-    locale: defaultLocale(),
+    locale: defaultLocale(), // needs to import defaultLocale from utils
   }).json();
 
   const { data } = response;

--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -127,7 +127,7 @@ const dismiss = () => {
   <!-- page content -->
   <div class="mt-8 flex flex-col-reverse items-stretch gap-2 md:flex-row-reverse lg:gap-4">
     <!-- schedule creation dialog -->
-    <div class="mx-auto mb-10 w-3/4 min-w-80 sm:w-1/4 md:mb-0 xl:w-1/6">
+    <div class="mx-auto mb-10 w-3/4 min-w-80 sm:w-1/4 md:mb-0 xl:w-1/6 z-10">
       <schedule-creation
         v-if="schedulesReady"
         :calendars="connectedCalendars"

--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -127,7 +127,7 @@ const dismiss = () => {
   <!-- page content -->
   <div class="mt-8 flex flex-col-reverse items-stretch gap-2 md:flex-row-reverse lg:gap-4">
     <!-- schedule creation dialog -->
-    <div class="mx-auto mb-10 w-3/4 min-w-80 sm:w-1/4 md:mb-0 xl:w-1/6 z-10">
+    <div class="z-10 mx-auto mb-10 w-3/4 min-w-80 sm:w-1/4 md:mb-0 xl:w-1/6">
       <schedule-creation
         v-if="schedulesReady"
         :calendars="connectedCalendars"


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This PR fixes an issue, where overflowing contents in the schedule creation sidebar were hidden behind adjacent elements. This happened because of reversed overlapping priority due to reversed flex items and got fixed by setting a z-index.

![image](https://github.com/user-attachments/assets/7942591f-72a7-4f15-868c-105cdd0855b9)

This also fixes another linter warning in App.vue.

## Benefits

Overlapping should show again.

## Applicable Issues

Closes #887 
