### PR TITLE
Add E2E tests for settings

### DIFF
--- a/frontend/src/components/CalendarManagement.vue
+++ b/frontend/src/components/CalendarManagement.vue
@@ -36,6 +36,7 @@ const filteredCalendars = computed(() => props.calendars.filter((calendar: Calen
         :disabled="loading"
         @click="emit('sync')"
         :title="t('label.sync')"
+        data-testid="calendar-settings-sync-calendars-button"
       >
         <span class="mr-2 inline-block">
           {{ t('label.syncCalendars') }}

--- a/frontend/src/components/SettingsCalendar.vue
+++ b/frontend/src/components/SettingsCalendar.vue
@@ -429,6 +429,7 @@ onMounted(async () => {
           v-model="calendarInput.data.title"
           type="text"
           class="w-full max-w-sm rounded-md"
+          data-testid="settings-calendar-title-input"
         />
       </label>
       <label v-if="isCalDav || editMode" class="flex items-center pl-4">
@@ -439,7 +440,7 @@ onMounted(async () => {
               {{ color }}
             </option>
           </select>
-          <input v-else type="text" v-model="calendarInput.data.color" class="w-full rounded-md" />
+          <input v-else type="text" data-testid="settings-calendar-color-input" v-model="calendarInput.data.color" class="w-full rounded-md" />
           <div class="size-8 shrink-0 rounded-full" :style="{ backgroundColor: calendarInput.data.color }"></div>
         </div>
       </label>

--- a/frontend/src/components/SettingsConnections.vue
+++ b/frontend/src/components/SettingsConnections.vue
@@ -135,6 +135,7 @@ const editProfile = async () => {
           v-if="!connection[0]"
           :label="t('label.connect')"
           class="btn-connect"
+          :data-testid="'connected-accounts-settings-' + t(provider) + '-connect-btn'"
           @click="() => connectAccount(providers[provider])"
           :title="t('label.connect')"
         />
@@ -142,6 +143,7 @@ const editProfile = async () => {
           v-if="connection[0]"
           :label="t('label.disconnect')"
           class="btn-disconnect"
+          :data-testid="'connected-accounts-settings-' + t(provider) + '-disconnect-btn'"
           @click="() => displayModal(providers[provider], connection[0].type_id)"
           :title="t('label.disconnect')"
         />

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -29,6 +29,7 @@ The tests expect that the default Appointment application settings haven't been 
 - The user scheduling availability hasn't been changed from the default settings;
 - In the dashboard the default calendar view is the current month view; this is important so that the tests can find an available booking slot, etc.
 - In `Booking Settings`, the `Booking Confirmation` option is enabled, so that requested appointments generate HOLD appointments that need to be confirmed
+- The timezone is set to the default of `America/Toronto`
 
 ## Running the E2E tests against your local dev environment
 

--- a/test/e2e/const/constants.ts
+++ b/test/e2e/const/constants.ts
@@ -6,8 +6,14 @@ export const APPT_URL = String(process.env.APPT_URL);
 export const APPT_MY_SHARE_LINK = String(process.env.APPT_MY_SHARE_LINK);
 export const APPT_SHORT_SHARE_LINK_PREFIX = String(process.env.APPT_SHORT_SHARE_LINK_PREFIX);
 export const APPT_LONG_SHARE_LINK_PREFIX = String(process.env.APPT_LONG_SHARE_LINK_PREFIX);
-export const APPT_PENDING_BOOKINGS_PAGE = `${process.env.APPT_URL}bookings/pending`;
-export const APPT_BOOKED_BOOKINGS_PAGE = `${process.env.APPT_URL}bookings/booked`;
+export const APPT_PENDING_BOOKINGS_PAGE = String(`${process.env.APPT_URL}bookings/pending`);
+export const APPT_BOOKED_BOOKINGS_PAGE = String(`${process.env.APPT_URL}bookings/booked`);
+export const APPT_MAIN_SETTINGS_PAGE = String(`${process.env.APPT_URL}settings`);
+export const APPT_GENERAL_SETTINGS_PAGE = String(`${process.env.APPT_URL}settings/general`);
+export const APPT_CALENDAR_SETTINGS_PAGE = String(`${process.env.APPT_URL}settings/calendar`);
+export const APPT_ACCOUNT_SETTINGS_PAGE = String(`${process.env.APPT_URL}settings/account`);
+export const APPT_CONNECTED_SETTINGS_PAGE = String(`${process.env.APPT_URL}settings/connectedAccounts`);
+export const APPT_DASHBOARD_MONTH_PAGE = String(`${process.env.APPT_URL}dashboard#month`);
 
 // page titles
 export const APPT_PAGE_TITLE = 'Thunderbird Appointment';
@@ -27,3 +33,20 @@ export const APPT_BOOKEE_EMAIL = String(process.env.APPT_BOOKEE_EMAIL);
 // playwright test tags
 export const PLAYWRIGHT_TAG_PROD_SANITY = '@prod-sanity';
 export const PLAYWRIGHT_TAG_E2E_SUITE = '@e2e-suite';
+
+// general settings options
+export const APPT_LANGUAGE_SETTING_EN = 'EN — English';
+export const APPT_LANGUAGE_SETTING_DE = 'DE — German';
+export const APPT_THEME_SETTING_LIGHT = 'Light';
+export const APPT_THEME_SETTING_DARK = 'Dark';
+export const APPT_TIMEZONE_SETTING_TORONTO = 'America/Toronto';
+export const APPT_TIMEZONE_SETTING_HALIFAX = 'America/Halifax';
+
+// html class attribute value when dark mode is enabled
+export const APPT_HTML_DARK_MODE_CLASS = 'dark';
+
+// timeouts
+export const TIMEOUT_2_SECONDS = 2_000;
+export const TIMEOUT_3_SECONDS = 3_000;
+export const TIMEOUT_30_SECONDS = 30_000;
+export const TIMEOUT_60_SECONDS = 60_000;

--- a/test/e2e/const/constants.ts
+++ b/test/e2e/const/constants.ts
@@ -42,6 +42,14 @@ export const APPT_THEME_SETTING_DARK = 'Dark';
 export const APPT_TIMEZONE_SETTING_TORONTO = 'America/Toronto';
 export const APPT_TIMEZONE_SETTING_HALIFAX = 'America/Halifax';
 
+// local browser store values
+export const APPT_BROWSER_STORE_LANGUAGE_EN = 'en';
+export const APPT_BROWSER_STORE_LANGUAGE_DE = 'de';
+export const APPT_BROWSER_STORE_THEME_LIGHT = 'light';
+export const APPT_BROWSER_STORE_THEME_DARK = 'dark';
+export const APPT_BROWSER_STORE_12HR_TIME = 12;
+export const APPT_BROWSER_STORE_24HR_TIME = 24;
+
 // html class attribute value when dark mode is enabled
 export const APPT_HTML_DARK_MODE_CLASS = 'dark';
 

--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -243,9 +243,9 @@
       }
     },
     "node_modules/@kubernetes/client-node": {
-      "version": "1.0.0-rc7",
-      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-1.0.0-rc7.tgz",
-      "integrity": "sha512-s0U74yQ/nTq13xk3YI8P2y02pUm9TritjhsCIbtPYbOrG/5ti2bY2WhxxQWGx1LhiTZPEdoULtsyXI2XrIESJw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-1.0.0.tgz",
+      "integrity": "sha512-a8NSvFDSHKFZ0sR1hbPSf8IDFNJwctEU5RodSCNiq/moRXWmrdmqhb1RRQzF+l+TSBaDgHw3YsYNxxE92STBzw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -258,15 +258,14 @@
         "form-data": "^4.0.0",
         "isomorphic-ws": "^5.0.0",
         "js-yaml": "^4.1.0",
-        "jsonpath-plus": "^10.0.0",
+        "jsonpath-plus": "^10.2.0",
         "node-fetch": "^2.6.9",
-        "openid-client": "^5.6.5",
+        "openid-client": "^6.1.3",
         "rfc4648": "^1.3.0",
         "stream-buffers": "^3.0.2",
         "tar": "^7.0.0",
         "tmp-promise": "^3.0.2",
         "tslib": "^2.5.0",
-        "url-parse": "^1.4.3",
         "ws": "^8.18.0"
       }
     },
@@ -651,9 +650,9 @@
       "license": "MIT"
     },
     "node_modules/@types/ws": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
-      "integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8svvI3hMyvN0kKCJMvTJP/x6Y/EoQbepff882wL+Sn5QsXb3etnamgrJq4isrBxSJj5L2AuXcI0+bgkoAXGUJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1082,16 +1081,16 @@
       }
     },
     "node_modules/browserstack-node-sdk": {
-      "version": "1.34.34",
-      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.34.34.tgz",
-      "integrity": "sha512-A16W7xDLc4n3i4GIwegQsNp90qoByIG+rlJpLnBGaQ+MZNknTOwKuX/JP0o8E4rq1aVLv6hx5v6aDKDVcDmNSw==",
+      "version": "1.34.45",
+      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.34.45.tgz",
+      "integrity": "sha512-GYwpxPkW/zkiiDU9ES64Y6SBGil54eQ8112Hgm6VDpieAUkUqUODAQa2n+LW+0a2Y4ZQA2Vsv7+8DUOR0jiP2g==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@google-cloud/compute": "^4.0.1",
         "@google-cloud/container": "^5.2.0",
         "@google-cloud/resource-manager": "^5.0.1",
-        "@kubernetes/client-node": "1.0.0-rc7",
+        "@kubernetes/client-node": "1.0.0",
         "@percy/appium-app": "^2.0.1",
         "@percy/selenium-webdriver": "^2.0.0",
         "archiver": "^6.0.1",
@@ -2014,6 +2013,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
@@ -2270,13 +2285,13 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
-      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -2300,14 +2315,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -3281,9 +3297,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.10.tgz",
+      "integrity": "sha512-skIAxZqcMkOrSwjJvplIPYrlXGpxTPnro2/QWTDCxAdWQrSTV5/KqspMWmi5WAx5+ULswASJiZ0a+1B/Lxt9cw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3583,17 +3599,11 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
+      "license": "ISC"
     },
     "node_modules/map-stream": {
       "version": "0.1.0",
@@ -3854,6 +3864,16 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/oauth4webapi": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.3.1.tgz",
+      "integrity": "sha512-ZwX7UqYrP3Lr+Glhca3a1/nF2jqf7VVyJfhGuW5JtrfDUxt0u+IoBPzFjZ2dd7PJGkdM6CFPVVYzuDYKHv101A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/object-hash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
@@ -3885,16 +3905,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/oidc-token-hash": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
-      "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10.13.0 || >=12.0.0"
       }
     },
     "node_modules/once": {
@@ -3934,29 +3944,17 @@
       }
     },
     "node_modules/openid-client": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
-      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.3.4.tgz",
+      "integrity": "sha512-CGZGk9Y6Bv9R4bXlrzVoxzD1n4h8iP914UhjVyRSftqzqO4CWaRqKpOmW253Jmpv4EWkz7/Gut/90iiWW8t0ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jose": "^4.15.9",
-        "lru-cache": "^6.0.0",
-        "object-hash": "^2.2.0",
-        "oidc-token-hash": "^5.0.3"
+        "jose": "^6.0.10",
+        "oauth4webapi": "^3.3.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/openid-client/node_modules/object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/p-cancelable": {
@@ -4306,13 +4304,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/path-scurry/node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -4513,13 +4504,6 @@
         "node": ">=0.4.x"
       }
     },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/queue-tick": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
@@ -4636,13 +4620,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
@@ -5325,16 +5302,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/teeny-request": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
@@ -5619,17 +5586,6 @@
       "dependencies": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
-      }
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "node_modules/url-template": {
@@ -5973,9 +5929,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6042,11 +5998,14 @@
       }
     },
     "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "dev": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/test/e2e/pages/booking-page.ts
+++ b/test/e2e/pages/booking-page.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import { type Page, type Locator } from '@playwright/test';
-import { APPT_MY_SHARE_LINK, APPT_SHORT_SHARE_LINK_PREFIX, APPT_LONG_SHARE_LINK_PREFIX } from '../const/constants';
+import { APPT_MY_SHARE_LINK, APPT_SHORT_SHARE_LINK_PREFIX, APPT_LONG_SHARE_LINK_PREFIX, TIMEOUT_30_SECONDS } from '../const/constants';
 
 export class BookingPage {
   readonly page: Page;
@@ -43,7 +43,6 @@ export class BookingPage {
   async gotoBookingPageShortUrl() {
     // the default share link is a short URL
     await this.page.goto(APPT_MY_SHARE_LINK);
-    await this.page.waitForLoadState('domcontentloaded');
   }
 
   /**
@@ -54,7 +53,6 @@ export class BookingPage {
     const prodShareLinkUser: string = APPT_MY_SHARE_LINK.split(APPT_SHORT_SHARE_LINK_PREFIX)[1];
     const longLink: string = `${APPT_LONG_SHARE_LINK_PREFIX}${prodShareLinkUser}`;
     await this.page.goto(longLink);
-    await this.page.waitForLoadState('domcontentloaded');
   }
 
   /**
@@ -63,8 +61,7 @@ export class BookingPage {
   async gotoBookingPageWeekView() {
     const weekLink: string = `${APPT_MY_SHARE_LINK}#week`;
     await this.page.goto(weekLink);
-    await this.page.waitForLoadState('domcontentloaded');
-    await expect(this.confirmBtn).toBeVisible({ timeout: 30_000 });
+    await expect(this.confirmBtn).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
   }
 
   /**
@@ -72,8 +69,7 @@ export class BookingPage {
    */
   async goForwardOneWeek() {
     await this.nextMonthArrow.click();
-    await this.page.waitForLoadState('domcontentloaded');
-    await expect(this.confirmBtn).toBeVisible({ timeout: 30_000 });
+    await expect(this.confirmBtn).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
   }
 
   /**

--- a/test/e2e/pages/dashboard-page.ts
+++ b/test/e2e/pages/dashboard-page.ts
@@ -1,5 +1,13 @@
 import { expect, type Page, type Locator } from '@playwright/test';
-import { APPT_TARGET_ENV, APPT_PENDING_BOOKINGS_PAGE, APPT_BOOKED_BOOKINGS_PAGE } from '../const/constants';
+
+import {
+  APPT_PENDING_BOOKINGS_PAGE,
+  APPT_BOOKED_BOOKINGS_PAGE,
+  APPT_DASHBOARD_MONTH_PAGE,
+  APPT_TIMEZONE_SETTING_TORONTO,
+  APPT_TIMEZONE_SETTING_HALIFAX,
+  TIMEOUT_60_SECONDS
+} from '../const/constants';
 
 
 export class DashboardPage {
@@ -13,6 +21,10 @@ export class DashboardPage {
   readonly pendingBookingsFilterSelect: Locator;
   readonly allFutureBookingsOptionText: string = 'All future bookings';
   readonly apptsFilterInput: Locator;
+  readonly calendarEvent24hrFormat: Locator;
+  readonly timezoneDisplayTextToronto: Locator;
+  readonly timezoneDisplayTextHalifax: Locator;
+  readonly availabilityPanelHeader: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -24,6 +36,10 @@ export class DashboardPage {
     this.pendingBookingsPageHeader = this.page.getByText('Bookings');
     this.pendingBookingsFilterSelect = this.page.getByTestId('bookings-filter-select');
     this.apptsFilterInput = this.page.getByPlaceholder('Search bookings');
+    this.calendarEvent24hrFormat = this.page.locator('[class="calendar-month_events"]', { hasText: ':00 - 17:00' }).first();
+    this.timezoneDisplayTextToronto = this.page.getByText(APPT_TIMEZONE_SETTING_TORONTO, { exact: true });
+    this.timezoneDisplayTextHalifax = this.page.getByText(APPT_TIMEZONE_SETTING_HALIFAX, { exact: true });
+    this.availabilityPanelHeader = this.page.getByPlaceholder('My Schedule');
   }
 
   /**
@@ -31,9 +47,8 @@ export class DashboardPage {
    */
   async gotoPendingBookings() {
     await this.page.goto(APPT_PENDING_BOOKINGS_PAGE);
-    await this.page.waitForLoadState('domcontentloaded');
     // ensure all future pending bookings are displayed
-    await this.pendingBookingsFilterSelect.selectOption(this.allFutureBookingsOptionText, { timeout: 60_000 });
+    await this.pendingBookingsFilterSelect.selectOption(this.allFutureBookingsOptionText, { timeout: TIMEOUT_60_SECONDS });
   }
 
   /**
@@ -41,9 +56,8 @@ export class DashboardPage {
    */
   async gotoBookedBookings() {
     await this.page.goto(APPT_BOOKED_BOOKINGS_PAGE);
-    await this.page.waitForLoadState('domcontentloaded');
     // ensure all future booked bookings are displayed
-    await this.pendingBookingsFilterSelect.selectOption(this.allFutureBookingsOptionText, { timeout: 60_000 });
+    await this.pendingBookingsFilterSelect.selectOption(this.allFutureBookingsOptionText, { timeout: TIMEOUT_60_SECONDS });
   }
 
   /**
@@ -79,6 +93,20 @@ export class DashboardPage {
     // now we have a list of future pending appointments for our host and requster; now ensure one
     // of them matches the slot that was selected by the test
     const apptLocator = this.page.getByRole('cell', { name: `${slotDate}` }).locator('div', { hasText: `${slotTime} to`});
-    await expect(apptLocator).toBeVisible( { timeout: 60_000 });
+    await expect(apptLocator).toBeVisible( { timeout: TIMEOUT_60_SECONDS });
+  }
+
+  /**
+   * Navigate to the dashboard month view
+   */
+  async gotoToDashboardMonthView() {
+    await this.page.goto(APPT_DASHBOARD_MONTH_PAGE);
+  }
+
+  /**
+   * Get the availability panel header text (i.e. '<display name>'s Availability')
+   */
+  async getAvailabilityPanelHeader(): Promise<string> {
+    return await this.availabilityPanelHeader.inputValue();
   }
 }

--- a/test/e2e/pages/settings-page.ts
+++ b/test/e2e/pages/settings-page.ts
@@ -1,0 +1,281 @@
+import { expect, type Page, type Locator } from '@playwright/test';
+
+import {
+  APPT_LOGIN_EMAIL,
+  APPT_MAIN_SETTINGS_PAGE,
+  APPT_GENERAL_SETTINGS_PAGE,
+  APPT_ACCOUNT_SETTINGS_PAGE,
+  APPT_CALENDAR_SETTINGS_PAGE,
+  APPT_CONNECTED_SETTINGS_PAGE,
+  APPT_HTML_DARK_MODE_CLASS,
+  TIMEOUT_3_SECONDS,
+  TIMEOUT_30_SECONDS,
+} from '../const/constants';
+
+export class SettingsPage {
+  readonly page: Page;
+  readonly settingsHeaderEN: Locator;
+  readonly settingsHeaderDE: Locator;
+  readonly generalSettingsBtn: Locator;
+  readonly calendarSettingsBtn: Locator;
+  readonly accountSettingsBtn: Locator;
+  readonly connectedSettingsBtn: Locator;
+  readonly generalSettingsHeaderEN: Locator;
+  readonly generalSettingsHeaderDE: Locator;
+  readonly calendarSettingsHeader: Locator;
+  readonly accountSettingsHeader: Locator;
+  readonly connectedSettingsHeader: Locator;
+  readonly languageSelect: Locator;
+  readonly themeSelect: Locator;
+  readonly htmlAttribLocator: Locator;
+  readonly settings12hrRadio: Locator;
+  readonly settings24hrRadio: Locator;
+  readonly timeZoneSelect: Locator;
+  readonly profileUsernameInput: Locator;
+  readonly profilePreferredEmailSelect: Locator;
+  readonly profileDisplayNameInput: Locator;
+  readonly profileMyLinkInput: Locator;
+  readonly profileSaveChangesBtn: Locator;
+  readonly refreshLinkBtn: Locator;
+  readonly confirmRefreshCancelBtn: Locator;
+  readonly inviteCodesHeader: Locator;
+  readonly noInviteCodesCell: Locator;
+  readonly firstInviteCode: Locator;
+  readonly deleteAcctBtn: Locator;
+  readonly confirmDeleteAcctBtn: Locator;
+  readonly downloadDataBtn: Locator;
+  readonly confirmDownloadDataBtn: Locator;
+  readonly availableCalendarsHeader: Locator;
+  readonly connectedCalendarsHeader: Locator;
+  readonly editCalendarBtn: Locator;
+  readonly connectedCalendarTitle: Locator;
+  readonly editCalendarSaveBtn: Locator;
+  readonly editCalendarTitleInput: Locator;
+  readonly editCalendarColorInput: Locator;
+  readonly syncCalendarsBtn: Locator;
+  readonly addGoogleCalendarBtn: Locator;
+  readonly addCaldavCalendarBtn: Locator;
+  readonly connectGoogleCalendarBtn: Locator;
+  readonly editCalendarCancelBtn: Locator;
+  readonly addCaldavUrlInput: Locator;
+  readonly addCaldavUserInput: Locator;
+  readonly addCaldavPasswordInput: Locator;
+  readonly editProfileBtn: Locator;
+  readonly mozProfilePageLogo: Locator;
+  readonly mozProfileSettingsSection: Locator;
+  readonly disconnectGoogleCalendarBtn: Locator;
+  readonly disconnectGoogleCalendarBackBtn: Locator;
+  readonly connectCaldavBtn: Locator;
+  readonly addCaldavConnectionUsernameInput: Locator;
+  readonly addCaldavConnectionLocationInput: Locator;
+  readonly addCaldavConnectionPasswordInput: Locator;
+  readonly addCaldavConnectionCloseModalBtn: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    // main settings view
+    this.settingsHeaderEN = this.page.getByRole('main').getByText('Settings', { exact: true });
+    this.settingsHeaderDE = this.page.getByRole('main').getByText('Einstellungen', { exact: true });
+    this.generalSettingsBtn = this.page.getByTestId('settings-general-settings-btn');
+    this.calendarSettingsBtn = this.page.getByTestId('settings-calendar-settings-btn');
+    this.accountSettingsBtn = this.page.getByTestId('settings-account-settings-btn');
+    this.connectedSettingsBtn = this.page.getByTestId('settings-connectedAccounts-settings-btn');
+
+    // general settings
+    this.generalSettingsHeaderEN = this.page.getByText('General Settings', { exact: true });
+    this.generalSettingsHeaderDE = this.page.getByText('Allgemeine Einstellungen', { exact: true });
+    this.calendarSettingsHeader = this.page.getByText('Calendar Settings', { exact: true });
+    this.accountSettingsHeader = this.page.getByText('Account Settings', { exact: true });
+    this.connectedSettingsHeader = this.page.getByText('Connected Accounts Settings', { exact: true });
+    this.languageSelect = this.page.getByTestId('settings-general-locale-select');
+    this.themeSelect = this.page.getByTestId('settings-general-theme-select');
+    this.htmlAttribLocator = this.page.locator("html");
+    this.settings12hrRadio = this.page.getByText('12-hour AM/PM', { exact: true });
+    this.settings24hrRadio = this.page.getByText('24-hour', { exact: true });
+    this.timeZoneSelect = this.page.getByTestId('settings-general-timezone-select');
+
+    // account settings
+    this.profileUsernameInput = this.page.getByTestId('settings-account-user-name-input');
+    this.profilePreferredEmailSelect = this.page.getByTestId('settings-account-email-select');
+    this.profileDisplayNameInput = this.page.getByTestId('settings-account-display-name-input');
+    this.profileMyLinkInput = this.page.getByTestId('settings-account-mylink-input');
+    this.profileSaveChangesBtn = this.page.getByTestId('settings-account-save-changes-btn');
+    this.refreshLinkBtn = this.page.getByTestId('settings-account-refresh-link-btn');
+    this.confirmRefreshCancelBtn = this.page.getByRole('button', { name: 'Cancel' });
+    this.noInviteCodesCell = this.page.getByRole('cell', { name: 'No Invite Codes could be' });
+    this.inviteCodesHeader = this.page.getByText('Invites', { exact: true });
+    this.firstInviteCode = this.page.getByRole('code').first();
+    this.deleteAcctBtn = this.page.getByTestId('settings-account-delete-btn');
+    this.confirmDeleteAcctBtn = this.page.getByRole('button', { name: 'Cancel' });
+    this.downloadDataBtn = this.page.getByTestId('settings-account-download-data-btn');
+    this.confirmDownloadDataBtn = this.page.getByRole('button', { name: 'Continue' });
+
+    // calendar settings
+    this.availableCalendarsHeader = this.page.getByText('Available Calendars', { exact: true });
+    this.connectedCalendarsHeader = this.page.getByText('Connected Calendars', { exact: true });
+    this.editCalendarBtn = this.page.getByTestId('settings-calendar-edit-calendar-btn');
+    this.connectedCalendarTitle = this.page.getByText(APPT_LOGIN_EMAIL, { exact: true });
+    this.editCalendarSaveBtn = this.page.getByRole('button', { name: 'Save' });
+    this.editCalendarTitleInput = this.page.getByTestId('settings-calendar-title-input');
+    this.editCalendarColorInput = this.page.getByTestId('settings-calendar-color-input');
+    this.syncCalendarsBtn = this.page.getByRole('button', { name: 'Sync Calendars' });
+    this.addGoogleCalendarBtn = this.page.getByRole('button', { name: 'Add Google calendar' });
+    this.addCaldavCalendarBtn = this.page.getByRole('button', { name: 'Add CalDAV calendar' });
+    this.connectGoogleCalendarBtn = this.page.getByRole('button', { name: 'Connect Google Calendar' });
+    this.editCalendarCancelBtn = this.page.getByRole('button', { name: 'Cancel' });
+    this.addCaldavUrlInput = this.page.getByTestId('settings-calendar-caldav-url-input');
+    this.addCaldavUserInput = this.page.getByTestId('settings-calendar-caldav-user-input');
+    this.addCaldavPasswordInput = this.page.getByTestId('settings-calendar-caldav-password-input');
+
+    // connected accounts settings
+    this.editProfileBtn = this.page.getByRole('button', { name: 'Edit profile' });
+    this.mozProfilePageLogo = this.page.getByTestId('logo');
+    this.mozProfileSettingsSection = this.page.getByTestId('settings-profile');
+    this.disconnectGoogleCalendarBtn = this.page.getByTestId('connected-accounts-settings-google-disconnect-btn');
+    this.disconnectGoogleCalendarBackBtn = this.page.getByRole('button', { name: 'Back' });
+    this.connectCaldavBtn = this.page.getByTestId('connected-accounts-settings-caldav-connect-btn');
+    this.addCaldavConnectionUsernameInput = this.page.getByRole('textbox', { name: 'user' });
+    this.addCaldavConnectionLocationInput = this.page.getByRole('textbox', { name: 'url' });
+    this.addCaldavConnectionPasswordInput = this.page.getByRole('textbox', { name: 'password' });
+    this.addCaldavConnectionCloseModalBtn = this.page.getByRole('img', { name: 'Close' });
+  }
+
+  /**
+   * Navigate directly to the main settings page
+   */
+  async gotoMainSettingsPage() {
+    await this.page.goto(APPT_MAIN_SETTINGS_PAGE);
+  }
+
+  /**
+   * Navigate directly to the general settings page
+   */
+  async gotoGeneralSettingsPage() {
+    await this.page.goto(APPT_GENERAL_SETTINGS_PAGE);
+  }
+
+  /**
+   * Navigate directly to the calendar settings page
+   */
+  async gotoCalendarSettingsPage() {
+    await this.page.goto(APPT_CALENDAR_SETTINGS_PAGE);
+  }
+
+  /**
+   * Navigate directly to the account settings page
+   */
+  async gotoAccountSettingsPage() {
+    await this.page.goto(APPT_ACCOUNT_SETTINGS_PAGE);
+  }
+
+  /**
+   * Navigate directly to the connected accounts settings page
+   */
+  async gotoConnectedAccountsSettingsPage() {
+    await this.page.goto(APPT_CONNECTED_SETTINGS_PAGE);
+  }
+
+  /**
+   * Change the general setting's page language setting
+   */
+  async changeLanguageSetting(language: string) {
+    await this.languageSelect.selectOption(language, { timeout: TIMEOUT_30_SECONDS });
+  }
+
+  /**
+   * Change the general setting's page theme setting
+   */
+  async changeThemeSetting(theme: string) {
+    await this.themeSelect.selectOption(theme, { timeout: TIMEOUT_30_SECONDS });
+  }
+
+  /**
+   * Check if dark mode is enabled
+   */
+  async isDarkModeEnabled(page: Page): Promise<boolean> {
+    const htmlTag = page.locator("html");
+    const htmlClass = await htmlTag.getAttribute("class");
+
+    if (htmlClass == APPT_HTML_DARK_MODE_CLASS) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Change time format settings to 12-hour format
+   */
+  async set12hrFormat() {
+    // give a few seconds to be applied as sometimes the test runs so fast
+    // it switches back to the dashboard tab before the time format is applied
+    await this.settings12hrRadio.click( { timeout: TIMEOUT_30_SECONDS });
+    await this.page.waitForTimeout(TIMEOUT_3_SECONDS); // give a few seconds to be applied
+  }
+
+  /**
+   * Change time format settings to 24-hour format
+   */
+  async set24hrFormat() {
+    await this.settings24hrRadio.click({ timeout: TIMEOUT_30_SECONDS });
+    // give a few seconds to be applied as sometimes the test runs so fast
+    // it switches back to the dashboard tab before the time format is applied
+    await this.page.waitForTimeout(TIMEOUT_3_SECONDS);
+  }
+
+  /**
+   * Change the general setting's time zone setting
+   */
+  async changeTimezoneSetting(timezone: string) {
+    await this.timeZoneSelect.selectOption(timezone, { timeout: TIMEOUT_30_SECONDS });
+    await this.page.waitForTimeout(TIMEOUT_3_SECONDS); // give a few seconds to be applied
+  }
+
+  /**
+   * Get the account settings profile username value
+   */
+  async getAccountProfileUsername(): Promise<string> {
+    return await this.profileUsernameInput.inputValue();
+  }
+
+  /**
+   * Get the account settings profile preferred email value
+   */
+  async getAccountProfilePreferredEmail(): Promise<string> {
+    return await this.profilePreferredEmailSelect.inputValue();
+  }
+
+  /**
+   * Get the account settings profile display name value
+   */
+  async getAccountProfileDisplayName(): Promise<string> {
+    return await this.profileDisplayNameInput.inputValue();
+  }
+
+  /**
+   * Set the account settings profile display name value
+   */
+  async setAccountProfileDisplayName(newDisplayName: string) {
+    await this.profileDisplayNameInput.fill(newDisplayName);
+    await this.profileSaveChangesBtn.click();
+    await this.page.waitForTimeout(TIMEOUT_3_SECONDS); // give a few seconds to be applied
+  }
+
+  /**
+   * Get the account settings profile my link value
+   */
+  async getAccountProfileMyLink(): Promise<string> {
+    return await this.profileMyLinkInput.inputValue();
+  }
+
+  /**
+   * Download account data
+   */
+  async downloadAccountData() {
+    expect(this.downloadDataBtn).toBeEnabled();
+    await this.downloadDataBtn.click();
+    expect(this.confirmDownloadDataBtn).toBeEnabled();
+    await this.confirmDownloadDataBtn.click();
+  }
+}

--- a/test/e2e/pages/settings-page.ts
+++ b/test/e2e/pages/settings-page.ts
@@ -90,7 +90,7 @@ export class SettingsPage {
     this.connectedSettingsHeader = this.page.getByText('Connected Accounts Settings', { exact: true });
     this.languageSelect = this.page.getByTestId('settings-general-locale-select');
     this.themeSelect = this.page.getByTestId('settings-general-theme-select');
-    this.htmlAttribLocator = this.page.locator("html");
+    this.htmlAttribLocator = this.page.locator('html');
     this.settings12hrRadio = this.page.getByText('12-hour AM/PM', { exact: true });
     this.settings24hrRadio = this.page.getByText('24-hour', { exact: true });
     this.timeZoneSelect = this.page.getByTestId('settings-general-timezone-select');
@@ -181,6 +181,7 @@ export class SettingsPage {
    */
   async changeLanguageSetting(language: string) {
     await this.languageSelect.selectOption(language, { timeout: TIMEOUT_30_SECONDS });
+    await this.page.waitForTimeout(TIMEOUT_3_SECONDS);
   }
 
   /**
@@ -188,6 +189,7 @@ export class SettingsPage {
    */
   async changeThemeSetting(theme: string) {
     await this.themeSelect.selectOption(theme, { timeout: TIMEOUT_30_SECONDS });
+    await this.page.waitForTimeout(TIMEOUT_3_SECONDS);
   }
 
   /**
@@ -196,12 +198,7 @@ export class SettingsPage {
   async isDarkModeEnabled(page: Page): Promise<boolean> {
     const htmlTag = page.locator("html");
     const htmlClass = await htmlTag.getAttribute("class");
-
-    if (htmlClass == APPT_HTML_DARK_MODE_CLASS) {
-      return true;
-    } else {
-      return false;
-    }
+    return htmlClass === APPT_HTML_DARK_MODE_CLASS;
   }
 
   /**
@@ -210,7 +207,7 @@ export class SettingsPage {
   async set12hrFormat() {
     // give a few seconds to be applied as sometimes the test runs so fast
     // it switches back to the dashboard tab before the time format is applied
-    await this.settings12hrRadio.click( { timeout: TIMEOUT_30_SECONDS });
+    await this.settings12hrRadio.click({ timeout: TIMEOUT_30_SECONDS });
     await this.page.waitForTimeout(TIMEOUT_3_SECONDS); // give a few seconds to be applied
   }
 

--- a/test/e2e/pages/splashscreen-page.ts
+++ b/test/e2e/pages/splashscreen-page.ts
@@ -1,5 +1,5 @@
 import { expect, type Page, type Locator } from '@playwright/test';
-import { APPT_URL, APPT_LOGIN_EMAIL, FXA_PAGE_TITLE, APPT_LOGIN_PWORD } from '../const/constants';
+import { APPT_URL, APPT_LOGIN_EMAIL, FXA_PAGE_TITLE, APPT_LOGIN_PWORD, TIMEOUT_30_SECONDS } from '../const/constants';
 
 export class SplashscreenPage {
   readonly page: Page;
@@ -20,7 +20,6 @@ export class SplashscreenPage {
 
   async gotoDashboard() {
     await this.page.goto(APPT_URL);
-    await this.page.waitForLoadState('domcontentloaded');
   }
 
   async clickLoginBtn() {
@@ -47,7 +46,7 @@ export class SplashscreenPage {
     expect(APPT_LOGIN_EMAIL, 'getting APPT_LOGIN_EMAIL env var').toBeTruthy();
     await this.enterLoginEmail(APPT_LOGIN_EMAIL);
     await this.clickLoginContinueBtn();
-    await expect(this.page).toHaveTitle(FXA_PAGE_TITLE, { timeout: 30_000 }); // be generous in case FxA is slow to load
+    await expect(this.page).toHaveTitle(FXA_PAGE_TITLE, { timeout: TIMEOUT_30_SECONDS }); // be generous in case FxA is slow to load
   }
 
   async localApptSignIn() {

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : 1, // actualy don't run in parallel locally either, for now
-  // Tests will timeout if still running after this time (ms)
+  // Individual test timeout - each test will time out if it is still running after this time (ms)
   timeout: 2 * 60 * 1000,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [['list']],

--- a/test/e2e/tests/book-appointment.spec.ts
+++ b/test/e2e/tests/book-appointment.spec.ts
@@ -2,15 +2,24 @@ import { test, expect } from '@playwright/test';
 import { BookingPage } from '../pages/booking-page';
 import { DashboardPage } from '../pages/dashboard-page';
 import { navigateToAppointmentAndSignIn } from '../utils/utils';
-import { APPT_DISPLAY_NAME, APPT_BOOKEE_NAME, APPT_BOOKEE_EMAIL,
-  PLAYWRIGHT_TAG_PROD_SANITY, PLAYWRIGHT_TAG_E2E_SUITE } from '../const/constants';
+
+import {
+  APPT_DISPLAY_NAME,
+  APPT_BOOKEE_NAME,
+  APPT_BOOKEE_EMAIL,
+  PLAYWRIGHT_TAG_PROD_SANITY,
+  PLAYWRIGHT_TAG_E2E_SUITE,
+  TIMEOUT_3_SECONDS,
+  TIMEOUT_30_SECONDS,
+  TIMEOUT_60_SECONDS,
+} from '../const/constants';
 
 var bookingPage: BookingPage;
 var dashboardPage: DashboardPage;
 
 // verify booking page loaded successfully
 const verifyBookingPageLoaded = async () => {
-  await expect(bookingPage.titleText).toBeVisible({ timeout: 60_000 });
+  await expect(bookingPage.titleText).toBeVisible({ timeout: TIMEOUT_60_SECONDS });
   await expect(bookingPage.titleText).toContainText(APPT_DISPLAY_NAME);
   await expect(bookingPage.invitingText).toBeVisible();
   await expect(bookingPage.invitingText).toContainText(APPT_DISPLAY_NAME);
@@ -73,7 +82,7 @@ test.describe('book an appointment', () => {
   }, async ({ page }) => {
     // in order to ensure we find an available slot we can click on, first switch to week view URL
     await bookingPage.gotoBookingPageWeekView();
-    await expect(bookingPage.titleText).toBeVisible({ timeout: 30_000 });
+    await expect(bookingPage.titleText).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
 
     // now select an available booking time slot  
     const selectedSlot: string|null = await bookingPage.selectAvailableBookingSlot(APPT_DISPLAY_NAME);
@@ -87,7 +96,7 @@ test.describe('book an appointment', () => {
 
     // by default after a slot is booked it requires confirmation from the host user first
     // 'boooking request sent' text appears twice, once in the pop-up and once in underlying page
-    await expect(bookingPage.requestSentTitleText.first()).toBeVisible({ timeout: 60_000 });
+    await expect(bookingPage.requestSentTitleText.first()).toBeVisible({ timeout: TIMEOUT_60_SECONDS });
     await expect(bookingPage.requestSentTitleText.nth(1)).toBeVisible();
 
     // booking request sent dialog availability text contains correct user name
@@ -117,6 +126,9 @@ test.describe('book an appointment', () => {
     // now verify a corresponding pending booking was created on the host account's list of pending bookings
     // (drop the day of the week from our time slot string as this function just needs the month, day, and year)
     const expMonthDayYear = expDateStr.substring(expDateStr.indexOf(',') + 2);
+    // wait a few seconds for the appointment dashboard to update, sometimes the test is so fast when it
+    // switches back to the dashboard the new pending appointment hasn't been added/displayed yet
+    await page.waitForTimeout(TIMEOUT_3_SECONDS);
     await dashboardPage.verifyEventCreated(APPT_DISPLAY_NAME, APPT_BOOKEE_NAME, expMonthDayYear, expTimeStr);
   });
 });

--- a/test/e2e/tests/settings.spec.ts
+++ b/test/e2e/tests/settings.spec.ts
@@ -1,0 +1,304 @@
+import { test, expect } from '@playwright/test';
+import { navigateToAppointmentAndSignIn } from '../utils/utils';
+import { SettingsPage } from '../pages/settings-page';
+import { DashboardPage } from '../pages/dashboard-page';
+
+import {
+  PLAYWRIGHT_TAG_E2E_SUITE,
+  APPT_LOGIN_EMAIL,
+  APPT_DISPLAY_NAME,
+  APPT_MY_SHARE_LINK,
+  APPT_TARGET_ENV,
+  APPT_LANGUAGE_SETTING_DE,
+  APPT_LANGUAGE_SETTING_EN,
+  APPT_THEME_SETTING_DARK,
+  APPT_THEME_SETTING_LIGHT,
+  APPT_TIMEZONE_SETTING_TORONTO,
+  APPT_TIMEZONE_SETTING_HALIFAX,
+  TIMEOUT_3_SECONDS,
+  TIMEOUT_30_SECONDS,
+ } from '../const/constants';
+
+let settingsPage: SettingsPage;
+let dashboardPage: DashboardPage;
+
+test.describe('settings navigation', {
+  tag: [PLAYWRIGHT_TAG_E2E_SUITE],
+}, () => {
+  test.beforeEach(async ({ page }) => {
+    // navigate to and sign into appointment
+    await navigateToAppointmentAndSignIn(page);
+    settingsPage = new SettingsPage(page);
+    dashboardPage = new DashboardPage(page);
+  });
+
+  test('able to navigate through the settings panels', async ({ page }) => {
+    // navigate to main settings URL and verify general settings displayed by default
+    await settingsPage.gotoMainSettingsPage();
+    await expect(settingsPage.settingsHeaderEN).toBeVisible({ timeout: TIMEOUT_30_SECONDS }); // generous time
+    await expect(settingsPage.generalSettingsHeaderEN).toBeVisible({ timeout: TIMEOUT_30_SECONDS }); // generous time
+    await expect(settingsPage.generalSettingsBtn).toBeEnabled();
+    await expect(settingsPage.calendarSettingsBtn).toBeEnabled();
+    await expect(settingsPage.accountSettingsBtn).toBeEnabled();
+    await expect(settingsPage.connectedSettingsBtn).toBeEnabled();
+
+    // click 'Calendar' button and verify corresponding settings appear
+    await settingsPage.calendarSettingsBtn.click();
+    await expect(settingsPage.calendarSettingsHeader).toBeVisible({ timeout: TIMEOUT_30_SECONDS }); // generous time
+
+    // click 'Account' button and verify corresponding settings appear
+    await settingsPage.accountSettingsBtn.click();
+    await expect(settingsPage.accountSettingsHeader).toBeVisible({ timeout: TIMEOUT_30_SECONDS }); // generous time
+
+    // click 'Connected Accounts' button and verify corresponding settings appear
+    await settingsPage.connectedSettingsBtn.click();
+    await expect(settingsPage.connectedSettingsHeader).toBeVisible({ timeout: TIMEOUT_30_SECONDS }); // generous time
+
+    // click 'General' button and verify general settings appear once again
+    await settingsPage.generalSettingsBtn.click();
+    await expect(settingsPage.generalSettingsHeaderEN).toBeVisible({ timeout: TIMEOUT_30_SECONDS }); // generous time
+  });
+});
+
+test.describe('general settings', {
+  tag: [PLAYWRIGHT_TAG_E2E_SUITE],
+}, () => {
+  test.beforeEach(async ({ page }) => {
+    // navigate to and sign into appointment
+    await navigateToAppointmentAndSignIn(page);
+    settingsPage = new SettingsPage(page);
+    dashboardPage = new DashboardPage(page);
+    // navigate to the general settings page
+    await settingsPage.gotoGeneralSettingsPage();
+  });
+
+  test('able to change language', async ({ page }) => {
+    // change language setting to DE and verify; we use expect.soft here because if the expect fails
+    // we still want the test to continue so that the test will change the setting back to original value
+    // (expect.soft will still mark the test case failed if the expect fails, but won't stop the test)
+    await settingsPage.changeLanguageSetting(APPT_LANGUAGE_SETTING_DE);
+    await expect.soft(settingsPage.settingsHeaderDE).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+    await expect.soft(settingsPage.generalSettingsHeaderDE).toBeVisible();
+
+    // change language settings back to EN and verify
+    await settingsPage.changeLanguageSetting(APPT_LANGUAGE_SETTING_EN);
+    await expect(settingsPage.settingsHeaderEN).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+    await expect(settingsPage.generalSettingsHeaderEN).toBeVisible();
+  });
+
+  test('able to change theme', async ({ page }) => {
+    // change theme setting to dark mode and verify
+    await settingsPage.changeThemeSetting(APPT_THEME_SETTING_DARK);
+    expect.soft(await settingsPage.isDarkModeEnabled(page)).toBeTruthy();
+
+    // change theme setting back to light mode and verify
+    await settingsPage.changeThemeSetting(APPT_THEME_SETTING_LIGHT);
+    expect(await settingsPage.isDarkModeEnabled(page)).toBeFalsy();
+  });
+
+  test('able to change time format', async ({ page }) => {
+    // change time format setting to 24-hour format and verify on dashboard calendar
+    await settingsPage.set24hrFormat();
+    await dashboardPage.gotoToDashboardMonthView();
+    await expect.soft(dashboardPage.calendarEvent24hrFormat).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+    await settingsPage.gotoGeneralSettingsPage();
+
+    // change time format setting back to 12-hour format and verify on dashboard calendar
+    await settingsPage.set12hrFormat();
+    await dashboardPage.gotoToDashboardMonthView();
+    await expect(dashboardPage.calendarEvent24hrFormat).not.toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+  });
+
+  test('able to change timezone', async ({ page }) => {
+    // change time zone setting and verify on dashboard calendar
+    await settingsPage.changeTimezoneSetting(APPT_TIMEZONE_SETTING_HALIFAX);
+    await dashboardPage.gotoToDashboardMonthView();
+    await expect.soft(dashboardPage.timezoneDisplayTextHalifax).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+
+    // change time format setting back and verify on dashboard calendar
+    await settingsPage.gotoGeneralSettingsPage();
+    await settingsPage.changeTimezoneSetting(APPT_TIMEZONE_SETTING_TORONTO);
+    await dashboardPage.gotoToDashboardMonthView();
+    await expect(dashboardPage.timezoneDisplayTextToronto).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+  });
+});
+
+test.describe('calendar settings', {
+  tag: [PLAYWRIGHT_TAG_E2E_SUITE],
+}, () => {
+  test.beforeEach(async ({ page }) => {
+    // navigate to and sign into appointment
+    await navigateToAppointmentAndSignIn(page);
+    settingsPage = new SettingsPage(page);
+    dashboardPage = new DashboardPage(page);
+    // navigate to the calendar settings page
+    await settingsPage.gotoCalendarSettingsPage();
+  });
+
+  test('able to sync calendars', async ({ page }) => {
+    // click the 'sync calendars button'
+    await expect(settingsPage.syncCalendarsBtn).toBeEnabled();
+    await settingsPage.syncCalendarsBtn.click();
+    await expect(settingsPage.syncCalendarsBtn).toBeDisabled();
+    await page.waitForTimeout(TIMEOUT_3_SECONDS);
+  });
+
+  test('able to edit calendar', async ({ page }) => {
+    // verify calendar is already connected
+    await expect(settingsPage.connectedCalendarsHeader).toBeVisible({ timeout: TIMEOUT_30_SECONDS }); // generous time
+    await expect(settingsPage.editCalendarBtn).toBeEnabled();
+    await expect(settingsPage.connectedCalendarTitle).toBeVisible();
+
+    // edit the connected calendar and click save button (without making changes)
+    await settingsPage.editCalendarBtn.click();
+    await expect(settingsPage.editCalendarTitleInput).toBeEnabled();
+    await expect(settingsPage.editCalendarColorInput).toBeEnabled();
+    await settingsPage.editCalendarSaveBtn.click();
+  });
+
+  test('add google calendar button', async ({ page }) => {
+    // just verify the 'connect google calendar' button becomes available then cancel out
+    await expect(settingsPage.addGoogleCalendarBtn).toBeEnabled();
+    await settingsPage.addGoogleCalendarBtn.click();
+    await expect(settingsPage.connectGoogleCalendarBtn).toBeEnabled();
+    await settingsPage.editCalendarCancelBtn.click();
+  });
+
+  test('add caldav calendar button', async ({ page }) => {
+    // just verify the discover caldav calendar fields appear then cancel out
+    await expect(settingsPage.addCaldavCalendarBtn).toBeEnabled();
+    await settingsPage.addCaldavCalendarBtn.click();
+    await expect(settingsPage.addCaldavUrlInput).toBeEnabled();
+    await expect(settingsPage.addCaldavUserInput).toBeEnabled();
+    await expect(settingsPage.addCaldavPasswordInput).toBeEnabled();
+    await settingsPage.editCalendarCancelBtn.click();
+  });
+});
+
+test.describe('account settings', {
+  tag: [PLAYWRIGHT_TAG_E2E_SUITE],
+}, () => {
+  test.beforeEach(async ({ page }) => {
+    // navigate to and sign into appointment
+    await navigateToAppointmentAndSignIn(page);
+    settingsPage = new SettingsPage(page);
+    dashboardPage = new DashboardPage(page);
+    // navigate to the account settings page
+    await settingsPage.gotoAccountSettingsPage();
+  });
+
+  test('verify profile details', async ({ page }) => {
+    // verify user name, preferred email, display name, and share link are all correct
+    expect(await settingsPage.getAccountProfileUsername()).toBe(APPT_LOGIN_EMAIL);
+    expect(await settingsPage.getAccountProfilePreferredEmail()).toBe(APPT_LOGIN_EMAIL);
+    expect(await settingsPage.getAccountProfileDisplayName()).toBe(APPT_DISPLAY_NAME);
+    expect(await settingsPage.getAccountProfileMyLink()).toBe(APPT_MY_SHARE_LINK);
+  });
+
+  test('able to change display name', async ({ page }) => {
+    // change the account settings user display name and save; we use expect.soft here because if the expect
+    // fails we still want the test to continue so that the test will change the setting back to original
+    // value (expect.soft will still mark the test case failed if the expect fails, but won't stop the test)
+    const newDisplayName: string = 'Display name modified by E2E!'
+    await settingsPage.setAccountProfileDisplayName(newDisplayName);
+    expect.soft(await settingsPage.getAccountProfileDisplayName()).toBe(newDisplayName);
+
+    // verify new display name is now displayed on the dashboard
+    await dashboardPage.gotoToDashboardMonthView();
+    // note that currently on stage the display name is not being updated after being changed
+    // so this test case will fail until issue #924 is fixed (uncomment line below when fixed)
+    // expect.soft(await dashboardPage.getAvailabilityPanelHeader()).toContain(newDisplayName);
+
+    // now change the display name setting back to what it was before, and save
+    await settingsPage.gotoAccountSettingsPage();
+    await settingsPage.setAccountProfileDisplayName(APPT_DISPLAY_NAME);
+    expect(await settingsPage.getAccountProfileDisplayName()).toBe(APPT_DISPLAY_NAME);
+
+    // verify new display name is now displayed on the dashboard
+    await dashboardPage.gotoToDashboardMonthView();
+    expect(await dashboardPage.getAvailabilityPanelHeader()).toContain(APPT_DISPLAY_NAME);
+  });
+
+  test('refresh link button', async ({ page }) => {
+    // verify that clicking the refresh link button results in a refresh link confirm dialog
+    // won't actually refresh the link as that would break the other E2E tests
+    await expect(settingsPage.refreshLinkBtn).toBeEnabled();
+    await settingsPage.refreshLinkBtn.click();
+    await settingsPage.confirmRefreshCancelBtn.click();
+  });
+
+  test('invite codes available', async ({ page }) => {
+    await expect(settingsPage.inviteCodesHeader).toBeVisible({ timeout: TIMEOUT_30_SECONDS }); // generous time in case a large list
+    // verify invite codes are available; note on local dev environment they won't be any; we need a pause here because
+    // sometimes even when invite codes header is visible, loading the list of actual invite codes takes a few seconds
+    await page.waitForTimeout(TIMEOUT_3_SECONDS);
+    if (APPT_TARGET_ENV == 'dev') {
+      await expect(settingsPage.noInviteCodesCell).toBeVisible();
+    } else {
+      await expect(settingsPage.noInviteCodesCell).not.toBeVisible();
+      // read the first invite code in the list
+      const firstCode = await settingsPage.firstInviteCode.textContent();
+      expect(firstCode).toHaveLength(36); // uuid is 36 char str including hyphens
+    }
+  });
+
+  test('able to download account data', async ({ page }) => {
+    // setup listener for browser download event
+    const downloadPromise = page.waitForEvent('download');
+    // click the account settings => download your data button and confirm
+    await settingsPage.downloadAccountData();
+    // now verify the browser download did happen successfully
+    const download = await downloadPromise;
+    const downloadedPath = await download.path(); // waits for download to finish
+    console.log(`account data file downloaded to ${downloadedPath}`);
+    expect(downloadedPath).toBeTruthy();
+    expect(await download.failure()).toBeFalsy();
+  });
+
+  test('delete account button', async ({ page }) => {
+    // verify that clicking the delete account button results in a delete account confirm dialog
+    // we won't actually delete the account :) as that would break the other E2E tests
+    await expect(settingsPage.deleteAcctBtn).toBeEnabled();
+    await settingsPage.deleteAcctBtn.click();
+    await settingsPage.confirmDeleteAcctBtn.click();
+  });
+});
+
+test.describe('connected accounts settings', {
+  tag: [PLAYWRIGHT_TAG_E2E_SUITE],
+}, () => {
+  test.beforeEach(async ({ page }) => {
+    // navigate to and sign into appointment
+    await navigateToAppointmentAndSignIn(page);
+    settingsPage = new SettingsPage(page);
+    dashboardPage = new DashboardPage(page);
+    // navigate to the connected accounts settings page
+    await settingsPage.gotoConnectedAccountsSettingsPage();
+  });
+
+  test('edit profile button', async ({ page }) => {
+    // verify that clicking the `edit profile` button redirects to the Mozilla Account profile page
+    await settingsPage.editProfileBtn.click();
+    // on dev env the button doesn't do anything (as expected) but on stage redirects to fxa profile
+    if (APPT_TARGET_ENV !== 'dev') {
+      await expect(settingsPage.mozProfilePageLogo).toBeVisible( { timeout: TIMEOUT_30_SECONDS });
+      await expect(settingsPage.mozProfileSettingsSection).toBeVisible();
+    }
+  });
+
+  test('disconnect calendar button', async ({ page }) => {
+    // verify that clicking the google calendar `disconnect` button brings up a confirmation dialog
+    // just cancel out; we don't want to actually disconnect the calendar and break the tests
+    await settingsPage.disconnectGoogleCalendarBtn.click();
+    await settingsPage.disconnectGoogleCalendarBackBtn.click();
+  });
+
+  test('connect caldav connection dialog', async ({ page }) => {
+    // verify that clicking the caldav connection `connect` button brings up the caldav connection dialog
+    await settingsPage.connectCaldavBtn.click();
+    await expect(settingsPage.addCaldavConnectionUsernameInput).toBeEditable();
+    await expect(settingsPage.addCaldavConnectionLocationInput).toBeEditable();
+    await expect(settingsPage.addCaldavConnectionPasswordInput).toBeEditable();
+    await settingsPage.addCaldavConnectionCloseModalBtn.click();
+  });
+});

--- a/test/e2e/tests/sign-in.spec.ts
+++ b/test/e2e/tests/sign-in.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { SplashscreenPage } from '../pages/splashscreen-page';
 import { FxAPage } from '../pages/fxa-page';
-import { APPT_TARGET_ENV, APPT_PAGE_TITLE, PLAYWRIGHT_TAG_PROD_SANITY, PLAYWRIGHT_TAG_E2E_SUITE } from '../const/constants';
+import { APPT_TARGET_ENV, APPT_PAGE_TITLE, PLAYWRIGHT_TAG_PROD_SANITY, PLAYWRIGHT_TAG_E2E_SUITE, TIMEOUT_30_SECONDS } from '../const/constants';
 import { DashboardPage } from '../pages/dashboard-page';
 
 let splashscreenPage: SplashscreenPage;
@@ -24,19 +24,17 @@ test.describe('sign-in', {
     // prod and stage use fxa to sign in; when running on local dev env we sign in to appt directly
     if (APPT_TARGET_ENV == 'prod' || APPT_TARGET_ENV == 'stage') {
       await splashscreenPage.getToFxA();
-      await expect(signInPage.signInHeaderText).toBeVisible({ timeout: 30_000 }); // generous time for fxa to appear
-      await expect(signInPage.userAvatar).toBeVisible({ timeout: 30_000});
+      await expect(signInPage.signInHeaderText).toBeVisible({ timeout: TIMEOUT_30_SECONDS }); // generous time for fxa to appear
+      await expect(signInPage.userAvatar).toBeVisible({ timeout: TIMEOUT_30_SECONDS});
       await expect(signInPage.signInButton).toBeVisible();
       await signInPage.signIn();
     } else {
       await splashscreenPage.localApptSignIn();
     }
 
-    await page.waitForLoadState('domcontentloaded');
-
-    await expect(page).toHaveTitle(APPT_PAGE_TITLE, { timeout: 30_000 }); // give generous time for sign-in
-    await expect(dashboardPage.userMenuAvatar).toBeVisible({ timeout: 30_000 });
-    await expect(dashboardPage.navBarDashboardBtn).toBeVisible({ timeout: 30_000 });
-    await expect(dashboardPage.shareMyLink).toBeVisible({ timeout: 30_000 });
+    await expect(page).toHaveTitle(APPT_PAGE_TITLE, { timeout: TIMEOUT_30_SECONDS }); // give generous time for sign-in
+    await expect(dashboardPage.userMenuAvatar).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+    await expect(dashboardPage.navBarDashboardBtn).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+    await expect(dashboardPage.shareMyLink).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
   });
 });

--- a/test/e2e/utils/utils.ts
+++ b/test/e2e/utils/utils.ts
@@ -32,3 +32,12 @@ export const navigateToAppointmentAndSignIn = async (page: Page) => {
     await expect(page).toHaveTitle(APPT_PAGE_TITLE, { timeout: TIMEOUT_30_SECONDS }); // give generous time
     await expect(dashboardPage.shareMyLink).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
 }
+
+/**
+ * Read and return the appointment user settings from the local browser store
+ */
+export const getUserSettingsFromLocalStore = async (page: Page) => {
+    const localUserStoreData = JSON.parse(await page.evaluate("localStorage.getItem('tba/user')"));
+    console.log(`User settings from local browser store: ${JSON.stringify(localUserStoreData['settings'])}`);
+    return localUserStoreData['settings'];
+}

--- a/test/e2e/utils/utils.ts
+++ b/test/e2e/utils/utils.ts
@@ -3,7 +3,7 @@ import { SplashscreenPage } from "../pages/splashscreen-page";
 import { FxAPage } from "../pages/fxa-page";
 import { DashboardPage } from "../pages/dashboard-page";
 import { expect, type Page } from '@playwright/test';
-import { APPT_TARGET_ENV, APPT_URL, APPT_PAGE_TITLE } from "../const/constants";
+import { APPT_TARGET_ENV, APPT_URL, APPT_PAGE_TITLE, TIMEOUT_30_SECONDS } from "../const/constants";
 
 /**
  * Navigate to and sign into the Appointment application target environment, using the URL and
@@ -29,7 +29,6 @@ export const navigateToAppointmentAndSignIn = async (page: Page) => {
     }
 
     // now that we're signed into the appointment dashboard give it time to load
-    await page.waitForLoadState('domcontentloaded');
-    await expect(page).toHaveTitle(APPT_PAGE_TITLE, { timeout: 30_000 }); // give generous time
-    await expect(dashboardPage.shareMyLink).toBeVisible({ timeout: 30_000 });
+    await expect(page).toHaveTitle(APPT_PAGE_TITLE, { timeout: TIMEOUT_30_SECONDS }); // give generous time
+    await expect(dashboardPage.shareMyLink).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
 }


### PR DESCRIPTION
Add E2E tests to exercise the Appointments settings. These additional tests will run as part of the E2E suite that runs locally as well as on stage per PR. Also adds some `data-testid` attributes to some of the front-end elements to make it easier for the tests to find them.

Also some general test improvements:
- Removing the waits for `domcontentloaded` when navigating to pages because playwright automatically waits for the page load event (which is the entire page, not just the domcontent)
- Added constants for timeout values

For more information on how to run these tests please see the [/test/e2e/README](https://github.com/thunderbird/appointment/blob/main/test/e2e/README.md).