### PR TITLE
Run E2E tests in CI when E2E test source changes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,6 +24,7 @@ jobs:
       validate-iac: ${{ steps.check.outputs.validate-iac }}
       validate-backend: ${{ steps.check.outputs.validate-backend }}
       validate-frontend: ${{ steps.check.outputs.validate-frontend }}
+      validate-e2e: ${{ steps.check.outputs.validate-e2e }}
     steps:
     - uses: actions/checkout@v4
 
@@ -39,6 +40,9 @@ jobs:
             - '.github/workflows/validate.yml'
           validate-frontend:
             - 'frontend/**'
+            - '.github/workflows/validate.yml'
+          validate-e2e:
+            - 'test/e2e/**'
             - '.github/workflows/validate.yml'
 
   validate-iac:
@@ -196,7 +200,7 @@ jobs:
   e2e-tests-browserstack:
     name: e2e-tests-browserstack
     needs: detect-changes
-    if: needs.detect-changes.outputs.validate-frontend == 'true' || needs.detect-changes.outputs.validate-backend == 'true'
+    if: needs.detect-changes.outputs.validate-frontend == 'true' || needs.detect-changes.outputs.validate-backend == 'true' || needs.detect-changes.outputs.validate-e2e == 'true'
     runs-on: ubuntu-latest
     environment: staging
     env:

--- a/backend/README.md
+++ b/backend/README.md
@@ -43,7 +43,7 @@ This project is deployed with Mozilla Accounts (known as fxa in the code.) Since
 To run tests in the backend, simply install the package in editing mode:
 
 ```bash
-cd backend && pip install -e .['test']
+cd backend && pip install -e .'[test]'
 ```
 
 After this you can run all of the tests with:


### PR DESCRIPTION
Update the GHA validate workflow so that when the E2E test source itself changes, the E2E tests should be run as part of the PR checks.

Also a small backend README correction.