### PR TITLE
Add data migration to lowercase emails, and only ingest lowercase emails.

### DIFF
--- a/backend/src/appointment/migrations/versions/2025_03_07_2109-537672c3933d_data_migration_clean_up_email_.py
+++ b/backend/src/appointment/migrations/versions/2025_03_07_2109-537672c3933d_data_migration_clean_up_email_.py
@@ -1,0 +1,45 @@
+"""data migration clean up email case
+
+Revision ID: 537672c3933d
+Revises: 330fdd8cd0f8
+Create Date: 2025-03-07 21:09:16.541016
+
+"""
+
+from alembic import op
+from sqlalchemy.orm import Session
+
+from appointment.database import models
+
+# revision identifiers, used by Alembic.
+revision = '537672c3933d'
+down_revision = '330fdd8cd0f8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    session = Session(op.get_bind())
+    subscribers: list[models.Subscriber] = session.query(models.Subscriber).all()
+    for subscriber in subscribers:
+        # Lowercase the emails
+        subscriber.email = subscriber.email.lower()
+        if subscriber.secondary_email:
+            subscriber.secondary_email = subscriber.secondary_email.lower()
+
+        # Add the subscriber to the database session and commit (update) it
+        session.add(subscriber)
+        session.commit()
+
+    waiting_list: list[models.WaitingList] = session.query(models.WaitingList).all()
+    for waiting_list_individual in waiting_list:
+        # Lowercase the emails
+        waiting_list_individual.email = waiting_list_individual.email.lower()
+
+        # Add the waiting list individual to the database session and commit (update) it
+        session.add(waiting_list_individual)
+        session.commit()
+
+
+def downgrade() -> None:
+    pass

--- a/backend/src/appointment/routes/api.py
+++ b/backend/src/appointment/routes/api.py
@@ -66,7 +66,7 @@ def update_me(
     me = repo.subscriber.update(db=db, data=data, subscriber_id=subscriber.id)
     return schemas.SubscriberMeOut(
         username=me.username,
-        email=me.email,
+        email=me.email.lower(),
         preferred_email=me.preferred_email,
         name=me.name,
         level=me.level,

--- a/backend/src/appointment/routes/google.py
+++ b/backend/src/appointment/routes/google.py
@@ -47,6 +47,8 @@ def google_auth(
     subscriber: Subscriber = Depends(get_subscriber),
 ):
     """Starts the google oauth process"""
+    if email:
+        email = email.lower()
     url, state = google_client.get_redirect_url(email)
 
     request.session[SESSION_OAUTH_STATE] = state
@@ -168,7 +170,7 @@ def disconnect_account(
     repo.calendar.delete_by_subscriber_and_provider(db, subscriber.id, provider=models.CalendarProvider.google)
 
     # Unassociated any secondary emails if they're attached to their google connection
-    if subscriber.secondary_email == google_connection.name:
+    if subscriber.secondary_email == google_connection.name.lower():
         subscriber.secondary_email = None
         db.add(subscriber)
         db.commit()

--- a/backend/src/appointment/routes/subscriber.py
+++ b/backend/src/appointment/routes/subscriber.py
@@ -27,7 +27,7 @@ def disable_subscriber(
     email: str, db: Session = Depends(get_db), subscriber: Subscriber = Depends(get_admin_subscriber)
 ):
     """endpoint to mark a subscriber deleted by email, needs admin permissions"""
-    subscriber_to_delete = repo.subscriber.get_by_email(db, email.lower())
+    subscriber_to_delete = repo.subscriber.get_by_email(db, email)
     if not subscriber_to_delete:
         raise validation.SubscriberNotFoundException()
     if subscriber_to_delete.is_deleted:
@@ -42,7 +42,7 @@ def disable_subscriber(
 @router.put('/enable/{email}')
 def enable_subscriber(email: str, db: Session = Depends(get_db), _: Subscriber = Depends(get_admin_subscriber)):
     """endpoint to enable a subscriber by email, needs admin permissions"""
-    subscriber_to_enable = repo.subscriber.get_by_email(db, email.lower())
+    subscriber_to_enable = repo.subscriber.get_by_email(db, email)
     if not subscriber_to_enable:
         raise validation.SubscriberNotFoundException()
     if not subscriber_to_enable.is_deleted:

--- a/backend/src/appointment/routes/subscriber.py
+++ b/backend/src/appointment/routes/subscriber.py
@@ -27,7 +27,7 @@ def disable_subscriber(
     email: str, db: Session = Depends(get_db), subscriber: Subscriber = Depends(get_admin_subscriber)
 ):
     """endpoint to mark a subscriber deleted by email, needs admin permissions"""
-    subscriber_to_delete = repo.subscriber.get_by_email(db, email)
+    subscriber_to_delete = repo.subscriber.get_by_email(db, email.lower())
     if not subscriber_to_delete:
         raise validation.SubscriberNotFoundException()
     if subscriber_to_delete.is_deleted:
@@ -42,7 +42,7 @@ def disable_subscriber(
 @router.put('/enable/{email}')
 def enable_subscriber(email: str, db: Session = Depends(get_db), _: Subscriber = Depends(get_admin_subscriber)):
     """endpoint to enable a subscriber by email, needs admin permissions"""
-    subscriber_to_enable = repo.subscriber.get_by_email(db, email)
+    subscriber_to_enable = repo.subscriber.get_by_email(db, email.lower())
     if not subscriber_to_enable:
         raise validation.SubscriberNotFoundException()
     if not subscriber_to_enable.is_deleted:

--- a/backend/src/appointment/routes/webhooks.py
+++ b/backend/src/appointment/routes/webhooks.py
@@ -53,7 +53,7 @@ def fxa_process(
             case 'https://schemas.accounts.firefox.com/event/profile-change':
                 if event_data.get('email') is not None:
                     # Update the subscriber's email, we do this first in case there's a problem with get_profile()
-                    subscriber.email = event_data.get('email')
+                    subscriber.email = event_data.get('email').lower()
                     db.add(subscriber)
                     db.commit()
 

--- a/backend/test/integration/test_auth.py
+++ b/backend/test/integration/test_auth.py
@@ -32,7 +32,7 @@ class TestAuth:
 
         assert response.status_code == 200, response.text
         data = response.json()
-        assert data == True
+        assert data is True
 
     def test_me(self, with_db, with_client):
         response = with_client.get('/me', headers=auth_headers)

--- a/backend/test/integration/test_auth.py
+++ b/backend/test/integration/test_auth.py
@@ -13,6 +13,27 @@ from appointment.database import repo, models
 
 
 class TestAuth:
+    def test_can_login(self, with_db, with_client, make_pro_subscriber, faker):
+        # Request can-login with a capitalized email
+        capital_email = faker.email().capitalize()
+        subscriber = make_pro_subscriber(email=capital_email)
+
+        assert subscriber.email != capital_email
+        assert subscriber.email == capital_email.lower()
+
+        with with_db() as db:
+            # Check we've saved the email as lowercase
+            subscriber_check = repo.subscriber.get_by_email(db, capital_email.lower())
+            assert subscriber_check is not None
+            assert subscriber_check.email != capital_email
+            assert subscriber_check.email == capital_email.lower()
+
+        response = with_client.post('/can-login', json={'email': subscriber.email})
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data == True
+
     def test_me(self, with_db, with_client):
         response = with_client.get('/me', headers=auth_headers)
         assert response.status_code == 200, response.text
@@ -198,21 +219,14 @@ class TestFXA:
         email = 'not-in-allow-list@bad-example.org'
         response = with_client.get(
             '/fxa_login',
-            params={
-                'email': email,
-                'invite_code': 'absolute nonsense!'
-            },
+            params={'email': email, 'invite_code': 'absolute nonsense!'},
         )
         assert response.status_code == 404, response.text
         data = response.json()
         assert data.get('detail') == l10n('invite-code-not-valid')
 
     def test_fxa_with_allowlist_and_with_used_invite_code(
-        self,
-        with_client,
-        with_l10n,
-        make_invite,
-        make_pro_subscriber
+        self, with_client, with_l10n, make_invite, make_pro_subscriber
     ):
         os.environ['AUTH_SCHEME'] = 'fxa'
         os.environ['FXA_ALLOW_LIST'] = '@example.org'
@@ -223,10 +237,7 @@ class TestFXA:
         email = 'not-in-allow-list@bad-example.org'
         response = with_client.get(
             '/fxa_login',
-            params={
-                'email': email,
-                'invite_code': invite.code
-            },
+            params={'email': email, 'invite_code': invite.code},
         )
         assert response.status_code == 403, response.text
         data = response.json()
@@ -433,17 +444,12 @@ class TestFXA:
 
         subscriber = make_basic_subscriber(email='apple@example.org')
         access_token_expires = timedelta(minutes=float(10))
-        one_time_access_token = create_access_token(data={
-            'sub': f'uid-{subscriber.id}',
-            'jti': secrets.token_urlsafe(16)
-        }, expires_delta=access_token_expires)
+        one_time_access_token = create_access_token(
+            data={'sub': f'uid-{subscriber.id}', 'jti': secrets.token_urlsafe(16)}, expires_delta=access_token_expires
+        )
 
         # Exchange the one-time token with a long-living token
-        response = with_client.post(
-            '/fxa-token', headers={
-                'Authorization': f'Bearer {one_time_access_token}'
-            }
-        )
+        response = with_client.post('/fxa-token', headers={'Authorization': f'Bearer {one_time_access_token}'})
 
         assert response.status_code == 200, response.text
 
@@ -454,11 +460,7 @@ class TestFXA:
         assert data.get('token_type') == 'bearer'
 
         # Test it out!
-        response = with_client.get(
-            '/me', headers={
-                'Authorization': f'Bearer {access_token}'
-            }
-        )
+        response = with_client.get('/me', headers={'Authorization': f'Bearer {access_token}'})
 
         assert response.status_code == 200, response.text
         assert response.json().get('email') == subscriber.email
@@ -471,15 +473,14 @@ class TestFXA:
 
         subscriber = make_basic_subscriber(email='apple@example.org')
         access_token_expires = timedelta(minutes=float(10))
-        regular_access_token = create_access_token(data={
-            'sub': f'uid-{subscriber.id}',
-        }, expires_delta=access_token_expires)
-
-        response = with_client.post(
-            '/fxa-token', headers={
-                'Authorization': f'Bearer {regular_access_token}'
-            }
+        regular_access_token = create_access_token(
+            data={
+                'sub': f'uid-{subscriber.id}',
+            },
+            expires_delta=access_token_expires,
         )
+
+        response = with_client.post('/fxa-token', headers={'Authorization': f'Bearer {regular_access_token}'})
 
         assert response.status_code == 401, response.text
 
@@ -489,9 +490,7 @@ class TestFXA:
 
         del with_client.app.dependency_overrides[auth.get_subscriber]
 
-        response = with_client.post(
-            '/fxa-token'
-        )
+        response = with_client.post('/fxa-token')
 
         assert response.status_code == 401, response.text
 
@@ -504,17 +503,12 @@ class TestFXA:
 
         subscriber = make_basic_subscriber(email='apple@example.org')
         access_token_expires = timedelta(minutes=float(10))
-        one_time_access_token = create_access_token(data={
-            'sub': f'uid-{subscriber.id}',
-            'jti': secrets.token_urlsafe(16)
-        }, expires_delta=access_token_expires)
+        one_time_access_token = create_access_token(
+            data={'sub': f'uid-{subscriber.id}', 'jti': secrets.token_urlsafe(16)}, expires_delta=access_token_expires
+        )
 
         # Exchange the one-time token with a long-living token
-        response = with_client.post(
-            '/fxa-token', headers={
-                'Authorization': f'Bearer {one_time_access_token}'
-            }
-        )
+        response = with_client.post('/fxa-token', headers={'Authorization': f'Bearer {one_time_access_token}'})
         os.environ['AUTH_SCHEME'] = saved_scheme
         assert response.status_code == 405, response.text
 
@@ -530,17 +524,15 @@ class TestCalDAV:
             assert len(ecs) == 0
 
         with patch('appointment.controller.calendar.Tools.dns_caldav_lookup') as mock:
-            mock.return_value = "https://example.com", 300
+            mock.return_value = 'https://example.com', 300
 
             with patch('appointment.controller.calendar.CalDavConnector.sync_calendars') as sync_mock:
                 sync_mock.return_value = None
 
                 response = with_client.post(
                     '/caldav/auth',
-                    json={'user': 'test@example.com',
-                    'url': 'example.com',
-                    'password': 'test'},
-                    headers=auth_headers
+                    json={'user': 'test@example.com', 'url': 'example.com', 'password': 'test'},
+                    headers=auth_headers,
                 )
 
                 mock.assert_called()
@@ -559,19 +551,13 @@ class TestCalDAV:
         ec = make_external_connections(TEST_USER_ID, type=models.ExternalConnectionType.caldav, type_id=type_id)
         calendar = make_caldav_calendar(subscriber_id=TEST_USER_ID, user=username)
 
-        response = with_client.post(
-            '/caldav/disconnect', json={'type_id': ec.type_id},
-            headers=auth_headers
-        )
+        response = with_client.post('/caldav/disconnect', json={'type_id': ec.type_id}, headers=auth_headers)
 
         assert response.status_code == 200, response.content
 
         with with_db() as db:
             ecs = repo.external_connection.get_by_type(
-                db,
-                TEST_USER_ID,
-                models.ExternalConnectionType.caldav,
-                type_id=type_id
+                db, TEST_USER_ID, models.ExternalConnectionType.caldav, type_id=type_id
             )
             assert len(ecs) == 0
 
@@ -586,19 +572,13 @@ class TestGoogle:
         ec = make_external_connections(TEST_USER_ID, type=models.ExternalConnectionType.google, type_id=type_id)
         calendar = make_google_calendar(subscriber_id=TEST_USER_ID)
 
-        response = with_client.post(
-            '/google/disconnect', json={'type_id': ec.type_id},
-            headers=auth_headers
-        )
+        response = with_client.post('/google/disconnect', json={'type_id': ec.type_id}, headers=auth_headers)
 
         assert response.status_code == 200, response.content
 
         with with_db() as db:
             ecs = repo.external_connection.get_by_type(
-                db,
-                TEST_USER_ID,
-                models.ExternalConnectionType.google,
-                type_id=type_id
+                db, TEST_USER_ID, models.ExternalConnectionType.google, type_id=type_id
             )
             assert len(ecs) == 0
 

--- a/backend/test/integration/test_waiting_list.py
+++ b/backend/test/integration/test_waiting_list.py
@@ -31,7 +31,9 @@ class TestJoinWaitingList:
             # Ensure our email was inserted as lowercase
             with with_db() as db:
                 assert db.query(models.WaitingList).filter(models.WaitingList.email == email).first() is None
-                assert db.query(models.WaitingList).filter(models.WaitingList.email == email.lower()).first() is not None
+                assert (
+                    db.query(models.WaitingList).filter(models.WaitingList.email == email.lower()).first() is not None
+                )
 
             # Ensure we sent out an email
             mock.assert_called_once()
@@ -146,7 +148,7 @@ class TestWaitingListActionConfirm:
 
         # Ensure the response was okay!
         assert response.status_code == 200, response.json()
-        assert response.json() == { "action": WaitingListAction.CONFIRM_EMAIL.value, "success": True }
+        assert response.json() == {'action': WaitingListAction.CONFIRM_EMAIL.value, 'success': True}
 
         with with_db() as db:
             self.assert_email_verified(db, waiting_list, success=True)
@@ -261,7 +263,7 @@ class TestWaitingListActionLeave:
 
         # Ensure the response was okay!
         assert response.status_code == 200, response.json()
-        assert response.json() == {"action": WaitingListAction.LEAVE.value, "success": True}
+        assert response.json() == {'action': WaitingListAction.LEAVE.value, 'success': True}
 
         with with_db() as db:
             self.assert_waiting_list_exists(db, waiting_list, success=True)
@@ -276,7 +278,7 @@ class TestWaitingListActionLeave:
 
         # Ensure the response was okay!
         assert response.status_code == 200, response.json()
-        assert response.json() == { "action": WaitingListAction.LEAVE.value, "success": True }
+        assert response.json() == {'action': WaitingListAction.LEAVE.value, 'success': True}
 
         with with_db() as db:
             assert not db.query(models.WaitingList).filter(models.WaitingList.email == email).first()
@@ -297,9 +299,9 @@ class TestWaitingListActionLeave:
         # Ensure the response was okay!
         assert response.status_code == 200, response.json()
         assert response.json() == {
-            "action": WaitingListAction.LEAVE.value,
-            "success": False,
-            "redirectToSettings": True
+            'action': WaitingListAction.LEAVE.value,
+            'success': False,
+            'redirectToSettings': True,
         }
 
 
@@ -340,11 +342,9 @@ class TestWaitingListAdminInvite:
         waiting_list_user = make_waiting_list()
 
         with patch('fastapi.BackgroundTasks.add_task') as mock:
-            response = with_client.post('/waiting-list/invite',
-                                        json={
-                                            'id_list': [waiting_list_user.id]
-                                        },
-                                        headers=auth_headers)
+            response = with_client.post(
+                '/waiting-list/invite', json={'id_list': [waiting_list_user.id]}, headers=auth_headers
+            )
 
             # Ensure the response was okay!
             data = response.json()
@@ -376,14 +376,12 @@ class TestWaitingListAdminInvite:
         """Test a successful invite of many users"""
         os.environ['APP_ADMIN_ALLOW_LIST'] = os.getenv('TEST_USER_EMAIL')
 
-        waiting_list_users = [ make_waiting_list().id for i in range(0, 10) ]
+        waiting_list_users = [make_waiting_list().id for i in range(0, 10)]
 
         with patch('fastapi.BackgroundTasks.add_task') as mock:
-            response = with_client.post('/waiting-list/invite',
-                                        json={
-                                            'id_list': waiting_list_users
-                                        },
-                                        headers=auth_headers)
+            response = with_client.post(
+                '/waiting-list/invite', json={'id_list': waiting_list_users}, headers=auth_headers
+            )
 
             # Ensure the response was okay!
             data = response.json()
@@ -415,12 +413,7 @@ class TestWaitingListAdminInvite:
                     }
 
     def test_invite_existing_subscriber(
-        self,
-        with_client,
-        with_db,
-        with_l10n,
-        make_waiting_list,
-        make_basic_subscriber
+        self, with_client, with_db, with_l10n, make_waiting_list, make_basic_subscriber
     ):
         os.environ['APP_ADMIN_ALLOW_LIST'] = os.getenv('TEST_USER_EMAIL')
 
@@ -428,11 +421,9 @@ class TestWaitingListAdminInvite:
         waiting_list_user = make_waiting_list(email=sub.email)
 
         with patch('fastapi.BackgroundTasks.add_task') as mock:
-            response = with_client.post('/waiting-list/invite',
-                                        json={
-                                            'id_list': [waiting_list_user.id]
-                                        },
-                                        headers=auth_headers)
+            response = with_client.post(
+                '/waiting-list/invite', json={'id_list': [waiting_list_user.id]}, headers=auth_headers
+            )
 
             # Ensure the response was okay!
             data = response.json()
@@ -446,26 +437,18 @@ class TestWaitingListAdminInvite:
             mock.assert_not_called()
 
     def test_invite_many_users_with_one_existing_subscriber(
-        self,
-        with_client,
-        with_db,
-        with_l10n,
-        make_waiting_list,
-        make_basic_subscriber
+        self, with_client, with_db, with_l10n, make_waiting_list, make_basic_subscriber
     ):
         os.environ['APP_ADMIN_ALLOW_LIST'] = os.getenv('TEST_USER_EMAIL')
 
         sub = make_basic_subscriber()
-        waiting_list_users = [ make_waiting_list().id for i in range(0, 10) ]
+        waiting_list_users = [make_waiting_list().id for i in range(0, 10)]
         waiting_list_users.append(make_waiting_list(email=sub.email).id)
 
         with patch('fastapi.BackgroundTasks.add_task') as mock:
-
-            response = with_client.post('/waiting-list/invite',
-                                        json={
-                                            'id_list': waiting_list_users
-                                        },
-                                        headers=auth_headers)
+            response = with_client.post(
+                '/waiting-list/invite', json={'id_list': waiting_list_users}, headers=auth_headers
+            )
 
             # Ensure the response was okay!
             data = response.json()
@@ -491,5 +474,5 @@ class TestWaitingListAdminInvite:
                         assert mock.call_args_list[i].kwargs == {
                             'date': waiting_list_user.time_created,
                             'lang': 'en',
-                            'to': waiting_list_user.email
+                            'to': waiting_list_user.email,
                         }

--- a/backend/test/integration/test_webhooks.py
+++ b/backend/test/integration/test_webhooks.py
@@ -109,7 +109,8 @@ class TestFXAWebhooks:
         make_external_connections(subscriber_id, type=models.ExternalConnectionType.fxa, type_id=FXA_USER_ID)
 
         assert subscriber.minimum_valid_iat_time is None
-        assert subscriber.email == OLD_EMAIL
+        assert subscriber.email != OLD_EMAIL
+        assert subscriber.email == OLD_EMAIL.lower()
         assert subscriber.avatar_url != FXA_CLIENT_PATCH.get('subscriber_avatar_url')
         assert subscriber.name != FXA_CLIENT_PATCH.get('subscriber_display_name')
 


### PR DESCRIPTION
(Fixes #914)

This isn't as the name implies actually a quick fix, but I find it a little silly slapping to .lower() in a bunch of places. If anyone else has a good idea on centralizing this step I'm all ears! (Likewise for additional test cases.)

But this should resolve any outstanding email casing issues. 