### PR TITLE
Timezone offset issue

### DIFF
--- a/backend/src/appointment/routes/caldav.py
+++ b/backend/src/appointment/routes/caldav.py
@@ -56,6 +56,7 @@ def caldav_autodiscover_auth(
         }
         # Raise and catch the unexpected behaviour warning so we can get proper stacktrace in sentry...
         try:
+            sentry_sdk.set_extra('debug_object', debug_obj)
             raise UnexpectedBehaviourWarning(message='Cache incorrect', info=debug_obj)
         except UnexpectedBehaviourWarning as ex:
             sentry_sdk.capture_exception(ex)
@@ -91,6 +92,7 @@ def caldav_autodiscover_auth(
         }
         # Raise and catch the unexpected behaviour warning so we can get proper stacktrace in sentry...
         try:
+            sentry_sdk.set_extra('debug_object', debug_obj)
             raise UnexpectedBehaviourWarning(message='Invalid caldav url', info=debug_obj)
         except UnexpectedBehaviourWarning as ex:
             sentry_sdk.capture_exception(ex)

--- a/backend/src/appointment/routes/schedule.py
+++ b/backend/src/appointment/routes/schedule.py
@@ -277,6 +277,7 @@ def request_schedule_availability_slot(
         }
         # Raise and catch the unexpected behaviour warning so we can get proper stacktrace in sentry...
         try:
+            sentry_sdk.set_extra('debug_object', debug_obj)
             raise UnexpectedBehaviourWarning(message='Invalid booking time warning!', info=debug_obj)
         except UnexpectedBehaviourWarning as ex:
             sentry_sdk.capture_exception(ex)

--- a/backend/src/appointment/routes/schedule.py
+++ b/backend/src/appointment/routes/schedule.py
@@ -36,7 +36,8 @@ from ..exceptions.misc import UnexpectedBehaviourWarning
 from ..exceptions.validation import RemoteCalendarConnectionError, EventCouldNotBeAccepted, EventCouldNotBeDeleted
 from ..tasks.emails import (
     send_confirmation_email,
-    send_zoom_meeting_failed_email, send_new_booking_email,
+    send_zoom_meeting_failed_email,
+    send_new_booking_email,
 )
 from ..l10n import l10n
 from slowapi import Limiter
@@ -45,7 +46,6 @@ from fastapi import APIRouter, Depends, BackgroundTasks, Request
 
 router = APIRouter()
 limiter = Limiter(key_func=get_remote_address)
-
 
 
 def is_this_a_valid_booking_time(schedule: models.Schedule, booking_slot: schemas.SlotBase) -> bool:
@@ -79,7 +79,11 @@ def is_this_a_valid_booking_time(schedule: models.Schedule, booking_slot: schema
 
     # We need to compare in local time
     start_datetime = datetime.combine(today, schedule.start_time, tzinfo=schedule_tzinfo) + schedule.timezone_offset
-    end_datetime = datetime.combine(today, schedule.end_time, tzinfo=schedule_tzinfo) + timedelta(days=add_day) + schedule.timezone_offset
+    end_datetime = (
+        datetime.combine(today, schedule.end_time, tzinfo=schedule_tzinfo)
+        + timedelta(days=add_day)
+        + schedule.timezone_offset
+    )
     booking_slot_end = booking_slot_start + timedelta(minutes=schedule.slot_duration)
 
     too_early = booking_slot_start < start_datetime
@@ -170,7 +174,7 @@ def update_schedule(
 
 
 @router.post('/public/availability', response_model=schemas.AppointmentOut)
-@limiter.limit("20/minute")
+@limiter.limit('20/minute')
 def read_schedule_availabilities(
     request: Request,
     subscriber: Subscriber = Depends(get_subscriber_from_schedule_or_signed_url),
@@ -178,8 +182,7 @@ def read_schedule_availabilities(
     redis=Depends(get_redis),
     google_client: GoogleClient = Depends(get_google_client),
 ):
-    """Returns the calculated availability for the first schedule from a subscribers public profile link
-    """
+    """Returns the calculated availability for the first schedule from a subscribers public profile link"""
     # Raise a schedule not found exception if the schedule owner does not have a timezone set.
     if subscriber.timezone is None:
         raise validation.ScheduleNotFoundException()
@@ -221,12 +224,12 @@ def read_schedule_availabilities(
         owner_name=subscriber.name,
         slots=actual_slots,
         slot_duration=schedule.slot_duration,
-        booking_confirmation=schedule.booking_confirmation
+        booking_confirmation=schedule.booking_confirmation,
     )
 
 
 @router.put('/public/availability/request')
-@limiter.limit("20/minute")
+@limiter.limit('20/minute')
 def request_schedule_availability_slot(
     request: Request,
     s_a: schemas.AvailabilitySlotAttendee,
@@ -236,8 +239,7 @@ def request_schedule_availability_slot(
     redis=Depends(get_redis),
     google_client=Depends(get_google_client),
 ):
-    """endpoint to request a time slot for a schedule via public link and send confirmation mail to owner if set
-    """
+    """endpoint to request a time slot for a schedule via public link and send confirmation mail to owner if set"""
 
     # Raise a schedule not found exception if the schedule owner does not have a timezone set.
     if subscriber.timezone is None:
@@ -274,7 +276,7 @@ def request_schedule_availability_slot(
                 'start_date': schedule.start_date,
                 'end_date': schedule.end_date,
                 'earliest_booking': schedule.earliest_booking,
-                'farthest_booking': schedule.farthest_booking
+                'farthest_booking': schedule.farthest_booking,
             },
             'slot': s_a.slot,
             'submitter_timezone': s_a.attendee.timezone,
@@ -388,7 +390,7 @@ def request_schedule_availability_slot(
             duration=slot.duration,
             schedule_name=schedule.name,
             to=subscriber.preferred_email,
-            lang=subscriber.language
+            lang=subscriber.language,
         )
 
         # Create remote HOLD event
@@ -429,7 +431,7 @@ def request_schedule_availability_slot(
             duration=slot.duration,
             schedule_name=schedule.name,
             to=subscriber.preferred_email,
-            lang=subscriber.language
+            lang=subscriber.language,
         )
 
     # Mini version of slot, so we can grab the newly created slot id for tests
@@ -449,8 +451,7 @@ def decide_on_schedule_availability_slot(
     redis=Depends(get_redis),
     google_client: GoogleClient = Depends(get_google_client),
 ):
-    """endpoint to react to owners decision to a request of a time slot of his public link
-    """
+    """endpoint to react to owners decision to a request of a time slot of his public link"""
     subscriber = repo.subscriber.verify_link(db, data.owner_url)
     if not subscriber:
         raise validation.InvalidLinkException()
@@ -498,15 +499,7 @@ def decide_on_schedule_availability_slot(
 
 
 def handle_schedule_availability_decision(
-    confirmed: bool,
-    calendar,
-    schedule,
-    subscriber,
-    slot,
-    db,
-    redis,
-    google_client,
-    background_tasks
+    confirmed: bool, calendar, schedule, subscriber, slot, db, redis, google_client, background_tasks
 ):
     """Actual handling of the availability decision
     if confirmed: create an event in remote calendar and send invitation mail
@@ -572,9 +565,7 @@ def handle_schedule_availability_decision(
 
             # Notify the organizer that the meeting link could not be created!
             background_tasks.add_task(
-                send_zoom_meeting_failed_email,
-                to=subscriber.preferred_email,
-                appointment_title=schedule.name
+                send_zoom_meeting_failed_email, to=subscriber.preferred_email, appointment_title=schedule.name
             )
         except OAuth2Error as err:
             logging.error('OAuth flow error during zoom meeting creation: ', err)
@@ -583,9 +574,7 @@ def handle_schedule_availability_decision(
 
             # Notify the organizer that the meeting link could not be created!
             background_tasks.add_task(
-                send_zoom_meeting_failed_email,
-                to=subscriber.preferred_email,
-                appointment_title=schedule.name
+                send_zoom_meeting_failed_email, to=subscriber.preferred_email, appointment_title=schedule.name
             )
         except SQLAlchemyError as err:  # Not fatal, but could make things tricky
             logging.error('Failed to save the zoom meeting link to the appointment: ', err)
@@ -655,21 +644,17 @@ def get_remote_connection(calendar, subscriber, db, redis, google_client):
             user=calendar.user,
             password=calendar.password,
         )
-    
+
     return (con, organizer_email)
 
 
 def save_remote_event(event, calendar, subscriber, slot, db, redis, google_client):
-    """Create or update a remote event
-    """
+    """Create or update a remote event"""
     con, organizer_email = get_remote_connection(calendar, subscriber, db, redis, google_client)
 
     try:
         return con.save_event(
-            event=event,
-            attendee=slot.attendee,
-            organizer=subscriber,
-            organizer_email=organizer_email
+            event=event, attendee=slot.attendee, organizer=subscriber, organizer_email=organizer_email
         )
     except EventNotCreatedException:
         raise EventCouldNotBeAccepted

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -148,6 +148,7 @@ def with_db():
             name='Test Account',
             level=models.SubscriberLevel.pro,
             short_link_hash='abc1234',
+            timezone='America/Vancouver',
         )
         db.add(subscriber)
         db.commit()

--- a/backend/test/factory/schedule_factory.py
+++ b/backend/test/factory/schedule_factory.py
@@ -30,7 +30,7 @@ def make_schedule(with_db, make_caldav_calendar):
         time_updated=None,
     ):
         with with_db() as db:
-            return repo.schedule.create(
+            schedule = repo.schedule.create(
                 db,
                 schemas.ScheduleBase(
                     active=active,
@@ -55,8 +55,14 @@ def make_schedule(with_db, make_caldav_calendar):
                     if factory_has_value(calendar_id)
                     else make_caldav_calendar(connected=True).id,
                     timezone=timezone,
-                    time_updated=time_updated,
                 ),
             )
+            if time_updated:
+                schedule.time_updated = time_updated
+                db.add(schedule)
+                db.commit()
+                # Re-bind the session, since commit closes it
+                db.refresh(schedule)
+            return schedule
 
     return _make_schedule

--- a/backend/test/integration/test_schedule.py
+++ b/backend/test/integration/test_schedule.py
@@ -354,7 +354,7 @@ class TestSchedule:
             # Based off the farthest_booking our latest slot is 4:30pm
             # Note: This should be in PDT (Pacific Daylight Time)
             # Note2: The schedule ends at 0 UTC (or 16-07:00) so the last slot is 30 mins before that.
-            assert slots[-1]['start'] == '2024-03-15T15:30:00-07:00'
+            assert slots[-1]['start'] == '2024-03-15T16:30:00-07:00'
 
         # Check availability over a year from now
         with freeze_time(date(2025, 6, 1)):
@@ -367,8 +367,8 @@ class TestSchedule:
             data = response.json()
             slots = data['slots']
 
-            assert slots[0]['start'] == '2025-06-02T08:00:00-07:00'
-            assert slots[-1]['start'] == '2025-06-13T15:30:00-07:00'
+            assert slots[0]['start'] == '2025-06-02T09:00:00-07:00'
+            assert slots[-1]['start'] == '2025-06-13T16:30:00-07:00'
 
         # Check availability with a start date day greater than the farthest_booking day
         with freeze_time(date(2025, 6, 27)):
@@ -381,8 +381,8 @@ class TestSchedule:
             data = response.json()
             slots = data['slots']
 
-            assert slots[0]['start'] == '2025-06-30T08:00:00-07:00'
-            assert slots[-1]['start'] == '2025-07-11T15:30:00-07:00'
+            assert slots[0]['start'] == '2025-06-30T09:00:00-07:00'
+            assert slots[-1]['start'] == '2025-07-11T16:30:00-07:00'
 
     def test_public_availability_with_blockers(
         self, monkeypatch, with_client, make_pro_subscriber, make_caldav_calendar, make_schedule

--- a/backend/test/integration/test_schedule.py
+++ b/backend/test/integration/test_schedule.py
@@ -349,8 +349,8 @@ class TestSchedule:
             slots = data['slots']
 
             # Based off the earliest_booking our earliest slot is tomorrow at 9:00am
-            # Note: this should be in PST (Pacific Standard Time)
-            assert slots[0]['start'] == '2024-03-04T08:00:00-08:00'
+            # Note: this should be in PDT (Pacific Daylight Time)
+            assert slots[0]['start'] == '2024-03-04T09:00:00-08:00'
             # Based off the farthest_booking our latest slot is 4:30pm
             # Note: This should be in PDT (Pacific Daylight Time)
             # Note2: The schedule ends at 0 UTC (or 16-07:00) so the last slot is 30 mins before that.

--- a/backend/test/integration/test_subscriber.py
+++ b/backend/test/integration/test_subscriber.py
@@ -27,7 +27,7 @@ class TestSubscriber:
         assert test_subscriber['short_link_hash'] == 'abc1234'
         assert test_subscriber['id'] == TEST_USER_ID
         assert test_subscriber['language'] == 'en'
-        assert test_subscriber['timezone'] is None
+        assert test_subscriber['timezone'] == 'America/Vancouver'
         assert test_subscriber['is_setup'] is False
         assert test_subscriber['ftue_level'] == 0
         assert test_subscriber['level'] == SubscriberLevel.pro.value

--- a/backend/test/unit/test_utils.py
+++ b/backend/test/unit/test_utils.py
@@ -116,8 +116,8 @@ class TestIsAValidBookingTime:
             farthest_booking=10080,
             weekdays=[1, 2, 3, 4, 5],
             slot_duration=30,
-            start_time="22:00",  # 9AM AEDT
-            end_time="06:00",  # 5PM AEDT
+            start_time='22:00',  # 9AM AEDT
+            end_time='06:00',  # 5PM AEDT
             timezone='Australia/Sydney',
             time_updated=datetime.datetime(2024, 11, 15, 12, 0, 0, tzinfo=datetime.UTC),
         )
@@ -125,3 +125,31 @@ class TestIsAValidBookingTime:
         is_valid = is_this_a_valid_booking_time(schedule, s_a.slot)
 
         assert is_valid is True
+
+    def test_pst_to_pdt_change(self, make_schedule):
+        request_data = {
+            's_a': {
+                'slot': {'start': '2025-03-11T16:00:00.000Z', 'duration': 30},
+                'attendee': {'name': 'melissa', 'email': 'melissa@example.org', 'timezone': 'America/Vancouver'},
+            },
+            'url': 'http://localhost:8080/user/username/example/',
+        }
+
+        s_a = schemas.AvailabilitySlotAttendee(**request_data['s_a'])
+
+        schedule = make_schedule(
+            active=True,
+            start_date=datetime.date(2025, 2, 5),
+            end_date=None,
+            earliest_booking=0,
+            farthest_booking=10080,
+            weekdays=[1, 2, 3, 4, 5],
+            slot_duration=30,
+            start_time='17:00',  # 9AM PST
+            end_time='01:00',  # 5PM PST
+            timezone='America/Vancouver',
+            time_updated=datetime.datetime(2025, 2, 5, 20, 8, 29, tzinfo=datetime.UTC),
+        )
+
+        is_valid = is_this_a_valid_booking_time(schedule, s_a.slot)
+        assert is_valid


### PR DESCRIPTION
Fixes #919 

This took a bit of thinking. But we can't actually calculate the time in UTC as the stored schedule start/end time is in UTC from potentially a different offset than the incoming booking start/end time.

So lets transform these all to local time and do the comparison. We have the intended start/end time's offset from when the schedule was last saved, so we can use that to transform 17 back to 9, and today's offset can be used to transform 16 to 9. 

I've also adjusted the test subscriber's timezone to default to America/Vancouver, and updated some tests.