### PR TITLE
Don't include relationships for the Subscriber admin item

### DIFF
--- a/backend/src/appointment/database/schemas.py
+++ b/backend/src/appointment/database/schemas.py
@@ -338,9 +338,10 @@ class SubscriberMeOut(SubscriberBase):
     schedule_links: list[str] = []
 
 
-class SubscriberAdminItem(Subscriber):
+class SubscriberAdminItem(SubscriberAuth):
     model_config = ConfigDict(from_attributes=True)
 
+    id: int
     invite: Invite | None = None
     time_created: datetime
     time_deleted: datetime | None

--- a/backend/src/appointment/database/schemas.py
+++ b/backend/src/appointment/database/schemas.py
@@ -345,6 +345,7 @@ class SubscriberAdminItem(SubscriberAuth):
     invite: Invite | None = None
     time_created: datetime
     time_deleted: datetime | None
+    ftue_level: Optional[int] = Field(json_schema_extra={'gte': 0})
 
 
 class Paginator(BaseModel):


### PR DESCRIPTION
I didn't get this error until now...odd. But this prevents it from recursively calling the relationships...oops.

This change pulls in some of schema.Subscriber keys without pulling in the relationships to calendars and slots that we don't need in this context.