### PR TITLE
Disable/Enable Routes Should Use ID (Fixes #932)

### DIFF
--- a/backend/src/appointment/routes/subscriber.py
+++ b/backend/src/appointment/routes/subscriber.py
@@ -47,12 +47,12 @@ def get_all_subscriber(
     )
 
 
-@router.put('/disable/{email}')
+@router.put('/disable/{id}')
 def disable_subscriber(
-    email: str, db: Session = Depends(get_db), subscriber: Subscriber = Depends(get_admin_subscriber)
+    id: str, db: Session = Depends(get_db), subscriber: Subscriber = Depends(get_admin_subscriber)
 ):
-    """endpoint to mark a subscriber deleted by email, needs admin permissions"""
-    subscriber_to_delete = repo.subscriber.get_by_email(db, email)
+    """endpoint to mark a subscriber deleted by id, needs admin permissions"""
+    subscriber_to_delete = repo.subscriber.get(db, int(id))
     if not subscriber_to_delete:
         raise validation.SubscriberNotFoundException()
     if subscriber_to_delete.is_deleted:
@@ -64,10 +64,10 @@ def disable_subscriber(
     return repo.subscriber.disable(db, subscriber_to_delete)
 
 
-@router.put('/enable/{email}')
-def enable_subscriber(email: str, db: Session = Depends(get_db), _: Subscriber = Depends(get_admin_subscriber)):
-    """endpoint to enable a subscriber by email, needs admin permissions"""
-    subscriber_to_enable = repo.subscriber.get_by_email(db, email)
+@router.put('/enable/{id}')
+def enable_subscriber(id: str, db: Session = Depends(get_db), _: Subscriber = Depends(get_admin_subscriber)):
+    """endpoint to enable a subscriber by id, needs admin permissions"""
+    subscriber_to_enable = repo.subscriber.get(db, int(id))
     if not subscriber_to_enable:
         raise validation.SubscriberNotFoundException()
     if not subscriber_to_enable.is_deleted:

--- a/backend/test/integration/test_subscriber.py
+++ b/backend/test/integration/test_subscriber.py
@@ -189,7 +189,7 @@ class TestSubscriber:
         assert new_subscriber.time_deleted is None
 
         # disable our new subscriber and verify
-        response = with_client.put(f'/subscriber/disable/{new_subscriber.email}', headers=auth_headers)
+        response = with_client.put(f'/subscriber/disable/{new_subscriber.id}', headers=auth_headers)
 
         assert response.status_code == 200, response.text
         response = with_client.post('/subscriber', json={'page': 1}, headers=auth_headers)
@@ -204,14 +204,14 @@ class TestSubscriber:
         assert date_deleted == today
 
         # attempt to disable same subscriber again, expect fail
-        response = with_client.put(f'/subscriber/disable/{new_subscriber.email}', headers=auth_headers)
+        response = with_client.put(f'/subscriber/disable/{new_subscriber.id}', headers=auth_headers)
 
         assert response.status_code == 400, response.text
         data = response.json()
         assert data['detail']['id'] == 'SUBSCRIBER_ALREADY_DELETED'
 
         # now enable the deleted subscriber and verify
-        response = with_client.put(f'/subscriber/enable/{new_subscriber.email}', headers=auth_headers)
+        response = with_client.put(f'/subscriber/enable/{new_subscriber.id}', headers=auth_headers)
 
         assert response.status_code == 200, response.text
         response = with_client.post('/subscriber', json={'page': 1}, headers=auth_headers)
@@ -222,7 +222,7 @@ class TestSubscriber:
         assert subscriber_ret['time_deleted'] is None
 
         # attempt to enable the same subscriber again, expect fail
-        response = with_client.put(f'/subscriber/enable/{new_subscriber.email}', headers=auth_headers)
+        response = with_client.put(f'/subscriber/enable/{new_subscriber.id}', headers=auth_headers)
 
         assert response.status_code == 400, response.text
         data = response.json()
@@ -233,7 +233,7 @@ class TestSubscriber:
         os.environ['APP_ADMIN_ALLOW_LIST'] = '@example.org'
 
         # disable our current subscriber and verify
-        response = with_client.put(f'/subscriber/disable/{os.getenv('TEST_USER_EMAIL')}', headers=auth_headers)
+        response = with_client.put(f'/subscriber/disable/{TEST_USER_ID}', headers=auth_headers)
 
         assert response.status_code == 403, response.text
         data = response.json()
@@ -244,7 +244,7 @@ class TestSubscriber:
         os.environ['APP_ADMIN_ALLOW_LIST'] = '@example.org'
 
         # disable a subscriber that doesn't exist
-        response = with_client.put('/subscriber/disable/this-user-does-not-exist@someemail.com', headers=auth_headers)
+        response = with_client.put('/subscriber/disable/999999999999', headers=auth_headers)
 
         assert response.status_code == 404, response.text
         data = response.json()
@@ -254,7 +254,7 @@ class TestSubscriber:
         # ensure our current subscriber is not admin
         os.environ['APP_ADMIN_ALLOW_LIST'] = '@notexample.org'
 
-        response = with_client.put(f'/subscriber/disable/{os.getenv('TEST_USER_EMAIL')}', headers=auth_headers)
+        response = with_client.put(f'/subscriber/disable/{TEST_USER_ID}', headers=auth_headers)
 
         assert response.status_code == 401, response.text
         data = response.json()
@@ -265,7 +265,7 @@ class TestSubscriber:
         os.environ['APP_ADMIN_ALLOW_LIST'] = '@example.org'
 
         # disable a subscriber that doesn't exist
-        response = with_client.put('/subscriber/enable/this-user-does-not-exist@someemail.com', headers=auth_headers)
+        response = with_client.put('/subscriber/enable/8888888888888888888', headers=auth_headers)
 
         assert response.status_code == 404, response.text
         data = response.json()
@@ -275,7 +275,7 @@ class TestSubscriber:
         # ensure our current subscriber is not admin
         os.environ['APP_ADMIN_ALLOW_LIST'] = '@notexample.org'
 
-        response = with_client.put(f'/subscriber/enable/{os.getenv('TEST_USER_EMAIL')}', headers=auth_headers)
+        response = with_client.put(f'/subscriber/enable/{TEST_USER_ID}', headers=auth_headers)
 
         assert response.status_code == 401, response.text
         data = response.json()
@@ -324,7 +324,7 @@ class TestSubscriber:
         steves_schedule = make_schedule(calendar_id=steves_calendar.id)
 
         # disable steves account
-        response = with_client.put(f'/subscriber/disable/{steve.email}', headers=auth_headers)
+        response = with_client.put(f'/subscriber/disable/{steve.id}', headers=auth_headers)
 
         assert response.status_code == 200, response.json()
 

--- a/frontend/src/views/admin/InviteCodePanelView.vue
+++ b/frontend/src/views/admin/InviteCodePanelView.vue
@@ -34,7 +34,7 @@ const pageNotification = ref<Alert>(null);
 const codeFilter = ref<string>(null);
 const inviteList = computed(() => {
   if (codeFilter.value) {
-    return invites.value.filter((invite) => invite.code.match(codeFilter.value));
+    return invites.value.filter((invite) => invite.code.match(new RegExp(codeFilter.value, 'gi')));
   }
   return invites.value;
 });

--- a/frontend/src/views/admin/InviteCodePanelView.vue
+++ b/frontend/src/views/admin/InviteCodePanelView.vue
@@ -3,20 +3,20 @@ import {
   computed, inject, onMounted, ref,
 } from 'vue';
 import { useI18n } from 'vue-i18n';
-import {
-  AlertSchemes, TableDataButtonType, TableDataType, InviteStatus,
-} from '@/definitions';
 import { useRouter } from 'vue-router';
 import { IconSend } from '@tabler/icons-vue';
-import {
-  Invite, InviteListResponse, BooleanResponse, Exception, TableDataRow, TableDataColumn, TableFilter, Alert,
-} from '@/models';
-import { dayjsKey, callKey } from '@/keys';
 import DataTable from '@/components/DataTable.vue';
 import LoadingSpinner from '@/elements/LoadingSpinner.vue';
 import PrimaryButton from '@/elements/PrimaryButton.vue';
 import AlertBox from '@/elements/AlertBox.vue';
 import AdminNav from '@/elements/admin/AdminNav.vue';
+import { dayjsKey, callKey } from '@/keys';
+import {
+  Invite, InviteListResponse, BooleanResponse, Exception, TableDataRow, TableDataColumn, TableFilter, Alert,
+} from '@/models';
+import {
+  AlertSchemes, TableDataButtonType, TableDataType, InviteStatus,
+} from '@/definitions';
 import { staggerRetrieve } from '@/utils';
 
 const router = useRouter();
@@ -31,8 +31,15 @@ const generateCodeAmount = ref(null);
 const loading = ref(true);
 const pageError = ref<Alert>(null);
 const pageNotification = ref<Alert>(null);
+const codeFilter = ref<string>(null);
+const inviteList = computed(() => {
+  if (codeFilter.value) {
+    return invites.value.filter((invite) => invite.code.match(codeFilter.value));
+  }
+  return invites.value;
+});
 
-const filteredInvites = computed(() => invites.value.map((invite) => ({
+const filteredInvites = computed(() => inviteList.value.map((invite) => ({
   code: {
     type: TableDataType.Code,
     value: invite.code,
@@ -148,7 +155,7 @@ const getInvites = async () => {
 
   invites.value = await staggerRetrieve(
     (payload: object) => call('invite/').post(payload).json(),
-    50,
+    250,
     pageError,
   );
 };
@@ -253,27 +260,41 @@ onMounted(async () => {
       @field-click="(_key, field) => revokeInvite(field.code.value)"
     >
       <template v-slot:footer>
-        <div class="flex w-1/3 flex-col gap-4 text-center md:w-full md:flex-row md:text-left">
-          <label class="flex flex-col gap-4 md:flex-row md:items-center md:gap-0">
-            <span>{{ t('label.amountOfCodes') }}</span>
-            <input
-              class="mx-4 w-60 rounded-md text-sm"
-              type="number"
-              v-model="generateCodeAmount"
+        <div class="flex w-full justify-between">
+          <div class="flex w-1/3 flex-col gap-4 text-center md:w-full md:flex-row md:text-left">
+            <label class="flex flex-col gap-4 md:flex-row md:items-center md:gap-0">
+              <span>{{ t('label.amountOfCodes') }}</span>
+              <input
+                class="mx-4 w-60 rounded-md text-sm"
+                type="number"
+                v-model="generateCodeAmount"
+                :disabled="loading"
+                enterkeyhint="done"
+                @keyup.enter="generateInvites"
+              />
+            </label>
+            <primary-button
+              class="btn-generate"
               :disabled="loading"
-              enterkeyhint="done"
-              @keyup.enter="generateInvites"
-            />
-          </label>
-          <primary-button
-            class="btn-generate"
-            :disabled="loading"
-            @click="generateInvites"
-            :title="t('label.generate')"
-          >
-            <icon-send/>
-            {{ t('label.generate') }}
-          </primary-button>
+              @click="generateInvites"
+              :title="t('label.generate')"
+            >
+              <icon-send/>
+              {{ t('label.generate') }}
+            </primary-button>
+          </div>
+          <div class="flex flex-col items-end gap-4">
+            <label class="flex flex-col gap-4 md:flex-row md:items-center md:gap-0">
+              <span>{{ t('label.search') }}</span>
+              <input
+                class="mx-4 w-60 rounded-md text-sm"
+                type="text"
+                v-model="codeFilter"
+                :disabled="loading"
+                enterkeyhint="search"
+              />
+            </label>
+          </div>
         </div>
       </template>
 

--- a/frontend/src/views/admin/SubscriberPanelView.vue
+++ b/frontend/src/views/admin/SubscriberPanelView.vue
@@ -13,11 +13,11 @@ import PrimaryButton from '@/elements/PrimaryButton.vue';
 import ConfirmationModal from '@/components/ConfirmationModal.vue';
 import { dayjsKey, callKey } from '@/keys';
 import {
-  Subscriber, SubscriberListResponse, BooleanResponse, Exception, TableDataRow, TableDataColumn, TableFilter, Alert,
+  Subscriber, BooleanResponse, Exception, TableDataRow, TableDataColumn, TableFilter, Alert,
 } from '@/models';
 import { useUserStore } from '@/stores/user-store';
 import { AlertSchemes, TableDataButtonType, TableDataType } from '@/definitions';
-import { sleep, staggerRetrieve } from '@/utils';
+import { staggerRetrieve } from '@/utils';
 
 const user = useUserStore();
 

--- a/frontend/src/views/admin/SubscriberPanelView.vue
+++ b/frontend/src/views/admin/SubscriberPanelView.vue
@@ -38,7 +38,7 @@ const hardDeleteModalContext = ref<Subscriber>(null);
 const emailFilter = ref<string>(null);
 const subscriberList = computed(() => {
   if (emailFilter.value) {
-    return subscribers.value.filter((sub) => sub.email.match(emailFilter.value));
+    return subscribers.value.filter((sub) => sub.email.match(new RegExp(emailFilter.value, 'gi')));
   }
   return subscribers.value;
 });

--- a/frontend/src/views/admin/WaitingListPanelView.vue
+++ b/frontend/src/views/admin/WaitingListPanelView.vue
@@ -3,8 +3,14 @@ import {
   computed, inject, onMounted, ref,
 } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { AlertSchemes, TableDataType } from '@/definitions';
 import { useRouter } from 'vue-router';
+import { IconSend } from '@tabler/icons-vue';
+import DataTable from '@/components/DataTable.vue';
+import LoadingSpinner from '@/elements/LoadingSpinner.vue';
+import AlertBox from '@/elements/AlertBox.vue';
+import AdminNav from '@/elements/admin/AdminNav.vue';
+import PrimaryButton from '@/elements/PrimaryButton.vue';
+import { dayjsKey, callKey } from '@/keys';
 import {
   WaitingListEntry,
   WaitingListInvite,
@@ -18,13 +24,7 @@ import {
   ExceptionDetail,
   Alert,
 } from '@/models';
-import { dayjsKey, callKey } from '@/keys';
-import { IconSend } from '@tabler/icons-vue';
-import DataTable from '@/components/DataTable.vue';
-import LoadingSpinner from '@/elements/LoadingSpinner.vue';
-import AlertBox from '@/elements/AlertBox.vue';
-import AdminNav from '@/elements/admin/AdminNav.vue';
-import PrimaryButton from '@/elements/PrimaryButton.vue';
+import { AlertSchemes, TableDataType } from '@/definitions';
 import { staggerRetrieve } from '@/utils';
 
 const router = useRouter();
@@ -40,8 +40,15 @@ const pageError = ref<Alert>(null);
 const pageNotification = ref<Alert>(null);
 const selectedFields = ref([]);
 const dataTableRef = ref(null);
+const emailFilter = ref<string>(null);
+const waitingListUsersList = computed(() => {
+  if (emailFilter.value) {
+    return waitingListUsers.value.filter((wl) => wl.email.match(emailFilter.value));
+  }
+  return waitingListUsers.value;
+});
 
-const filteredUsers = computed(() => waitingListUsers.value.map((user) => ({
+const filteredUsers = computed(() => waitingListUsersList.value.map((user) => ({
   id: {
     type: TableDataType.Text,
     value: user.id,
@@ -179,7 +186,7 @@ const getInvites = async () => {
 
   waitingListUsers.value = await staggerRetrieve(
     (payload: object) => call('waiting-list/').post(payload).json(),
-    50,
+    250,
     pageError,
   );
 };
@@ -272,6 +279,7 @@ onMounted(async () => {
       @fieldSelect="onFieldSelect"
     >
       <template v-slot:footer>
+        <div class="flex w-full">
         <div class="flex w-1/3 flex-col gap-4 text-center md:w-full md:flex-row md:text-left">
           <label class="flex flex-col gap-4 md:flex-row md:items-center md:gap-0">
             <span>{{ t('label.sendInviteToWaitingList', {count: selectedFields.length}) }}</span>
@@ -280,6 +288,19 @@ onMounted(async () => {
             <icon-send />
             {{ t('label.send') }}
           </primary-button>
+        </div>
+          <div class="flex flex-col items-end gap-4">
+            <label class="flex flex-col gap-4 md:flex-row md:items-center md:gap-0">
+              <span>{{ t('label.search') }}</span>
+              <input
+                class="mx-4 w-60 rounded-md text-sm"
+                type="text"
+                v-model="emailFilter"
+                :disabled="loading"
+                enterkeyhint="search"
+              />
+            </label>
+          </div>
         </div>
         <div>
           {{ t('waitingList.adminInviteNotice')}}

--- a/frontend/src/views/admin/WaitingListPanelView.vue
+++ b/frontend/src/views/admin/WaitingListPanelView.vue
@@ -42,7 +42,7 @@ const dataTableRef = ref(null);
 const emailFilter = ref<string>(null);
 const waitingListUsersList = computed(() => {
   if (emailFilter.value) {
-    return waitingListUsers.value.filter((wl) => wl.email.match(emailFilter.value));
+    return waitingListUsers.value.filter((wl) => wl.email.match(new RegExp(emailFilter.value, 'gi')));
   }
   return waitingListUsers.value;
 });

--- a/frontend/src/views/admin/WaitingListPanelView.vue
+++ b/frontend/src/views/admin/WaitingListPanelView.vue
@@ -14,7 +14,6 @@ import { dayjsKey, callKey } from '@/keys';
 import {
   WaitingListEntry,
   WaitingListInvite,
-  WaitingListResponse,
   BooleanResponse,
   TableDataRow,
   TableDataColumn,


### PR DESCRIPTION
get_by_email now does searches on lowercase emails only, so we can't delete a mixed-case user lol!

This should have been using ids from the start anyway. 

Additionally I've added in a quick search textbox to help find emails faster (or invite codes)