### PR TITLE
Fix GHA E2E stage test job

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -367,11 +367,7 @@ jobs:
 
   e2e-tests-browserstack-stage:
     name: e2e-tests-browserstack-stage
-    needs:
-      - deploy-stage-backend
-      - build-and-deploy-stage-frontend
-    if: |
-      needs.deploy-stage-backend.result == 'success' || needs.build-and-deploy-stage-frontend.result == 'success'
+    needs: create-release
     runs-on: ubuntu-latest
     environment: staging
     env:


### PR DESCRIPTION
## Description of the Change
Fix the `e2e-tests-browserstack-stage` job (within the `deploy-staging.yml` GHA workflow). Remove the IF condition and run the tests every time a release has been created.

## Applicable Issues
Fixes #950 