### PR TITLE
Unique .env files shouldn't be added to container images

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,10 +20,6 @@ COPY scripts/cron /etc/cron.d/appointment-cron
 RUN chmod 0644 /etc/cron.d/appointment-cron
 RUN crontab /etc/cron.d/appointment-cron
 
-# Dev only
-#RUN echo '!! If the next step fails, copy .env.example to .env in the backend folder !!'
-#COPY .env .
-
 RUN pip install --upgrade pip
 RUN pip install .'[deploy]'
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,8 +21,8 @@ RUN chmod 0644 /etc/cron.d/appointment-cron
 RUN crontab /etc/cron.d/appointment-cron
 
 # Dev only
-RUN echo '!! If the next step fails, copy .env.example to .env in the backend folder !!'
-COPY .env .
+#RUN echo '!! If the next step fails, copy .env.example to .env in the backend folder !!'
+#COPY .env .
 
 RUN pip install --upgrade pip
 RUN pip install .'[deploy]'


### PR DESCRIPTION
## Description of the Change
Removing developer used line from main code (thus assumable production code, once out of beta)

## Benefits
First time container builder reason: Yes, it echos that .env needs to be made, but this allows a successful build immediately upon cloning the repo, and more importantly..
Image/infrastructure security reason: The .env file should not be built in to the image, as one can take the image and pull the password out if anyone ever uploads an image for public pulling. This is especially true, since the docker-compose file utilizes the .env file on the host system, not on the container, anyway.
Removing it from the Dockerfile prevents many possible future accidents.

Leaving them commented, rather than removed still allows for an easy change by devs if they want these lines.

## Applicable Issues
Working on designing a method for using this with podman. #949
It requires image files to already exist, which means building the images first.
This isn't a required change, though you might find it beneficial to do long term for reasons other than "making it easier to run with podman".