### PR TITLE
Set the E2E test browser context timezone and fix download test

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -25,11 +25,11 @@ The E2E tests require an existing Appointment (and corresponding FxA account) an
     - The share link is found in Appointment => Settings => Account => My Link.
 - The tests also require an email address to be used as the appointment bookee's email address when actually requesting bookings. This is the email address entered on the `Book selection` dialog (after an appointment slot was selected on the booking share link page). Note that real Appointment emails will be sent to this email address.
 
-The tests expect that the default Appointment application settings haven't been changed for the provided test user:
+The tests expect the following Appointment application settings:
 - The user scheduling availability hasn't been changed from the default settings;
 - In the dashboard the default calendar view is the current month view; this is important so that the tests can find an available booking slot, etc.
 - In `Booking Settings`, the `Booking Confirmation` option is enabled, so that requested appointments generate HOLD appointments that need to be confirmed
-- The timezone is set to the default of `America/Toronto`
+- The timezone is set to `America/Toronto`
 
 ## Running the E2E tests against your local dev environment
 

--- a/test/e2e/tests/book-appointment.spec.ts
+++ b/test/e2e/tests/book-appointment.spec.ts
@@ -12,6 +12,7 @@ import {
   TIMEOUT_3_SECONDS,
   TIMEOUT_30_SECONDS,
   TIMEOUT_60_SECONDS,
+  APPT_TIMEZONE_SETTING_TORONTO,
 } from '../const/constants';
 
 var bookingPage: BookingPage;
@@ -59,6 +60,14 @@ const verifyBookingPageLoaded = async () => {
 test.beforeEach(async ({ page }) => {
   bookingPage = new BookingPage(page);
   dashboardPage = new DashboardPage(page);
+});
+
+// the share link (request a booking page) will display in the local browser context timezone but the main
+// appointment account settings could be a different timezone (if so the test will fail to find the booked
+// appointment since the time slot value will not match); set the browser context to always be in
+// `America/Toronto` so the share link will be in the same timezone as the main account settings
+test.use({
+  timezoneId: APPT_TIMEZONE_SETTING_TORONTO,
 });
 
 // verify we are able to book an appointment using existing user's share link

--- a/test/e2e/tests/settings.spec.ts
+++ b/test/e2e/tests/settings.spec.ts
@@ -285,12 +285,10 @@ test.describe('account settings', {
     const downloadPromise = page.waitForEvent('download');
     // click the account settings => download your data button and confirm
     await settingsPage.downloadAccountData();
-    // now verify the browser download did happen successfully
+    // now verify the browser download event was triggered and downloaded without error
     const download = await downloadPromise;
-    const downloadedPath = await download.path(); // waits for download to finish
-    console.log(`account data file downloaded to ${downloadedPath}`);
-    expect(downloadedPath).toBeTruthy();
-    expect(await download.failure()).toBeFalsy();
+    const downloadErr = await download.failure(); // waits for download to finish and checks for error
+    expect(downloadErr).toBeFalsy();
   });
 
   test('delete account button', async ({ page }) => {


### PR DESCRIPTION
Ensure the playwright browser context timezone is set for the E2E tests (fixes #957).

Also one of the settings tests (download data) fails when running in BrowserStack because BrowserStack doesn't support the `download.path` playwright method; so fixing that too.

```
    Error: Path is not available when connecting remotely. Use saveAs() to save a local copy.

      294 |     // now verify the browser download did happen successfully
      295 |     const download = await downloadPromise;
    > 296 |     const downloadedPath = await download.path(); // waits for download to finish
```

Here's a [link of the updated tests ](https://automate.browserstack.com/dashboard/v2/builds/ba55998a9a17f973261692be5995fa087b1a6004)running successfully on stage via BrowserStack in both Firefox and Chromium.