### PR TITLE
Slug change confirmation

### DIFF
--- a/frontend/src/components/ScheduleCreation.vue
+++ b/frontend/src/components/ScheduleCreation.vue
@@ -187,6 +187,9 @@ const getScheduleAppointment = (): ScheduleAppointment => ({
 const isFormDirty = computed(
   () => JSON.stringify(scheduleInput.value) !== JSON.stringify(referenceSchedule.value),
 );
+const isSlugDirty = computed(
+  () => scheduleInput.value.slug !== referenceSchedule.value.slug,
+);
 
 // handle notes char limit
 const charLimit = 250;
@@ -328,6 +331,7 @@ const saveSchedule = async (withConfirmation = true) => {
   // Update our reference schedule!
   referenceSchedule.value = { ...scheduleInput.value };
   revertForm(false);
+  closeModals();
 };
 
 // Update slug with a random 8 character string
@@ -728,7 +732,7 @@ watch(
               </text-input>
               <link-button
                 class="p-0.5"
-                @click="scheduleInput.active ? showRefreshSlugConfirmation() : null"
+                @click="scheduleInput.active ? refreshSlug() : null"
                 :disabled="!scheduleInput.active"
                 data-testid="dashboard-booking-settings-link-refresh-btn"
               >
@@ -802,7 +806,7 @@ watch(
     >
       <primary-button
         class="btn-save w-full"
-        @click="saveSchedule(!existing)"
+        @click="isSlugDirty ? showRefreshSlugConfirmation() : saveSchedule(!existing)"
         :disabled="!scheduleInput.active || savingInProgress"
         data-testid="dashboard-save-changes-btn"
       >
@@ -847,9 +851,9 @@ watch(
     :open="refreshSlugModalOpen"
     :title="t('label.refreshLink')"
     :message="t('text.refreshLinkNotice')"
-    :confirm-label="t('label.refresh')"
+    :confirm-label="t('label.save')"
     :cancel-label="t('label.cancel')"
-    @confirm="() => refreshSlug()"
+    @confirm="saveSchedule(!existing)"
     @close="closeModals"
   ></confirmation-modal>
 </template>

--- a/frontend/src/components/ScheduleCreation.vue
+++ b/frontend/src/components/ScheduleCreation.vue
@@ -265,6 +265,17 @@ const scheduleValidationError = (schedule: Schedule): string|null => {
   return null;
 };
 
+// Update slug with a random 8 character string
+const refreshSlugModalOpen = ref(false);
+const showRefreshSlugConfirmation = async () => {
+  refreshSlugModalOpen.value = true;
+};
+
+const closeModals = () => {
+  savedConfirmation.show = false;
+  refreshSlugModalOpen.value = false;
+};
+
 // handle actual schedule creation/update
 const savingInProgress = ref(false);
 const saveSchedule = async (withConfirmation = true) => {
@@ -332,17 +343,6 @@ const saveSchedule = async (withConfirmation = true) => {
   referenceSchedule.value = { ...scheduleInput.value };
   revertForm(false);
   closeModals();
-};
-
-// Update slug with a random 8 character string
-const refreshSlugModalOpen = ref(false);
-const showRefreshSlugConfirmation = async () => {
-  refreshSlugModalOpen.value = true;
-};
-
-const closeModals = () => {
-  savedConfirmation.show = false;
-  refreshSlugModalOpen.value = false;
 };
 
 const refreshSlug = () => {

--- a/frontend/src/components/SettingsAccount.vue
+++ b/frontend/src/components/SettingsAccount.vue
@@ -341,7 +341,7 @@ const actuallyDeleteAccount = async () => {
     :open="refreshLinkModalOpen"
     :title="t('label.refreshLink')"
     :message="t('text.refreshLinkNotice')"
-    :confirm-label="t('label.refresh')"
+    :confirm-label="t('label.save')"
     :cancel-label="t('label.cancel')"
     @confirm="() => refreshLinkConfirm()"
     @close="closeModals"

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -296,7 +296,7 @@
     "privacy": "Datenschutz",
     "quickLink": "Kurzlink",
     "refresh": "Erneuern",
-    "refreshLink": "Link erneuern",
+    "refreshLink": "Link ändern",
     "remove": "Entfernen",
     "replies": "Antworten",
     "requested": "Angefragt",
@@ -485,7 +485,7 @@
     "preferredEmailHelp": "Die E-Mail-Adresse festlegen, die für ausgehende Kommunikation in Kalenderereignissen verwendet werden soll.",
     "recipientsCanScheduleBetween": "Empfänger können einen Termin zwischen {earliest} und {farthest} ab dem aktuellen Zeitpunkt wählen. ",
     "redirectedNotice": "Du wirst weitergeleitet nach {url}.",
-    "refreshLinkNotice": "Dadurch wird dein Link erneuert. Deine alten Links werden nicht länger funktionieren.",
+    "refreshLinkNotice": "Dadurch wird dein Link geändert. Der vorherige Link wird dann nicht länger funktionieren.",
     "requestInformationSentToOwner": "Der Kalenderbesitzer wurde per E-Mail über deine Buchungsanfrage informiert.",
     "scheduleSettings": {
       "clickHereToConnect": "Hier einen Kalender verbinden",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -485,7 +485,7 @@
     "preferredEmailHelp": "Set the email you'll use for out-going communication. This will be used in calendar events and emails.",
     "recipientsCanScheduleBetween": "Recipients can schedule a {duration} appointment between {earliest} and {farthest} ahead of time.",
     "redirectedNotice": "You are being redirected to {url}.",
-    "refreshLinkNotice": "This refreshes your link. Your old links will no longer work.",
+    "refreshLinkNotice": "Saving will change your schedule's link. Any old links will no longer work.",
     "requestInformationSentToOwner": "Information about this booking request has been emailed to the owner.",
     "scheduleSettings": {
       "clickHereToConnect": "Click here to connect a calendar!",


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This PR changes the slug changed confirmation modal from showing when clicking the refresh button to clicking the save button. The confirmation appears only, if the slug was changed manually or per refresh button.

![appointment_schedule_slug_change](https://github.com/user-attachments/assets/d24409fb-a200-4b80-b7dc-ee30b3cbb209)

## Benefits

Uses get warned even if they manually edited their link.

## Applicable Issues
Closes #903 