### PR TITLE
Hopeful fix for being logged out after logging in

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -146,10 +146,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e .'[test]'
 
-      - name: Backend lint check
-        run: |
-          cd ./backend && ruff check
-
       - name: Test with pytest
         working-directory: ./backend
         run: |
@@ -161,6 +157,10 @@ jobs:
         continue-on-error: true
         run: |
           coverage report
+
+      - name: Backend lint check
+        run: |
+          cd ./backend && ruff check
 
   validate-frontend:
     needs: detect-changes

--- a/backend/src/appointment/controller/auth.py
+++ b/backend/src/appointment/controller/auth.py
@@ -24,6 +24,7 @@ def logout(
 ):
     """Sets a minimum valid issued at time (time). This prevents access tokens issued earlier from working."""
     if deny_previous_tokens:
+        # TODO: This will be removed in the future
         # Reduce the parry-window for webhooks. This will hopefully prevent the login immediately logged out issue.
         subscriber.minimum_valid_iat_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=1)
         db.add(subscriber)

--- a/backend/src/appointment/controller/auth.py
+++ b/backend/src/appointment/controller/auth.py
@@ -24,7 +24,8 @@ def logout(
 ):
     """Sets a minimum valid issued at time (time). This prevents access tokens issued earlier from working."""
     if deny_previous_tokens:
-        subscriber.minimum_valid_iat_time = datetime.datetime.now(datetime.UTC)
+        # Reduce the parry-window for webhooks. This will hopefully prevent the login immediately logged out issue.
+        subscriber.minimum_valid_iat_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=1)
         db.add(subscriber)
         db.commit()
 

--- a/backend/src/appointment/dependencies/auth.py
+++ b/backend/src/appointment/dependencies/auth.py
@@ -79,7 +79,9 @@ def get_user_from_token(db, token: str, require_jti=False):
             'Invalid Token Error - Expired',
             debug_obj={
                 'minimum_issued_at': subscriber.minimum_valid_iat_time,
-                'minimum_issued_at_timestamp': int(subscriber.minimum_valid_iat_time.timestamp()) if subscriber.minimum_valid_iat_time else None,
+                'minimum_issued_at_timestamp': int(subscriber.minimum_valid_iat_time.timestamp())
+                if subscriber.minimum_valid_iat_time
+                else None,
                 'subscriber': sub,
                 'issued_at': iat,
                 'require_jti': require_jti,

--- a/backend/src/appointment/dependencies/auth.py
+++ b/backend/src/appointment/dependencies/auth.py
@@ -18,6 +18,7 @@ from ..dependencies.database import get_db
 from ..exceptions import validation
 from ..exceptions.misc import UnexpectedBehaviourWarning
 from ..exceptions.validation import InvalidTokenException, InvalidPermissionLevelException
+from ..utils import flag_code
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl='token', auto_error=False)
 
@@ -38,15 +39,6 @@ def get_user_from_accounts_session(request, db):
     return repo.external_connection.get_subscriber_by_accounts_uuid(db, user_profile.get('uuid'))
 
 
-def flag_code(reason, debug_obj):
-    # Raise and catch the unexpected behaviour warning so we can get proper stacktrace in sentry...
-    try:
-        sentry_sdk.set_extra('debug_object', debug_obj)
-        raise UnexpectedBehaviourWarning(message=reason, info=debug_obj)
-    except UnexpectedBehaviourWarning as ex:
-        sentry_sdk.capture_exception(ex)
-
-
 def get_user_from_token(db, token: str, require_jti=False):
     sub = None
     iat = None
@@ -61,7 +53,7 @@ def get_user_from_token(db, token: str, require_jti=False):
     except jwt.exceptions.InvalidTokenError as ex:
         flag_code(
             'Invalid Token Error - Exception',
-            debug_obj={'exception': ex, 'subscriber': sub, 'issued_at': iat, 'token_id': jti},
+            debug_obj={'exception': ex, 'subscriber': sub, 'issued_at': iat, 'jti': jti},
         )
         raise InvalidTokenException()
 
@@ -70,7 +62,7 @@ def get_user_from_token(db, token: str, require_jti=False):
 
     # Check this first as any doesn't short-circuit
     if subscriber is None:
-        flag_code('Invalid Token Error - No Sub', debug_obj={'subscriber': sub, 'issued_at': iat, 'token_id': jti})
+        flag_code('Invalid Token Error - No Sub', debug_obj={'subscriber': sub, 'issued_at': iat, 'jti': jti})
         raise InvalidTokenException()
 
     # Token has been expired by us - temp measure to avoid spinning a refresh system, or a deny list for this issue
@@ -91,8 +83,8 @@ def get_user_from_token(db, token: str, require_jti=False):
                 'minimum_issued_at_timestamp': int(subscriber.minimum_valid_iat_time.timestamp()),
                 'subscriber': sub,
                 'issued_at': iat,
-                'require_token_id': require_jti,
-                'token_id': jti,
+                'require_jti': require_jti,
+                'jti': jti,
             },
         )
         raise InvalidTokenException()

--- a/backend/src/appointment/dependencies/auth.py
+++ b/backend/src/appointment/dependencies/auth.py
@@ -79,7 +79,7 @@ def get_user_from_token(db, token: str, require_jti=False):
             'Invalid Token Error - Expired',
             debug_obj={
                 'minimum_issued_at': subscriber.minimum_valid_iat_time,
-                'minimum_issued_at_timestamp': int(subscriber.minimum_valid_iat_time.timestamp()),
+                'minimum_issued_at_timestamp': int(subscriber.minimum_valid_iat_time.timestamp()) if subscriber.minimum_valid_iat_time else None,
                 'subscriber': sub,
                 'issued_at': iat,
                 'require_jti': require_jti,

--- a/backend/src/appointment/dependencies/auth.py
+++ b/backend/src/appointment/dependencies/auth.py
@@ -16,7 +16,6 @@ from ..database import repo, models
 from ..defines import AuthScheme, REDIS_USER_SESSION_PROFILE_KEY
 from ..dependencies.database import get_db
 from ..exceptions import validation
-from ..exceptions.misc import UnexpectedBehaviourWarning
 from ..exceptions.validation import InvalidTokenException, InvalidPermissionLevelException
 from ..utils import flag_code
 


### PR DESCRIPTION
Related #969 

This is just for staging right now. Based off the sentry data the user's minimum time is one second after issued at time. The only thinig that sets the minimum time is the webhooks. So I guess the webhooks are getting fired off after we ask them to destroy a token. If someone logs in just at the right time, they can be immediately logged out lol.

Neither systems are long for this world, so hopefully this reduces the issue until we switch auth over. 