### PR TITLE
Expand nightly E2E tests job to include all tests

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -45,10 +45,10 @@ jobs:
           username:  ${{ secrets.BROWSERSTACK_USERNAME }}
           access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           project-name: 'Thunderbird Appointment'
-          build-name: 'Nightly Tests: BUILD_INFO'
+          build-name: 'TB Appointment Nightly Tests: BUILD_INFO'
 
-      - name: Run Playwright Tests on Browserstack
+      - name: Run E2E Tests on Production on Browserstack
         run: |
           cd ./test/e2e
           cp .env.prod.example .env
-          npm run prod-sanity-test-browserstack-gha
+          npm run prod-nightly-tests-browserstack-gha

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -180,3 +180,52 @@ npm run prod-sanity-test-browserstack
 ```
 
 After the tests finish in your local console you'll see a link to the BrowserStack test session; when signed into your BrowserStack account you'll be able to use that link to see the test session results including video playback.
+
+## Debugging E2E Test Failures
+
+Here is some advice for how to investigate E2E test failures.
+
+### E2E Tests Failing on your Local Dev Environment
+If you are running the E2E tests on your local machine against your local development environment and the tests are failing, you can:
+- Run the tests again this time in debug (UI) mode (see above)
+    - In the debug mode browser expand each test that was ran, and review each test step to trace the test progress and failure
+    - Look at the corresponding screenshots to get a visual of where and when the tests actually failed
+    - Try to correlate the test failure with any local code changes
+
+### E2E Tests Failing in CI on your PR Check
+If you pushed to a branch or PR and the resulting Github pull request E2E test job check is failing, you can:
+
+- In your PR scroll down to the 'Checks' section and click on the failed E2E test job
+- In the console view, expand the E2E tests step and read the test failure details
+- Check if a playwright report artifact exists:
+    - In the console view click on `Summary` (top left)
+    - This shows the GHA summary, at the bottom of the page look for an `Artifacts` section and click on `playwright-report` and download the ZIP
+    - Open the ZIP file, expand it, and open the `index.html` file in your browser
+
+### E2E Tests Failing in CI after a Deployment to Stage or Production
+If you did a stage or production deployment and the resulting E2E tests job failed, you can:
+
+- Go into the Github repo, and
+    - Choose `Actions` at the top
+    - On the list of Actions on the left side choose the one matching your stage or production deployment
+    - In the corresponding list of completed action jobs, click on the failing one
+    - Then click on the failed E2E test step to open the console view
+    - In the console view, expand the E2E tests job and read the test failure details
+    - The tests run in BrowserStack which records a video playback of all of the tests
+        - In the console view search the logs for the string `View build on BrowserStack dashboard` and retrieve the associated BrowserStack session link
+        - Click on the link and sign into BrowserStack with your credentials and view the video replay of the failing test
+
+### Nightly E2E Tests CI Job Failing
+If you notice an email from Github actions indicating that the Nightly E2E Tests job failed, you can:
+
+- Open the failing Github nightly-tests action job:
+    - Click on the `View workflow run` link in the email - or -
+    - Go into the Github repo, and
+        - Choose `Actions` at the top
+        - On the list of Actions on the left side choose `nightly-tests`
+        - In the corresponding list of completed nightly test action jobs, click on the failing one
+    - Then click on the failed E2E test step to open the console view
+    - In the console view, expand the E2E tests job and read the test failure details
+    - The nightly tests run in BrowserStack which records a video playback of all of the tests
+        - In the console view search the logs for the string `View build on BrowserStack dashboard` and retrieve the associated BrowserStack session link
+        - Click on the link and sign into BrowserStack with your credentials and view the video replay of the failing test

--- a/test/e2e/const/constants.ts
+++ b/test/e2e/const/constants.ts
@@ -33,6 +33,7 @@ export const APPT_BOOKEE_EMAIL = String(process.env.APPT_BOOKEE_EMAIL);
 // playwright test tags
 export const PLAYWRIGHT_TAG_PROD_SANITY = '@prod-sanity';
 export const PLAYWRIGHT_TAG_E2E_SUITE = '@e2e-suite';
+export const PLAYWRIGHT_TAG_PROD_NIGHTLY = '@prod-nightly';
 
 // general settings options
 export const APPT_LANGUAGE_SETTING_EN = 'EN — English';

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -13,6 +13,7 @@
     "prod-sanity-test-debug": "npx playwright test --grep prod-sanity --project=firefox --headed --ui",
     "prod-sanity-test-browserstack": "npx browserstack-node-sdk playwright test --grep prod-sanity --browserstack.buildName 'Production Sanity Test'",
     "prod-sanity-test-browserstack-gha": "npx browserstack-node-sdk playwright test --grep prod-sanity",
+    "prod-nightly-tests-browserstack-gha": "npx browserstack-node-sdk playwright test --grep prod-nightly",
     "postinstall": "npm update browserstack-node-sdk"
   },
   "keywords": [],

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -29,9 +29,8 @@ export default defineConfig({
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     // baseURL: 'http://127.0.0.1:3000',
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: 'off',
+    screenshot: 'only-on-failure',
   },
 
   /* Configure projects for major browsers */

--- a/test/e2e/tests/book-appointment.spec.ts
+++ b/test/e2e/tests/book-appointment.spec.ts
@@ -8,6 +8,7 @@ import {
   APPT_BOOKEE_NAME,
   APPT_BOOKEE_EMAIL,
   PLAYWRIGHT_TAG_PROD_SANITY,
+  PLAYWRIGHT_TAG_PROD_NIGHTLY,
   PLAYWRIGHT_TAG_E2E_SUITE,
   TIMEOUT_3_SECONDS,
   TIMEOUT_30_SECONDS,
@@ -70,24 +71,23 @@ test.use({
   timezoneId: APPT_TIMEZONE_SETTING_TORONTO,
 });
 
-// verify we are able to book an appointment using existing user's share link
 test.describe('book an appointment', () => {
   test('able to access booking page via short link', {
-    tag: PLAYWRIGHT_TAG_PROD_SANITY,
+    tag: [PLAYWRIGHT_TAG_PROD_SANITY],
   }, async ({ page }) => {
     await bookingPage.gotoBookingPageShortUrl();
     await verifyBookingPageLoaded();
   });
 
   test('able to access booking page via long link', {
-    tag: PLAYWRIGHT_TAG_PROD_SANITY,
+    tag: [PLAYWRIGHT_TAG_PROD_SANITY]
   }, async ({ page }) => {
     await bookingPage.gotoBookingPageLongUrl();
     await verifyBookingPageLoaded();
   });
 
   test('able to request a booking', {
-    tag: [PLAYWRIGHT_TAG_PROD_SANITY, PLAYWRIGHT_TAG_E2E_SUITE],
+    tag: [PLAYWRIGHT_TAG_PROD_SANITY, PLAYWRIGHT_TAG_E2E_SUITE, PLAYWRIGHT_TAG_PROD_NIGHTLY],
   }, async ({ page }) => {
     // in order to ensure we find an available slot we can click on, first switch to week view URL
     await bookingPage.gotoBookingPageWeekView();

--- a/test/e2e/tests/settings.spec.ts
+++ b/test/e2e/tests/settings.spec.ts
@@ -5,6 +5,7 @@ import { DashboardPage } from '../pages/dashboard-page';
 
 import {
   PLAYWRIGHT_TAG_E2E_SUITE,
+  PLAYWRIGHT_TAG_PROD_NIGHTLY,
   APPT_LOGIN_EMAIL,
   APPT_DISPLAY_NAME,
   APPT_MY_SHARE_LINK,
@@ -30,7 +31,7 @@ let settingsPage: SettingsPage;
 let dashboardPage: DashboardPage;
 
 test.describe('settings navigation', {
-  tag: [PLAYWRIGHT_TAG_E2E_SUITE],
+  tag: [PLAYWRIGHT_TAG_E2E_SUITE, PLAYWRIGHT_TAG_PROD_NIGHTLY],
 }, () => {
   test.beforeEach(async ({ page }) => {
     // navigate to and sign into appointment
@@ -68,7 +69,7 @@ test.describe('settings navigation', {
 });
 
 test.describe('general settings', {
-  tag: [PLAYWRIGHT_TAG_E2E_SUITE],
+  tag: [PLAYWRIGHT_TAG_E2E_SUITE, PLAYWRIGHT_TAG_PROD_NIGHTLY],
 }, () => {
   test.beforeEach(async ({ page }) => {
     // navigate to and sign into appointment
@@ -163,7 +164,7 @@ test.describe('general settings', {
 });
 
 test.describe('calendar settings', {
-  tag: [PLAYWRIGHT_TAG_E2E_SUITE],
+  tag: [PLAYWRIGHT_TAG_E2E_SUITE, PLAYWRIGHT_TAG_PROD_NIGHTLY],
 }, () => {
   test.beforeEach(async ({ page }) => {
     // navigate to and sign into appointment
@@ -216,7 +217,7 @@ test.describe('calendar settings', {
 });
 
 test.describe('account settings', {
-  tag: [PLAYWRIGHT_TAG_E2E_SUITE],
+  tag: [PLAYWRIGHT_TAG_E2E_SUITE, PLAYWRIGHT_TAG_PROD_NIGHTLY],
 }, () => {
   test.beforeEach(async ({ page }) => {
     // navigate to and sign into appointment
@@ -304,7 +305,7 @@ test.describe('account settings', {
 });
 
 test.describe('connected accounts settings', {
-  tag: [PLAYWRIGHT_TAG_E2E_SUITE],
+  tag: [PLAYWRIGHT_TAG_E2E_SUITE, PLAYWRIGHT_TAG_PROD_NIGHTLY],
 }, () => {
   test.beforeEach(async ({ page }) => {
     // navigate to and sign into appointment

--- a/test/e2e/tests/sign-in.spec.ts
+++ b/test/e2e/tests/sign-in.spec.ts
@@ -1,8 +1,16 @@
 import { test, expect } from '@playwright/test';
 import { SplashscreenPage } from '../pages/splashscreen-page';
 import { FxAPage } from '../pages/fxa-page';
-import { APPT_TARGET_ENV, APPT_PAGE_TITLE, PLAYWRIGHT_TAG_PROD_SANITY, PLAYWRIGHT_TAG_E2E_SUITE, TIMEOUT_30_SECONDS } from '../const/constants';
 import { DashboardPage } from '../pages/dashboard-page';
+
+import {
+  APPT_TARGET_ENV,
+  APPT_PAGE_TITLE,
+  PLAYWRIGHT_TAG_PROD_SANITY,
+  PLAYWRIGHT_TAG_E2E_SUITE,
+  PLAYWRIGHT_TAG_PROD_NIGHTLY,
+  TIMEOUT_30_SECONDS
+} from '../const/constants';
 
 let splashscreenPage: SplashscreenPage;
 let signInPage: FxAPage;

--- a/test/e2e/tests/splashscreen.spec.ts
+++ b/test/e2e/tests/splashscreen.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { SplashscreenPage } from '../pages/splashscreen-page';
-import { APPT_PAGE_TITLE, PLAYWRIGHT_TAG_PROD_SANITY, PLAYWRIGHT_TAG_E2E_SUITE } from '../const/constants';
+import { APPT_PAGE_TITLE, PLAYWRIGHT_TAG_PROD_SANITY, PLAYWRIGHT_TAG_E2E_SUITE, PLAYWRIGHT_TAG_PROD_NIGHTLY } from '../const/constants';
 
 let splashscreenPage: SplashscreenPage;
 


### PR DESCRIPTION
Currently only the production sanity E2E test runs nightly; expand the nightly E2E test job (runs on production) to include the newly added settings tests too.