### PR TITLE
Small update to E2E settings tests

### DIFF
--- a/test/e2e/pages/settings-page.ts
+++ b/test/e2e/pages/settings-page.ts
@@ -49,7 +49,6 @@ export class SettingsPage {
   readonly connectedCalendarsHeader: Locator;
   readonly editCalendarBtn: Locator;
   readonly connectedCalendarTitle: Locator;
-  readonly editCalendarSaveBtn: Locator;
   readonly editCalendarTitleInput: Locator;
   readonly editCalendarColorInput: Locator;
   readonly syncCalendarsBtn: Locator;
@@ -116,7 +115,6 @@ export class SettingsPage {
     this.connectedCalendarsHeader = this.page.getByText('Connected Calendars', { exact: true });
     this.editCalendarBtn = this.page.getByTestId('settings-calendar-edit-calendar-btn');
     this.connectedCalendarTitle = this.page.getByText(APPT_LOGIN_EMAIL, { exact: true });
-    this.editCalendarSaveBtn = this.page.getByRole('button', { name: 'Save' });
     this.editCalendarTitleInput = this.page.getByTestId('settings-calendar-title-input');
     this.editCalendarColorInput = this.page.getByTestId('settings-calendar-color-input');
     this.syncCalendarsBtn = this.page.getByRole('button', { name: 'Sync Calendars' });

--- a/test/e2e/tests/settings.spec.ts
+++ b/test/e2e/tests/settings.spec.ts
@@ -15,6 +15,7 @@ import {
   APPT_THEME_SETTING_LIGHT,
   APPT_TIMEZONE_SETTING_TORONTO,
   APPT_TIMEZONE_SETTING_HALIFAX,
+  TIMEOUT_2_SECONDS,
   TIMEOUT_3_SECONDS,
   TIMEOUT_30_SECONDS,
   APPT_BROWSER_STORE_LANGUAGE_EN,
@@ -187,11 +188,12 @@ test.describe('calendar settings', {
     await expect(settingsPage.editCalendarBtn).toBeEnabled();
     await expect(settingsPage.connectedCalendarTitle).toBeVisible();
 
-    // edit the connected calendar and click save button (without making changes)
+    // edit the connected calendar and cancel out
     await settingsPage.editCalendarBtn.click();
+    await page.waitForTimeout(TIMEOUT_2_SECONDS);
     await expect(settingsPage.editCalendarTitleInput).toBeEnabled();
     await expect(settingsPage.editCalendarColorInput).toBeEnabled();
-    await settingsPage.editCalendarSaveBtn.click();
+    await settingsPage.editCalendarCancelBtn.click();
   });
 
   test('add google calendar button', async ({ page }) => {
@@ -296,6 +298,7 @@ test.describe('account settings', {
     // we won't actually delete the account :) as that would break the other E2E tests
     await expect(settingsPage.deleteAcctBtn).toBeEnabled();
     await settingsPage.deleteAcctBtn.click();
+    await page.waitForTimeout(TIMEOUT_2_SECONDS);
     await settingsPage.confirmDeleteAcctBtn.click();
   });
 });


### PR DESCRIPTION
A couple of small updates to the E2E settings tests:
- For the edit calendar settings test, click the cancel button instead of save (as there is an issue where caldav settings appears briefly before google calendar settings; I created issue #977 for that)
- Add a small timeout for the delete account button test (need time for the delete confirmation to appear before clicking cancel) 
