### PR TITLE
Don't use one time access token for every request (Fixes #969)

### DIFF
--- a/backend/src/appointment/dependencies/auth.py
+++ b/backend/src/appointment/dependencies/auth.py
@@ -68,6 +68,8 @@ def get_user_from_token(db, token: str, require_jti=False):
             subscriber.minimum_valid_iat_time and int(subscriber.minimum_valid_iat_time.timestamp()) > int(iat),
             # If we require this token to be a one time token, then require the claim
             require_jti and not jti,
+            # If don't require this token to be a one time token, and it is...well we don't want it, go away.
+            not require_jti and jti,
         ]
     ):
         raise InvalidTokenException()

--- a/backend/src/appointment/dependencies/auth.py
+++ b/backend/src/appointment/dependencies/auth.py
@@ -17,7 +17,6 @@ from ..defines import AuthScheme, REDIS_USER_SESSION_PROFILE_KEY
 from ..dependencies.database import get_db
 from ..exceptions import validation
 from ..exceptions.validation import InvalidTokenException, InvalidPermissionLevelException
-from ..utils import flag_code
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl='token', auto_error=False)
 

--- a/frontend/src/stores/user-store.ts
+++ b/frontend/src/stores/user-store.ts
@@ -240,7 +240,7 @@ export const useUserStore = defineStore('user', () => {
 
   /**
    * Request subscriber login
-   * @param username
+   * @param username an auth string, could be username, one time token, or session id
    * @param password or null if fxa authentication
    */
   const login = async (username: string, password: string|null): Promise<Error> => {
@@ -260,8 +260,11 @@ export const useUserStore = defineStore('user', () => {
       data.value.accessToken = tokenData.value.access_token;
     } else if (import.meta.env.VITE_AUTH_SCHEME === AuthSchemes.Fxa) {
       // We get a one-time token back from the api, use it to fetch the real access token
-      data.value.accessToken = username;
-      const { error, data: tokenData }: TokenResponse = await call.value('fxa-token').post().json();
+      const { error, data: tokenData }: TokenResponse = await call.value('fxa-token', {
+        headers: {
+          Authorization: `Bearer ${username}`,
+        }
+      }).post().json();
 
       if (error.value || !tokenData.value.access_token) {
         return { error: tokenData.value ?? error.value };


### PR DESCRIPTION
Fixes #969 

The current login flow is expected to work like this:

```mermaid
flowchart TD
    A[FXA Login] -->|Redirect| B[APMT Backend - /fxa]
    B -->|Redirect| C[APMT Frontend - /post-login/:one-time-token]
    C -->|API Call using one-time-token as auth| D[APMT Backend - /fxa-token]
    D -->|Returns longer-lived token| E[APMT Frontend]
    E -->|Uses longer-lived token| F[APMT ...rest of the app...]
```

We have a one time token that is returned, and then swapped for a longer lived token. This is so if anyone is snooping on urls they won't be able to do much with that token, as the token is returned in the redirect to post-login in the url. (Not much we can do here without sessions afaik.) 

However, that one time token can be used for any request...which obviously isn't great. This PR adds another check to see if we're not looking for a one time token (via the require_jti var), and we get one (via the jti var) then to exit out with invalid creds.

Additionally we were setting the one time token to the user store's accessToken variable. The thought was the next request was only going to be the one time token to long living token exchange. However in practice, an async request could swoop in, use it and then invalidate that token for the exchange.

We no longer set the one time token to the user store's accessToken var, instead directly setting it on the request.
