### PR TITLE
Improve E2E test timeouts

### DIFF
--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -21,16 +21,30 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : 1, // actualy don't run in parallel locally either, for now
-  // Individual test timeout - each test will time out if it is still running after this time (ms)
-  timeout: 2 * 60 * 1000,
+  // Global timeout: Playwright will timeout if the entire session (includes all test runs) exceeds this.
+  // Must take into account running on mulitple browsers (and BrowserStack is much slower too!). Odds are the
+  // tests will time out at the locator/test level first anyway; but there is no default so best to specify
+  globalTimeout: 15 * 60 * 1000,
+  // Individual test timeout - a single test will time out if it is still running after this time (ms)
+  timeout: 90 * 1000, // 1.5 minutes
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [['list']],
+  // When running in CI we don't use the html report as we use BrowserStack's reporting
+  reporter: process.env.CI ? [['list']] : [['html']] ,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     // baseURL: 'http://127.0.0.1:3000',
-    trace: 'off',
+    trace: 'off', // traces can contain sensitive info so only do this manually locally if need be
     screenshot: 'only-on-failure',
+    // Maximum time (ms) each action such as `click()` can take. Defaults to 0 (no limit)
+    actionTimeout: 10_000,
+    // Maximum time given for browser page navigation
+    navigationTimeout: 15_000,
+  },
+  expect: {
+    // set default timeout for all expects that have a {timeout} option i.e. if locators are not found,
+    // timeout after 10 seconds instead of waiting for the entire test timeout set above
+    timeout: 10_000,
   },
 
   /* Configure projects for major browsers */

--- a/test/e2e/tests/book-appointment.spec.ts
+++ b/test/e2e/tests/book-appointment.spec.ts
@@ -14,6 +14,7 @@ import {
   TIMEOUT_30_SECONDS,
   TIMEOUT_60_SECONDS,
   APPT_TIMEZONE_SETTING_TORONTO,
+  APPT_TARGET_ENV,
 } from '../const/constants';
 
 var bookingPage: BookingPage;
@@ -82,8 +83,11 @@ test.describe('book an appointment', () => {
   test('able to access booking page via long link', {
     tag: [PLAYWRIGHT_TAG_PROD_SANITY]
   }, async ({ page }) => {
-    await bookingPage.gotoBookingPageLongUrl();
-    await verifyBookingPageLoaded();
+    // not supported on local dev env
+    if (APPT_TARGET_ENV != 'dev') {
+      await bookingPage.gotoBookingPageLongUrl();
+      await verifyBookingPageLoaded();
+    }
   });
 
   test('able to request a booking', {

--- a/test/e2e/tests/settings.spec.ts
+++ b/test/e2e/tests/settings.spec.ts
@@ -319,9 +319,9 @@ test.describe('connected accounts settings', {
   test('edit profile button', async ({ page }) => {
     // verify that clicking the `edit profile` button redirects to the Mozilla Account profile page
     // note that on dev env this relies on having VITE_FXA_EDIT_PROFILE= set to point to stage FxA
-    await settingsPage.editProfileBtn.click();
     // skip this on dev env because stage FxA use may or may not be setup to use with local dev
     if (APPT_TARGET_ENV !== 'dev') {
+      await settingsPage.editProfileBtn.click();
       await expect(settingsPage.mozProfilePageLogo).toBeVisible( { timeout: TIMEOUT_30_SECONDS });
       await expect(settingsPage.mozProfileSettingsSection).toBeVisible();
     }


### PR DESCRIPTION
Some E2E test improvements:

- Add/update Playwright E2E timeouts so that when there are test failures the tests will fail out faster (and not hold up the queue of BrowserStack jobs)
- A couple of tests fail when run against the local dev environment b/c they are only meant for stage/prod; exclude them on local dev

Here's an example of the tests [running in BrowserStack](https://automate.browserstack.com/dashboard/v2/builds/63bacda3c38b93800ab495575afbb1395c7e3e2c) with this new timeouts added.
