### PR TITLE
Username only URLs

### DIFF
--- a/backend/src/appointment/controller/apis/zoom_client.py
+++ b/backend/src/appointment/controller/apis/zoom_client.py
@@ -1,10 +1,11 @@
 import json
-import os
+import logging
 import time
 
 import sentry_sdk
 from requests_oauthlib import OAuth2Session
 from ...database import models, repo
+from ...exceptions.zoom_api import ZoomScopeChanged
 
 
 class ZoomClient:
@@ -14,8 +15,7 @@ class ZoomClient:
     OAUTH_DEVICE_VERIFY_URL = 'https://zoom.us/oauth_device'
     OAUTH_REQUEST_URL = 'https://api.zoom.us/v2'
 
-    SCOPES = ['user:read', 'user_info:read', 'meeting:write']
-    NEW_SCOPES = [
+    SCOPES = [
         'meeting:read:meeting',
         'meeting:write:meeting',
         'meeting:update:meeting',
@@ -34,13 +34,10 @@ class ZoomClient:
         self.callback_url = callback_url
         self.subscriber_id = None
         self.client = None
-        self.use_new_scopes = os.getenv('ZOOM_API_NEW_APP', False) == 'True'
 
     @property
     def scopes(self):
         """Returns the appropriate scopes"""
-        if self.use_new_scopes:
-            return self.NEW_SCOPES
         return self.SCOPES
 
     def check_expiry(self, token: dict | None):
@@ -90,9 +87,16 @@ class ZoomClient:
         return url, state
 
     def get_credentials(self, code: str):
-        return self.client.fetch_token(
-            self.OAUTH_TOKEN_URL, code, client_secret=self.client_secret, include_client_id=True
-        )
+        try:
+            creds = self.client.fetch_token(
+                self.OAUTH_TOKEN_URL, code, client_secret=self.client_secret, include_client_id=True
+            )
+        except Warning as e:
+            # This usually is the "Scope has changed" error.
+            logging.error(f'[zoom_client.get_credentials] Zoom Warning: {str(e)}')
+            raise ZoomScopeChanged()
+
+        return creds
 
     def token_saver(self, token):
         """requests-oauth automagically calls this function when it has a new refresh token for us.

--- a/backend/src/appointment/controller/auth.py
+++ b/backend/src/appointment/controller/auth.py
@@ -84,5 +84,10 @@ def schedule_links_by_subscriber(db, subscriber: models.Subscriber):
 
     # Empty space at join is for trailing slash!
     return list(
-        map(lambda sch: '/'.join([short_url, url_safe_username, urllib.parse.quote_plus(sch.slug), '']), schedules)
+        map(
+            lambda sch:
+                '/'.join([short_url, url_safe_username, urllib.parse.quote_plus(sch.slug), '']) if sch.slug
+                else '/'.join([short_url, url_safe_username, '']),
+            schedules
+        )
     )

--- a/backend/src/appointment/controller/auth.py
+++ b/backend/src/appointment/controller/auth.py
@@ -82,12 +82,12 @@ def schedule_links_by_subscriber(db, subscriber: models.Subscriber):
 
     url_safe_username = urllib.parse.quote_plus(subscriber.username)
 
-    # Empty space at join is for trailing slash!
-    return list(
-        map(
-            lambda sch:
-                '/'.join([short_url, url_safe_username, urllib.parse.quote_plus(sch.slug), '']) if sch.slug
-                else '/'.join([short_url, url_safe_username, '']),
-            schedules
-        )
-    )
+    return list(map(lambda sch: schedule_link(sch, short_url, url_safe_username), schedules))
+
+
+def schedule_link(schedule: models.Schedule, base: str, username: str):
+    """helper to generate a schedule link depending on the existence of a schedule slug"""
+    if schedule.slug:
+        return f"{base}/{username}/{urllib.parse.quote_plus(schedule.slug)}/"
+    else:
+        return f"{base}/{username}/"

--- a/backend/src/appointment/controller/auth.py
+++ b/backend/src/appointment/controller/auth.py
@@ -49,8 +49,9 @@ def sign_url(url: str):
     return signature
 
 
-def signed_url_by_subscriber(subscriber: schemas.Subscriber):
-    """helper to generated signed url for given subscriber"""
+def user_link_by_subscriber(subscriber: models.Subscriber):
+    """Returns a user link based off the subscriber's username
+    Note that this contains a trailing slash"""
     short_url = os.getenv('SHORT_BASE_URL')
     base_url = f"{os.getenv('FRONTEND_URL')}/user"
 
@@ -60,34 +61,29 @@ def signed_url_by_subscriber(subscriber: schemas.Subscriber):
 
     url_safe_username = urllib.parse.quote_plus(subscriber.username)
 
+    return f'{short_url}/{url_safe_username}/'
+
+
+def signed_url_by_subscriber(subscriber: schemas.Subscriber):
+    """helper to generated signed url for given subscriber"""
+    base_url = user_link_by_subscriber(subscriber)
+
     # We sign with a different hash that the end-user doesn't have access to
     # We also need to use the default url, as short urls are currently setup as a redirect
-    url = f'{base_url}/{url_safe_username}/{subscriber.short_link_hash}'
+    url = ''.join([base_url, subscriber.short_link_hash])
 
     signature = sign_url(url)
 
     # We return with the signed url signature
-    return f'{short_url}/{url_safe_username}/{signature}'
+    return ''.join([base_url, signature])
 
 
-def schedule_links_by_subscriber(db, subscriber: models.Subscriber):
+def schedule_slugs_by_subscriber(db, subscriber: models.Subscriber) -> dict:
     # Generate some schedule links
     schedules = repo.schedule.get_by_subscriber(db, subscriber_id=subscriber.id)
-    short_url = os.getenv('SHORT_BASE_URL')
-    base_url = f"{os.getenv('FRONTEND_URL')}/user"
 
-    # If we don't have a short url, then use the default url with /user added to it
-    if not short_url:
-        short_url = base_url
+    slugs = {}
+    for schedule in schedules:
+        slugs[schedule.id] = urllib.parse.quote_plus(schedule.slug) if schedule.slug else None
 
-    url_safe_username = urllib.parse.quote_plus(subscriber.username)
-
-    return list(map(lambda sch: schedule_link(sch, short_url, url_safe_username), schedules))
-
-
-def schedule_link(schedule: models.Schedule, base: str, username: str):
-    """helper to generate a schedule link depending on the existence of a schedule slug"""
-    if schedule.slug:
-        return f"{base}/{username}/{urllib.parse.quote_plus(schedule.slug)}/"
-    else:
-        return f"{base}/{username}/"
+    return slugs

--- a/backend/src/appointment/database/repo/schedule.py
+++ b/backend/src/appointment/database/repo/schedule.py
@@ -125,9 +125,10 @@ def verify_link(db: Session, url: str) -> models.Subscriber | None:
     if not subscriber:
         return None
 
-    schedule = get_by_slug(db, slug, subscriber.id)
+    if slug:
+        schedule = get_by_slug(db, slug, subscriber.id)
 
-    if not schedule:
-        return None
+        if not schedule:
+            return None
 
     return subscriber

--- a/backend/src/appointment/database/repo/schedule.py
+++ b/backend/src/appointment/database/repo/schedule.py
@@ -7,6 +7,7 @@ import uuid
 from sqlalchemy.orm import Session
 from .. import models, schemas, repo
 from ... import utils
+from ...controller.auth import signed_url_by_subscriber
 
 
 def create(db: Session, schedule: schemas.ScheduleBase):
@@ -125,10 +126,23 @@ def verify_link(db: Session, url: str) -> models.Subscriber | None:
     if not subscriber:
         return None
 
+    # If we're a signed url, then early exit here to avoid slug checks
+    is_signed_url = signed_url_by_subscriber(subscriber) == url
+    if is_signed_url:
+        return subscriber
+
     if slug:
         schedule = get_by_slug(db, slug, subscriber.id)
 
         if not schedule:
+            return None
+    elif not slug:
+        schedules = get_by_subscriber(db, subscriber.id)
+
+        # If there's no schedules (we can't display anything)
+        # or if there's a slug in the first schedule, but it's not provided (upper condition)
+        # then error out!
+        if not schedules or schedules[0].slug:
             return None
 
     return subscriber

--- a/backend/src/appointment/database/schemas.py
+++ b/backend/src/appointment/database/schemas.py
@@ -337,7 +337,8 @@ class Subscriber(SubscriberAuth):
 
 class SubscriberMeOut(SubscriberBase):
     unique_hash: Optional[str] = None
-    schedule_links: list[str] = []
+    user_link: Optional[str] = None
+    schedule_slugs: dict = {}
 
 
 class SubscriberAdminItem(SubscriberAuth):

--- a/backend/src/appointment/database/schemas.py
+++ b/backend/src/appointment/database/schemas.py
@@ -196,7 +196,7 @@ class ScheduleValidationIn(ScheduleBase):
     """ScheduleBase but with specific fields overridden to add validation."""
 
     # Regex to exclude any character can be mess with a url
-    slug: Annotated[Optional[str], Field(min_length=2, max_length=16, pattern=r'^[^\;\/\?\:\@\&\=\+\$\,\#]*$')] = None
+    slug: Annotated[Optional[str], Field(max_length=16, pattern=r'^[^\;\/\?\:\@\&\=\+\$\,\#]*$')] = None
     slot_duration: Annotated[int, Field(ge=10, default=30)]
     # Require these fields
     start_date: date

--- a/backend/src/appointment/exceptions/zoom_api.py
+++ b/backend/src/appointment/exceptions/zoom_api.py
@@ -1,0 +1,4 @@
+class ZoomScopeChanged(Exception):
+    """Raise when Zoom API lets us know the scope has changed."""
+
+    pass

--- a/backend/src/appointment/l10n/de/main.ftl
+++ b/backend/src/appointment/l10n/de/main.ftl
@@ -79,6 +79,7 @@ oauth-error = Es ist ein Fehler bei der Authentifizierung aufgetreten. Bitte ern
 
 zoom-not-connected = Es wird ein Zoom-Konto benötigt, um einen Meeting-Link zu erstellen.
 zoom-connect-to-continue = Bitte ein Zoom-Konto verbinden, einen benutzerdefinierten Meeting-Link eingeben oder auf "Videoverbindung überspringen" klicken, um fortzufahren.
+zoom-unknown-error = Es gab einen unerwarteten Fehler beim Verbinden des Zoom-Kontos. Bitte später noch einmal versuchen.
 
 ## Google Exceptions
 

--- a/backend/src/appointment/l10n/en/main.ftl
+++ b/backend/src/appointment/l10n/en/main.ftl
@@ -79,6 +79,7 @@ oauth-error = There was an error with the authentication flow. Please try again.
 
 zoom-not-connected = You need a connected Zoom account in order to create a meeting link.
 zoom-connect-to-continue = You must connect a Zoom account, enter a custom meeting link, or click "Skip Connect Video" to continue.
+zoom-unknown-error = There was an unexpected error while connecting your Zoom account. Please try again later.
 
 ## Google Exceptions
 

--- a/backend/src/appointment/routes/api.py
+++ b/backend/src/appointment/routes/api.py
@@ -17,7 +17,7 @@ from ..database import repo, schemas
 from ..controller.calendar import CalDavConnector, Tools, GoogleConnector
 from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks, Request
 from ..controller.apis.google_client import GoogleClient
-from ..controller.auth import signed_url_by_subscriber, schedule_links_by_subscriber
+from ..controller.auth import signed_url_by_subscriber, schedule_slugs_by_subscriber, user_link_by_subscriber
 from ..database.models import Subscriber, CalendarProvider, InviteStatus
 from ..defines import DEFAULT_CALENDAR_COLOUR
 from ..dependencies.google import get_google_client
@@ -78,7 +78,8 @@ def update_me(
         timezone=me.timezone,
         is_setup=me.is_setup,
         avatar_url=me.avatar_url,
-        schedule_links=schedule_links_by_subscriber(db, subscriber),
+        user_link=user_link_by_subscriber(subscriber),
+        schedule_slugs=schedule_slugs_by_subscriber(db, subscriber),
         unique_hash=me.unique_hash,
         language=me.language,
         colour_scheme=me.colour_scheme,

--- a/backend/src/appointment/routes/auth.py
+++ b/backend/src/appointment/routes/auth.py
@@ -18,7 +18,7 @@ from fastapi.responses import RedirectResponse
 
 from .. import utils
 from ..controller.apis.accounts_client import AccountsClient
-from ..controller.auth import schedule_links_by_subscriber
+from ..controller.auth import schedule_slugs_by_subscriber, user_link_by_subscriber
 from ..database import repo, schemas
 from ..database.models import Subscriber, ExternalConnectionType
 from ..defines import INVITES_TO_GIVE_OUT, AuthScheme, REDIS_USER_SESSION_PROFILE_KEY
@@ -614,7 +614,8 @@ def me(
         timezone=subscriber.timezone,
         avatar_url=subscriber.avatar_url,
         is_setup=subscriber.is_setup,
-        schedule_links=schedule_links_by_subscriber(db, subscriber),
+        user_link=user_link_by_subscriber(subscriber),
+        schedule_slugs=schedule_slugs_by_subscriber(db, subscriber),
         unique_hash=hash,
         language=subscriber.language,
         colour_scheme=subscriber.colour_scheme,

--- a/backend/src/appointment/routes/metrics.py
+++ b/backend/src/appointment/routes/metrics.py
@@ -120,9 +120,10 @@ def ftue_step(
         'apmt.ftue.step.level': data.step_level,
         '$current_url': current_url
     }
-    posthog.set(distinct_id=subscriber.unique_hash, properties=payload)
-    posthog.capture(distinct_id=subscriber.unique_hash, event='apmt.ftue.step', properties={
-        'step_name': data.step_name,
-        'step_level': data.step_level,
-        'service': APP_NAME_SHORT,
-    })
+    if posthog and subscriber:
+        posthog.set(distinct_id=subscriber.unique_hash, properties=payload)
+        posthog.capture(distinct_id=subscriber.unique_hash, event='apmt.ftue.step', properties={
+            'step_name': data.step_name,
+            'step_level': data.step_level,
+            'service': APP_NAME_SHORT,
+        })

--- a/backend/src/appointment/routes/schedule.py
+++ b/backend/src/appointment/routes/schedule.py
@@ -113,7 +113,7 @@ def create_calendar_schedule(
 
     # The first schedule currently is initialized without a slug to provide a username only availability link.
     # If we already have at least one schedule and slug isn't provided, give them the last 8 characters from a uuid4.
-    if len(repo.schedule.get_by_subscriber(db, subscriber.id) > 0) and not schedule.slug:
+    if len(repo.schedule.get_by_subscriber(db, subscriber.id)) > 0 and not schedule.slug:
         slug = repo.schedule.generate_slug(db, db_schedule.id)
         if not slug:
             # A little extra, but things are a little out of place right now..

--- a/backend/src/appointment/routes/schedule.py
+++ b/backend/src/appointment/routes/schedule.py
@@ -111,13 +111,14 @@ def create_calendar_schedule(
 
     db_schedule = repo.schedule.create(db=db, schedule=schedule)
 
-    # If slug isn't provided, give them the last 8 characters from a uuid4
-    # TODO: We might want to set initial slug to None if the user should start with an username only url
-    slug = repo.schedule.generate_slug(db, db_schedule.id)
-    if not slug:
-        # A little extra, but things are a little out of place right now..
-        repo.schedule.hard_delete(db, db_schedule.id)
-        raise validation.ScheduleCreationException()
+    # The first schedule currently is initialized without a slug to provide a username only availability link.
+    # If we already have at least one schedule and slug isn't provided, give them the last 8 characters from a uuid4.
+    if len(repo.schedule.get_by_subscriber(db, subscriber.id) > 0) and not schedule.slug:
+        slug = repo.schedule.generate_slug(db, db_schedule.id)
+        if not slug:
+            # A little extra, but things are a little out of place right now..
+            repo.schedule.hard_delete(db, db_schedule.id)
+            raise validation.ScheduleCreationException()
 
     return db_schedule
 

--- a/backend/src/appointment/routes/schedule.py
+++ b/backend/src/appointment/routes/schedule.py
@@ -112,6 +112,7 @@ def create_calendar_schedule(
     db_schedule = repo.schedule.create(db=db, schedule=schedule)
 
     # If slug isn't provided, give them the last 8 characters from a uuid4
+    # TODO: We might want to set initial slug to None if the user should start with an username only url
     slug = repo.schedule.generate_slug(db, db_schedule.id)
     if not slug:
         # A little extra, but things are a little out of place right now..
@@ -163,12 +164,9 @@ def update_schedule(
     ):
         raise validation.ZoomNotConnectedException()
 
-    if schedule.slug is None:
-        # If slug isn't provided, give them the last 8 characters from a uuid4
-        schedule.slug = repo.schedule.generate_slug(db, id)
-        if not schedule.slug:
-            # A little extra, but things are a little out of place right now..
-            raise validation.ScheduleCreationException()
+    # If slug isn't provided, make it null in db
+    if not schedule.slug:
+        schedule.slug = None
 
     return repo.schedule.update(db=db, schedule=schedule, schedule_id=id)
 

--- a/backend/src/appointment/utils.py
+++ b/backend/src/appointment/utils.py
@@ -63,15 +63,15 @@ def retrieve_user_url_data(url):
     """URL Decodes, and retrieves username, slug/signature, and main url from /<username>/<slug/signature?>/"""
     parsed_url = parse.urlparse(url)
     split_path = [x for x in parsed_url.path.split('/') if x]
-
+    
+    # Check for general validity of the path
     if split_path is None or len(split_path) == 0:
         return False
-    # If we have only two entries, we got only a username without a slug/signature
-    elif len(split_path) == 2:
-        split_path = split_path[-1:]
-    # If we have more than two entries, grab the last two (username and slug/signature)
-    elif len(split_path) > 2:
-        split_path = split_path[-2:]
+
+    # Normalize short and long urls to only username and slug/signature (remove the /user/ segment)
+    # FIXME: Handle edge case: A user with username='user' might make trouble here
+    if len(split_path) > 1 and split_path[0] == 'user':
+        split_path.pop(0)
 
     clean_url = url
     username = urllib.parse.unquote_plus(split_path[0])

--- a/backend/src/appointment/utils.py
+++ b/backend/src/appointment/utils.py
@@ -66,7 +66,7 @@ def retrieve_user_url_data(url):
 
     if split_path is None or len(split_path) == 0:
         return False
-    # If we have only one entry, we got only a username without a slug/signature
+    # If we have only two entries, we got only a username without a slug/signature
     elif len(split_path) == 2:
         split_path = split_path[-1:]
     # If we have more than two entries, grab the last two (username and slug/signature)

--- a/backend/src/appointment/utils.py
+++ b/backend/src/appointment/utils.py
@@ -65,7 +65,7 @@ def retrieve_user_url_data(url):
     split_path = [x for x in parsed_url.path.split('/') if x]
     
     # Check for general validity of the path
-    if split_path is None or len(split_path) == 0:
+    if split_path is None or len(split_path) == 0 or len(split_path) > 3:
         return False
 
     # Normalize short and long urls to only username and slug/signature (remove the /user/ segment)

--- a/backend/src/appointment/utils.py
+++ b/backend/src/appointment/utils.py
@@ -60,28 +60,33 @@ def decrypt(value):
 
 
 def retrieve_user_url_data(url):
-    """URL Decodes, and retrieves username, signature, and main url from /<username>/<signature>/"""
+    """URL Decodes, and retrieves username, slug/signature, and main url from /<username>/<slug/signature?>/"""
     parsed_url = parse.urlparse(url)
     split_path = [x for x in parsed_url.path.split('/') if x]
 
     if split_path is None or len(split_path) == 0:
         return False
-    # If we have more than two entries, grab the last two
+    # If we have only one entry, we got only a username without a slug/signature
+    elif len(split_path) == 2:
+        split_path = split_path[-1:]
+    # If we have more than two entries, grab the last two (username and slug/signature)
     elif len(split_path) > 2:
         split_path = split_path[-2:]
 
     clean_url = url
-    username = split_path[0]
-    signature = None
+    username = urllib.parse.unquote_plus(split_path[0])
+    slug = None
     if len(split_path) > 1:
-        signature = split_path[1]
+        slug = split_path[1]
         # Strip any tailing slashes
-        clean_url = clean_url.replace(signature, "").rstrip('/')
+        clean_url = clean_url.replace(slug, "").rstrip('/')
         # Re-add just the last one
         clean_url = f'{clean_url}/'
+        # Decode slug/signature
+        slug = urllib.parse.unquote_plus(slug)
 
-    # Return the username and signature decoded, but ensure the clean_url is encoded.
-    return urllib.parse.unquote_plus(username), urllib.parse.unquote_plus(signature), clean_url
+    # Return the username and slug/signature decoded, but ensure the clean_url is encoded.
+    return username, slug, clean_url
 
 
 def chunk_list(to_chunk: list, chunk_by: int):

--- a/backend/test/factory/subscriber_factory.py
+++ b/backend/test/factory/subscriber_factory.py
@@ -19,8 +19,8 @@ def make_subscriber(with_db):
                 db,
                 schemas.SubscriberAuth(
                     name=name if factory_has_value(name) else fake.name(),
-                    username=username if factory_has_value(username) else fake.name().replace(' ', '_'),
-                    email=email if factory_has_value(email) else fake.email(),
+                    username=username if factory_has_value(username) else fake.unique.name().replace(' ', '_'),
+                    email=email if factory_has_value(email) else fake.unique.email(),
                     level=level,
                     timezone='America/Vancouver',
                     short_link_hash=secrets.token_hex(32)

--- a/backend/test/unit/test_auth_dependency.py
+++ b/backend/test/unit/test_auth_dependency.py
@@ -190,7 +190,7 @@ class TestAuthDependency:
         assert retrieved_subscriber.id == subscriber.id
         assert retrieved_subscriber.email == subscriber.email
 
-    def test_get_subscriber_from_schedule_or_signed_url_with_schedule_slug(
+    def test_get_subscriber_from_schedule_or_signed_url_with_schedule_slug_using_short_url(
         self, with_db, with_l10n, make_pro_subscriber, make_schedule, make_caldav_calendar
     ):
         subscriber = make_pro_subscriber()
@@ -204,7 +204,7 @@ class TestAuthDependency:
         assert retrieved_subscriber.id == subscriber.id
         assert retrieved_subscriber.email == subscriber.email
 
-    def test_get_subscriber_from_schedule_or_signed_url_without_schedule_slug(
+    def test_get_subscriber_from_schedule_or_signed_url_without_schedule_slug_using_short_url(
         self, with_db, with_l10n, make_pro_subscriber, make_schedule, make_caldav_calendar
     ):
         subscriber = make_pro_subscriber()
@@ -213,6 +213,34 @@ class TestAuthDependency:
 
         with with_db() as db:
             url = f'https://apmt.day/{subscriber.username}/'
+            retrieved_subscriber = get_subscriber_from_schedule_or_signed_url(url, db)
+
+        assert retrieved_subscriber.id == subscriber.id
+        assert retrieved_subscriber.email == subscriber.email
+
+    def test_get_subscriber_from_schedule_or_signed_url_with_schedule_slug(
+        self, with_db, with_l10n, make_pro_subscriber, make_schedule, make_caldav_calendar
+    ):
+        subscriber = make_pro_subscriber()
+        calendar = make_caldav_calendar(subscriber_id=subscriber.id)
+        schedule = make_schedule(calendar_id=calendar.id)
+
+        with with_db() as db:
+            url = f'https://apmt.day/user/{subscriber.username}/{schedule.slug}/'
+            retrieved_subscriber = get_subscriber_from_schedule_or_signed_url(url, db)
+
+        assert retrieved_subscriber.id == subscriber.id
+        assert retrieved_subscriber.email == subscriber.email
+
+    def test_get_subscriber_from_schedule_or_signed_url_without_schedule_slug(
+        self, with_db, with_l10n, make_pro_subscriber, make_schedule, make_caldav_calendar
+    ):
+        subscriber = make_pro_subscriber()
+        calendar = make_caldav_calendar(subscriber_id=subscriber.id)
+        make_schedule(calendar_id=calendar.id)
+
+        with with_db() as db:
+            url = f'https://apmt.day/user/{subscriber.username}/'
             retrieved_subscriber = get_subscriber_from_schedule_or_signed_url(url, db)
 
         assert retrieved_subscriber.id == subscriber.id

--- a/backend/test/unit/test_auth_dependency.py
+++ b/backend/test/unit/test_auth_dependency.py
@@ -203,3 +203,17 @@ class TestAuthDependency:
 
         assert retrieved_subscriber.id == subscriber.id
         assert retrieved_subscriber.email == subscriber.email
+
+    def test_get_subscriber_from_schedule_or_signed_url_without_schedule_slug(
+        self, with_db, with_l10n, make_pro_subscriber, make_schedule, make_caldav_calendar
+    ):
+        subscriber = make_pro_subscriber()
+        calendar = make_caldav_calendar(subscriber_id=subscriber.id)
+        make_schedule(calendar_id=calendar.id)
+
+        with with_db() as db:
+            url = f'https://apmt.day/{subscriber.username}/'
+            retrieved_subscriber = get_subscriber_from_schedule_or_signed_url(url, db)
+
+        assert retrieved_subscriber.id == subscriber.id
+        assert retrieved_subscriber.email == subscriber.email

--- a/backend/test/unit/test_utils.py
+++ b/backend/test/unit/test_utils.py
@@ -51,11 +51,7 @@ class TestRetrieveUserUrlData:
         original_clean_url = f'https://appointment.local/user/{original_username}/'
         url = f'{original_clean_url}/{original_signature}/other-junk/'
 
-        username, signature, clean_url = retrieve_user_url_data(url)
-
-        assert original_username != username
-        assert original_signature != signature
-        assert original_clean_url != clean_url
+        assert not retrieve_user_url_data(url)
 
 
 class TestIsAValidBookingTime:

--- a/frontend/src/components/CalendarManagement.vue
+++ b/frontend/src/components/CalendarManagement.vue
@@ -6,7 +6,8 @@ import {
 import { useI18n } from 'vue-i18n';
 import { CalendarManagementType } from '@/definitions';
 import { Calendar } from '@/models';
-import SecondaryButton from '@/elements/SecondaryButton.vue';
+import SecondaryButton from '@/tbpro/elements/SecondaryButton.vue';
+import PrimaryButton from '@/tbpro/elements/PrimaryButton.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 const emit = defineEmits(['modify', 'remove', 'sync']);
@@ -32,16 +33,18 @@ const filteredCalendars = computed(() => props.calendars.filter((calendar: Calen
     <div class="text-xl">{{ title }}</div>
     <div class="mx-auto mr-0 inline-flex" v-if="type === CalendarManagementType.Connect">
       <secondary-button
-        class="btn-sync text-sm !text-teal-500 disabled:scale-100 disabled:opacity-50 disabled:shadow-none"
+        class="btn-sync"
         :disabled="loading"
         @click="emit('sync')"
         :title="t('label.sync')"
         data-testid="calendar-settings-sync-calendars-button"
       >
+        <template v-slot:icon>
+          <icon-refresh class="size-4 stroke-2" :class="{ 'animate-spin': loading }" />
+        </template>
         <span class="mr-2 inline-block">
           {{ t('label.syncCalendars') }}
         </span>
-        <icon-refresh class="inline-block size-4 stroke-2" :class="{ 'animate-spin': loading }" />
       </secondary-button>
     </div>
   </div>
@@ -53,34 +56,34 @@ const filteredCalendars = computed(() => props.calendars.filter((calendar: Calen
       <span class="calendar-title">
       {{ cal.title }}
       </span>
-      <button
+      <primary-button
         v-if="type === CalendarManagementType.Connect"
         @click="emit('modify', cal.id)"
         :disabled="loading"
-        class="
-          btn-conntect ml-auto flex items-center gap-0.5 rounded-full bg-teal-500 px-2 py-1
-          text-xs text-white disabled:scale-100 disabled:opacity-50 disabled:shadow-none
-        "
+        class="btn-conntect ml-auto"
+        size="small"
         :title="t('label.connect')"
         data-testid="settings-calendar-connect-calendar-btn"
       >
-        <icon-arrow-right class="size-3 stroke-3"/>
+        <template v-slot:icon>
+          <icon-arrow-right class="size-3 stroke-3"/>
+        </template>
         {{ t('label.connectCalendar') }}
-      </button>
-      <button
+      </primary-button>
+      <primary-button
         v-if="type === CalendarManagementType.Edit"
         @click="emit('modify', cal.id)"
         :disabled="loading"
-        class="
-          btn-edit ml-auto flex items-center gap-0.5 rounded-full bg-teal-500 px-2 py-1
-          text-xs text-white disabled:scale-100 disabled:opacity-50 disabled:shadow-none
-        "
+        class="btn-edit ml-auto"
+        size="small"
         :title="t('label.edit')"
         data-testid="settings-calendar-edit-calendar-btn"
       >
-        <icon-pencil class="size-3 stroke-3"/>
+        <template v-slot:icon>
+          <icon-pencil class="size-3 stroke-3"/>
+        </template>
         {{ t('label.editCalendar') }}
-      </button>
+      </primary-button>
       <button
         v-if="!cal.connected"
         class="btn-remove bg-transparent p-0.5 disabled:scale-100 disabled:opacity-50 disabled:shadow-none"

--- a/frontend/src/components/FTUE/SetupProfile.vue
+++ b/frontend/src/components/FTUE/SetupProfile.vue
@@ -75,7 +75,7 @@ const onSubmit = async () => {
       </text-input>
       <text-input
         name="username"
-        :prefix="quickLink"
+        :outer-prefix="quickLink"
         v-model="username"
         :required="true"
         :error="errorUsername"

--- a/frontend/src/components/FTUE/SetupProfile.vue
+++ b/frontend/src/components/FTUE/SetupProfile.vue
@@ -4,7 +4,7 @@ import { storeToRefs } from 'pinia';
 import { createFTUEStore } from '@/stores/ftue-store';
 import { createUserStore } from '@/stores/user-store';
 import { useI18n } from 'vue-i18n';
-import { dayjsKey, callKey } from '@/keys';
+import { dayjsKey, callKey, shortUrlKey } from '@/keys';
 import TextInput from '@/tbpro/elements/TextInput.vue';
 import SelectInput from '@/tbpro/elements/SelectInput.vue';
 import PrimaryButton from '@/tbpro/elements/PrimaryButton.vue';
@@ -12,10 +12,12 @@ import PrimaryButton from '@/tbpro/elements/PrimaryButton.vue';
 const { t } = useI18n();
 const dj = inject(dayjsKey);
 const call = inject(callKey);
+const shortUrl = inject(shortUrlKey);
 
 const ftueStore = createFTUEStore(call);
 const { hasNextStep } = storeToRefs(ftueStore);
 const user = createUserStore(call);
+const quickLink = shortUrl.substring(shortUrl.indexOf('//')+2) + '/';
 
 // @ts-expect-error ignore type err
 // See https://github.com/microsoft/TypeScript/issues/49231
@@ -71,7 +73,14 @@ const onSubmit = async () => {
       <text-input name="full-name" v-model="fullName" :required="true" :error="errorFullName">
         {{ t('ftue.fullName') }}
       </text-input>
-      <text-input name="username" v-model="username" :required="true" :error="errorUsername">
+      <text-input
+        name="username"
+        :prefix="quickLink"
+        v-model="username"
+        :required="true"
+        :error="errorUsername"
+        :help="t('ftue.usernameHelp')"
+      >
         {{ t('label.username') }}
       </text-input>
       <select-input

--- a/frontend/src/components/FTUE/SetupSchedule.vue
+++ b/frontend/src/components/FTUE/SetupSchedule.vue
@@ -38,15 +38,15 @@ const { timeToBackendTime, timeToFrontendTime } = scheduleStore;
 
 const calendarOptions = computed<SelectOption[]>(() => connectedCalendars.value.map((calendar) => ({
   label: calendar.title,
-  value: calendar.id,
+  value: calendar.id.toString(),
 })));
 const durationOptions: SelectOption[] = SLOT_DURATION_OPTIONS.map((min) => ({
   label: `${min} min`,
-  value: min,
+  value: min.toString(),
 }));
 const scheduleDayOptions: SelectOption[] = isoWeekdays.map((day) => ({
   label: day.min[0],
-  value: day.iso,
+  value: day.iso.toString(),
 }));
 
 const formRef = ref<HTMLFormElement>();
@@ -57,7 +57,7 @@ const schedule = ref({
   startTime: '09:00',
   endTime: '17:00',
   duration: DEFAULT_SLOT_DURATION,
-  days: [1, 2, 3, 4, 5],
+  days: ['1', '2', '3', '4', '5'],
   details: '',
 });
 
@@ -132,7 +132,7 @@ onMounted(async () => {
       startTime: timeToFrontendTime(dbSchedule.start_time, dbSchedule.time_updated),
       endTime: timeToFrontendTime(dbSchedule.end_time, dbSchedule.time_updated),
       duration: dbSchedule.slot_duration,
-      days: dbSchedule.weekdays,
+      days: dbSchedule.weekdays.map(String),
     };
   }
 

--- a/frontend/src/components/ScheduleCreation.vue
+++ b/frontend/src/components/ScheduleCreation.vue
@@ -17,7 +17,6 @@ import {
 } from '@/keys';
 
 import AppointmentCreatedModal from '@/components/AppointmentCreatedModal.vue';
-import ConfirmationModal from '@/components/ConfirmationModal.vue';
 import PrimaryButton from '@/tbpro/elements/PrimaryButton.vue';
 import AlertBox from '@/elements/AlertBox.vue';
 import ToolTip from '@/elements/ToolTip.vue';
@@ -28,7 +27,6 @@ import TextInput from '@/tbpro/elements/TextInput.vue';
 import CheckboxInput from '@/tbpro/elements/CheckboxInput.vue';
 import SelectInput from '@/tbpro/elements/SelectInput.vue';
 import LinkButton from '@/tbpro/elements/LinkButton.vue';
-import RefreshIcon from '@/tbpro/icons/RefreshIcon.vue';
 import CopyIcon from '@/tbpro/icons/CopyIcon.vue';
 
 // icons
@@ -187,9 +185,6 @@ const getScheduleAppointment = (): ScheduleAppointment => ({
 const isFormDirty = computed(
   () => JSON.stringify(scheduleInput.value) !== JSON.stringify(referenceSchedule.value),
 );
-const isSlugDirty = computed(
-  () => scheduleInput.value.slug !== referenceSchedule.value.slug,
-);
 
 // handle notes char limit
 const charLimit = 250;
@@ -265,15 +260,8 @@ const scheduleValidationError = (schedule: Schedule): string|null => {
   return null;
 };
 
-// Update slug with a random 8 character string
-const refreshSlugModalOpen = ref(false);
-const showRefreshSlugConfirmation = async () => {
-  refreshSlugModalOpen.value = true;
-};
-
 const closeModals = () => {
   savedConfirmation.show = false;
-  refreshSlugModalOpen.value = false;
 };
 
 // handle actual schedule creation/update
@@ -342,11 +330,6 @@ const saveSchedule = async (withConfirmation = true) => {
   // Update our reference schedule!
   referenceSchedule.value = { ...scheduleInput.value };
   revertForm(false);
-  closeModals();
-};
-
-const refreshSlug = () => {
-  scheduleInput.value.slug = window.crypto.randomUUID().substring(0, 8);
   closeModals();
 };
 
@@ -715,31 +698,6 @@ watch(
         </div>
         <div v-show="activeStep4" class="flex flex-col gap-2">
           <hr/>
-          <!-- custom quick link -->
-          <label class="relative flex flex-col gap-1">
-            <div class="flex items-center gap-2">
-              <text-input
-                type="text"
-                name="slug"
-                :prefix="`/${user.data.username}/`"
-                v-model="scheduleInput.slug"
-                class="w-full rounded-md disabled:cursor-not-allowed"
-                :small-text="true"
-                maxLength="16"
-                :disabled="!scheduleInput.active"
-              >
-                {{ t("label.quickLink") }}
-              </text-input>
-              <link-button
-                class="p-0.5"
-                @click="scheduleInput.active ? refreshSlug() : null"
-                :disabled="!scheduleInput.active"
-                data-testid="dashboard-booking-settings-link-refresh-btn"
-              >
-                <refresh-icon />
-              </link-button>
-            </div>
-          </label>
           <!-- option to deactivate confirmation -->
           <div class="flex flex-col gap-3">
             <switch-toggle
@@ -806,7 +764,7 @@ watch(
     >
       <primary-button
         class="btn-save w-full"
-        @click="isSlugDirty ? showRefreshSlugConfirmation() : saveSchedule(!existing)"
+        @click="saveSchedule(!existing)"
         :disabled="!scheduleInput.active || savingInProgress"
         data-testid="dashboard-save-changes-btn"
       >
@@ -846,16 +804,6 @@ watch(
     :public-link="user.data.signedUrl"
     @close="closeModals"
   />
-  <!-- Refresh link confirmation modal -->
-  <confirmation-modal
-    :open="refreshSlugModalOpen"
-    :title="t('label.refreshLink')"
-    :message="t('text.refreshLinkNotice')"
-    :confirm-label="t('label.save')"
-    :cancel-label="t('label.cancel')"
-    @confirm="saveSchedule(!existing)"
-    @close="closeModals"
-  ></confirmation-modal>
 </template>
 
 <style scoped>

--- a/frontend/src/components/ScheduleCreation.vue
+++ b/frontend/src/components/ScheduleCreation.vue
@@ -102,7 +102,7 @@ const defaultSchedule: Schedule = {
   end_time: '17:00',
   earliest_booking: 1440,
   farthest_booking: 20160,
-  weekdays: [1, 2, 3, 4, 5],
+  weekdays: ['1', '2', '3', '4', '5'],
   slot_duration: DEFAULT_SLOT_DURATION,
   meeting_link_provider: MeetingLinkProviderType.None,
   slug: user.mySlug,
@@ -193,7 +193,7 @@ const charCount = computed(() => scheduleInput.value.details?.length ?? 0);
 // Weekday options
 const scheduleDayOptions: SelectOption[] = isoWeekdays.map((day) => ({
   label: day.min[0],
-  value: day.iso.toString(),
+  value: day.iso, // Important: For now this needs to be ints, as that's what the values from the api as.
 }));
 
 // Connected calendar options

--- a/frontend/src/components/ScheduleCreation.vue
+++ b/frontend/src/components/ScheduleCreation.vue
@@ -188,7 +188,7 @@ const isFormDirty = computed(
 
 // handle notes char limit
 const charLimit = 250;
-const charCount = computed(() => scheduleInput.value.details.length);
+const charCount = computed(() => scheduleInput.value.details?.length ?? 0);
 
 // Weekday options
 const scheduleDayOptions: SelectOption[] = isoWeekdays.map((day) => ({

--- a/frontend/src/components/ScheduleCreation.vue
+++ b/frontend/src/components/ScheduleCreation.vue
@@ -193,13 +193,13 @@ const charCount = computed(() => scheduleInput.value.details?.length ?? 0);
 // Weekday options
 const scheduleDayOptions: SelectOption[] = isoWeekdays.map((day) => ({
   label: day.min[0],
-  value: day.iso,
+  value: day.iso.toString(),
 }));
 
 // Connected calendar options
 const calendarOptions = computed<SelectOption[]>(() => props.calendars.map((calendar) => ({
   label: calendar.title,
-  value: calendar.id,
+  value: calendar.id.toString(),
 })));
 
 // Earliest booking options
@@ -208,25 +208,25 @@ const earliestOptions: SelectOption[] = [0, 0.5, 1, 2, 3, 4, 5].map((d) => {
   if (d === 0) {
     return {
       label: t('label.immediately'),
-      value: 0,
+      value: '0',
     };
   }
   return {
     label: dj.duration(d, 'days').humanize(),
-    value: d * 60 * 24,
+    value: (d * 60 * 24).toString(),
   };
 });
 
 // Farthest booking options
 const farthestOptions: SelectOption[] = [1, 2, 3, 4].map((d) => ({
   label: dj.duration(d, 'weeks').humanize(),
-  value: d * 60 * 24 * 7,
+  value: (d * 60 * 24 * 7).toString(),
 }));
 
 // Appointment duration options
 const durationOptions: SelectOption[] = SLOT_DURATION_OPTIONS.map((duration) => ({
   label: t('units.minutes', { value: duration }),
-  value: duration,
+  value: duration.toString(),
 }));
 
 // humanize selected durations

--- a/frontend/src/components/SettingsAccount.vue
+++ b/frontend/src/components/SettingsAccount.vue
@@ -92,6 +92,9 @@ const errorDisplayName = ref<string>(null);
 
 // Save user data
 const updateUser = async () => {
+  // Prepare slug processing
+  activeSlug.value = activeSlug.value.trim();
+
   // First update the slug if it was changed
   if (activeSlug.value !== user.mySlug) {
     const response = await schedule.updateFirstSlug(activeSlug.value);

--- a/frontend/src/components/SettingsAccount.vue
+++ b/frontend/src/components/SettingsAccount.vue
@@ -61,7 +61,17 @@ const usernameShort = computed(() => {
   }
   return username;
 })
-const quickLinkFull = computed(() => `${shortUrl}/${user.data.username}/${activeSlug.value}`)
+
+/**
+ * Used for hover tooltips, and the copy button
+ */
+const quickLinkFull = computed(() => user.mySlug
+  ? `${shortUrl}/${user.data.username}/${user.mySlug}/`
+  : `${shortUrl}/${user.data.username}/`);
+
+/**
+ * Used to show the link up until the passcode portion of the url (aka the label before the textbox.)
+ */
 const quickLinkPrefix = computed(() => shortUrl.substring(shortUrl.indexOf('//') + 2) + `/${usernameShort.value}/`);
 
 // Preferred email options

--- a/frontend/src/components/SettingsAccount.vue
+++ b/frontend/src/components/SettingsAccount.vue
@@ -24,7 +24,7 @@ import { createScheduleStore } from '@/stores/schedule-store';
 import { MetricEvents } from '@/definitions';
 import { usePosthog, posthog } from '@/composables/posthog';
 import {
-  StringListResponse, SubscriberResponse, BlobResponse, BooleanResponse,  SelectOption,
+  StringListResponse, SubscriberResponse, BlobResponse, BooleanResponse,  SelectOption, Error,
 } from '@/models';
 import { callKey, shortUrlKey } from '@/keys';
 import { createUserStore } from '@/stores/user-store';
@@ -89,6 +89,7 @@ const refreshData = async () => Promise.all([
 // Form validation
 const errorUsername = ref<string>(null);
 const errorDisplayName = ref<string>(null);
+const errorSlug = ref<string>(null);
 
 // Save user data
 const updateUser = async () => {
@@ -100,7 +101,10 @@ const updateUser = async () => {
     const response = await schedule.updateFirstSlug(activeSlug.value);
     // eslint-disable-next-line no-prototype-builtins
     if (response.hasOwnProperty('error')) {
-      // TODO: error message is in data
+      // Error message is in data
+      errorSlug.value = (response as Error).message;
+    } else {
+      errorSlug.value = null;
     }
   }
 
@@ -303,6 +307,9 @@ const actuallyDeleteAccount = async () => {
               :small-text="true"
               maxLength="16"
             />
+            <div v-if="errorSlug" class="text-sm text-red-500">
+              {{ errorSlug }}
+            </div>
           </div>
           <text-button
             uid="myLink"

--- a/frontend/src/components/SettingsAccount.vue
+++ b/frontend/src/components/SettingsAccount.vue
@@ -91,6 +91,7 @@ const updateUser = async () => {
   // First update the slug if it was changed
   if (activeSlug.value !== user.mySlug) {
     const response = await schedule.updateFirstSlug(activeSlug.value);
+    // eslint-disable-next-line no-prototype-builtins
     if (response.hasOwnProperty('error')) {
       // TODO: error message is in data
     }

--- a/frontend/src/components/SettingsAccount.vue
+++ b/frontend/src/components/SettingsAccount.vue
@@ -26,12 +26,13 @@ import { usePosthog, posthog } from '@/composables/posthog';
 import {
   StringListResponse, SubscriberResponse, BlobResponse, BooleanResponse,  SelectOption,
 } from '@/models';
-import { callKey } from '@/keys';
+import { callKey, shortUrlKey } from '@/keys';
 import { createUserStore } from '@/stores/user-store';
 
 // component constants
 const { t } = useI18n({ useScope: 'global' });
 const call = inject(callKey);
+const shortUrl = inject(shortUrlKey);
 const router = useRouter();
 const schedule = createScheduleStore(call);
 const externalConnectionsStore = createExternalConnectionsStore(call);
@@ -48,6 +49,9 @@ const updateLinkModalOpen = ref(false);
 const availableEmails = ref([user.data.preferredEmail]);
 const activePreferredEmail = ref(user.data.preferredEmail);
 const formRef = ref<HTMLFormElement>();
+
+// Custom quick link
+const quickLink = computed(() => shortUrl.substring(shortUrl.indexOf('//')+2) + `/${user.data.username}/`);
 
 // Preferred email options
 const emailOptions = computed<SelectOption[]>(() => availableEmails.value.map((email) => ({
@@ -293,7 +297,7 @@ const actuallyDeleteAccount = async () => {
             <text-input
               type="text"
               name="slug"
-              :prefix="`/${user.data.username}/`"
+              :prefix="quickLink"
               v-model="activeSlug"
               class="w-full rounded-md disabled:cursor-not-allowed"
               :small-text="true"

--- a/frontend/src/components/SettingsAccount.vue
+++ b/frontend/src/components/SettingsAccount.vue
@@ -4,10 +4,10 @@ import {
 } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
-import CautionButton from '@/elements/CautionButton.vue';
+import DangerButton from '@/tbpro/elements/DangerButton.vue';
 import ConfirmationModal from '@/components/ConfirmationModal.vue';
-import PrimaryButton from '@/elements/PrimaryButton.vue';
-import SecondaryButton from '@/elements/SecondaryButton.vue';
+import PrimaryButton from '@/tbpro/elements/PrimaryButton.vue';
+import SecondaryButton from '@/tbpro/elements/SecondaryButton.vue';
 import TextInput from '@/tbpro/elements/TextInput.vue';
 import SelectInput from '@/tbpro/elements/SelectInput.vue';
 import TextButton from '@/elements/TextButton.vue';
@@ -50,8 +50,8 @@ const availableEmails = ref([user.data.preferredEmail]);
 const activePreferredEmail = ref(user.data.preferredEmail);
 const formRef = ref<HTMLFormElement>();
 
-// Custom quick link
-const quickLink = computed(() => shortUrl.substring(shortUrl.indexOf('//')+2) + `/${user.data.username}/`);
+// Custom quick link prefix
+const quickLinkPrefix = computed(() => shortUrl.substring(shortUrl.indexOf('//')+2) + `/${user.data.username}/`);
 
 // Preferred email options
 const emailOptions = computed<SelectOption[]>(() => availableEmails.value.map((email) => ({
@@ -240,7 +240,6 @@ const actuallyDeleteAccount = async () => {
             v-model="activeUsername"
             type="text"
             name="username"
-            class="w-full rounded-md"
             :class="{ '!border-red-500': errorUsername }"
             :required="true"
             data-testid="settings-account-user-name-input"
@@ -280,7 +279,6 @@ const actuallyDeleteAccount = async () => {
             v-model="activeDisplayName"
             type="text"
             name="displayName"
-            class="w-full rounded-md"
             :class="{ '!border-red-500': errorDisplayName }"
             data-testid="settings-account-display-name-input"
           />
@@ -297,9 +295,8 @@ const actuallyDeleteAccount = async () => {
             <text-input
               type="text"
               name="slug"
-              :prefix="quickLink"
+              :prefix="quickLinkPrefix"
               v-model="activeSlug"
-              class="w-full rounded-md disabled:cursor-not-allowed"
               :small-text="true"
               maxLength="16"
             />
@@ -316,19 +313,21 @@ const actuallyDeleteAccount = async () => {
       </label>
       <div class="mt-6 flex gap-4 self-end">
         <secondary-button
-          :label="t('label.refreshLink')"
-          class="btn-refresh !text-teal-500"
+          class="btn-refresh"
           @click="refreshLink"
           :title="t('label.refresh')"
           data-testid="settings-account-refresh-link-btn"
-        />
+        >
+          {{ t('label.refreshLink') }}
+        </secondary-button>
         <secondary-button
-          :label="t('label.saveChanges')"
-          class="btn-save !text-teal-500"
+          class="btn-save"
           @click="updateUserCheckForConfirmation"
           :title="t('label.save')"
           data-testid="settings-account-save-changes-btn"
-        />
+        >
+          {{ t('label.saveChanges') }}
+        </secondary-button>
       </div>
     </form>
     <div class="pl-6" id="invites">
@@ -344,24 +343,26 @@ const actuallyDeleteAccount = async () => {
       <div class="text-xl">{{ t('heading.accountData') }}</div>
       <div class="mt-4 pl-4">
         <primary-button
-          :label="t('label.downloadYourData')"
           class="btn-download"
           @click="downloadData"
           :title="t('label.download')"
           data-testid="settings-account-download-data-btn"
-        />
+        >
+          {{ t('label.downloadYourData') }}
+        </primary-button>
       </div>
     </div>
     <div class="pl-6" id="delete-your-account">
       <div class="text-xl">{{ t('heading.accountDeletion') }}</div>
       <div class="mt-4 pl-4">
-        <caution-button
-          :label="t('label.deleteYourAccount')"
+        <danger-button
           class="btn-delete"
           @click="deleteAccount"
           :title="t('label.delete')"
           data-testid="settings-account-delete-btn"
-        />
+        >
+          {{ t('label.deleteYourAccount') }}
+        </danger-button>
       </div>
     </div>
   </div>

--- a/frontend/src/components/SettingsAccount.vue
+++ b/frontend/src/components/SettingsAccount.vue
@@ -295,7 +295,7 @@ const actuallyDeleteAccount = async () => {
             <text-input
               type="text"
               name="slug"
-              :prefix="quickLinkPrefix"
+              :outer-prefix="quickLinkPrefix"
               v-model="activeSlug"
               :small-text="true"
               maxLength="16"

--- a/frontend/src/components/SettingsAccount.vue
+++ b/frontend/src/components/SettingsAccount.vue
@@ -14,7 +14,7 @@ import TextButton from '@/elements/TextButton.vue';
 import ToolTip from '@/elements/ToolTip.vue';
 
 // icons
-import { IconExternalLink, IconInfoCircle } from '@tabler/icons-vue';
+import { IconInfoCircle } from '@tabler/icons-vue';
 
 // stores
 import UserInviteTable from '@/components/UserInviteTable.vue';
@@ -177,6 +177,7 @@ const refreshLink = async () => {
 const refreshLinkConfirm = async () => {
   await user.changeSignedUrl();
   await refreshData();
+  activeSlug.value = user.mySlug;
   closeModals();
 
   sendMetrics(MetricEvents.RefreshLink);

--- a/frontend/src/components/SettingsCalendar.vue
+++ b/frontend/src/components/SettingsCalendar.vue
@@ -15,11 +15,12 @@ import {
 } from '@/models';
 import AlertBox from '@/elements/AlertBox.vue';
 import CalendarManagement from '@/components/CalendarManagement.vue';
-import CautionButton from '@/elements/CautionButton.vue';
+import DangerButton from '@/tbpro/elements/DangerButton.vue';
 import ConfirmationModal from '@/components/ConfirmationModal.vue';
 import GoogleCalendarButton from '@/elements/GoogleCalendarButton.vue';
-import PrimaryButton from '@/elements/PrimaryButton.vue';
-import SecondaryButton from '@/elements/SecondaryButton.vue';
+import PrimaryButton from '@/tbpro/elements/PrimaryButton.vue';
+import SecondaryButton from '@/tbpro/elements/SecondaryButton.vue';
+import TextInput from '@/tbpro/elements/TextInput.vue';
 import { posthog, usePosthog } from '@/composables/posthog';
 import { clearFormErrors, handleFormError } from '@/utils';
 
@@ -300,19 +301,21 @@ onMounted(async () => {
 
     <div class="flex gap-4">
       <secondary-button
-        :label="t('label.addCalendar', { provider: t('label.google') })"
-        class="btn-add text-sm !text-teal-500"
+        class="btn-add"
         @click="discoverGoogleCalendars"
         :disabled="inputMode"
         :title="t('label.addCalendar', { provider: t('label.google') })"
-      />
+      >
+        {{ t('label.addCalendar', { provider: t('label.google') }) }}
+      </secondary-button>
       <secondary-button
-        :label="t('label.addCalendar', { provider: t('label.caldav') })"
-        class="btn-add text-sm !text-teal-500"
+        class="btn-add"
         @click="discoverCaldavCalendars"
         :disabled="inputMode"
         :title="t('label.addCalendar', { provider: t('label.caldav') })"
-      />
+      >
+        {{ t('label.addCalendar', { provider: t('label.caldav') }) }}
+      </secondary-button>
     </div>
 
     <!-- CalDAV calendar discovery -->
@@ -341,8 +344,9 @@ onMounted(async () => {
               {{ t('label.principal') }}
               <div class="text-xs text-gray-500">{{ t('calDAVForm.help.location') }}</div>
             </div>
-            <input
+            <text-input
               v-model="principal.url"
+              name="url"
               type="url"
               class="w-full max-w-sm rounded-md"
               :disabled="processPrincipal"
@@ -355,8 +359,9 @@ onMounted(async () => {
               {{ t('label.username') }}
               <div class="text-xs text-gray-500">{{ t('calDAVForm.help.user') }}</div>
             </div>
-            <input
+            <text-input
               v-model="principal.user"
+              name="user"
               type="text"
               class="w-full max-w-sm rounded-md"
               :disabled="processPrincipal"
@@ -369,8 +374,9 @@ onMounted(async () => {
               {{ t('label.password') }}
               <div class="text-xs text-gray-500">{{ t('calDAVForm.help.password') }}</div>
             </div>
-            <input
+            <text-input
               v-model="principal.password"
+              name="password"
               type="password"
               class="w-full max-w-sm rounded-md"
               :disabled="processPrincipal"
@@ -381,21 +387,23 @@ onMounted(async () => {
         </form>
         <div class="flex justify-end gap-4">
           <secondary-button
-            :label="t('label.cancel')"
-            class="btn-cancel text-sm !text-teal-500"
+            class="btn-cancel"
             @click="resetInput"
             :title="t('label.cancel')"
             :disabled="processPrincipal"
             data-testid="settings-calendar-caldav-cancel-button"
-          />
+          >
+            {{ t('label.cancel') }}
+          </secondary-button>
           <primary-button
-            :label="'Search for calendars'"
-            class="btn-search text-sm"
+            class="btn-search"
             :waiting="processPrincipal"
             @click="getRemoteCaldavCalendars"
             :title="t('label.search')"
             data-testid="settings-calendar-caldav-process-principal-button"
-          />
+          >
+            {{ t('label.searchForCalendars') }}
+          </primary-button>
         </div>
       </div>
     </div>
@@ -425,10 +433,11 @@ onMounted(async () => {
       </div>
       <label v-if="isCalDav || editMode" class="flex items-center pl-4">
         <div class="w-full max-w-2xs">{{ t('label.title') }}</div>
-        <input
+        <text-input
           v-model="calendarInput.data.title"
+          name="title"
           type="text"
-          class="w-full max-w-sm rounded-md"
+          class="w-full"
           data-testid="settings-calendar-title-input"
         />
       </label>
@@ -440,58 +449,62 @@ onMounted(async () => {
               {{ color }}
             </option>
           </select>
-          <input v-else type="text" data-testid="settings-calendar-color-input" v-model="calendarInput.data.color" class="w-full rounded-md" />
+          <text-input
+            v-else
+            name="color"
+            type="text"
+            data-testid="settings-calendar-color-input"
+            v-model="calendarInput.data.color"
+            class="w-full"
+          />
           <div class="size-8 shrink-0 rounded-full" :style="{ backgroundColor: calendarInput.data.color }"></div>
         </div>
       </label>
       <label v-if="isCalDav" class="flex items-center pl-4">
         <div class="w-full max-w-2xs">{{ t('label.calendarUrl') }}</div>
-        <input
+        <text-input
           v-model="calendarInput.data.url"
+          name="url"
           type="url"
           class="w-full max-w-sm rounded-md"
         />
       </label>
       <label v-if="isCalDav" class="flex items-center pl-4">
         <div class="w-full max-w-2xs">{{ t('label.username') }}</div>
-        <input
+        <text-input
           v-model="calendarInput.data.user"
+          name="user"
           type="text"
           class="w-full max-w-sm rounded-md"
         />
       </label>
       <label v-if="isCalDav" class="flex items-center pl-4">
         <div class="w-full max-w-2xs">{{ t('label.password') }}</div>
-        <input
+        <text-input
           v-model="calendarInput.data.password"
+          name="password"
           type="password"
           class="w-full max-w-sm rounded-md"
         />
       </label>
       <div class="flex justify-between gap-4">
         <div class="flex">
-          <caution-button
+          <danger-button
             v-if="editMode"
-            :label="t('label.disconnect')"
-            class="btn-disconnect text-sm"
+            class="btn-disconnect"
             @click="() => disconnectCalendar(calendarInput.id)"
             :title="t('label.disconnect')"
-          />
+          >
+            {{ t('label.disconnect') }}
+          </danger-button>
         </div>
         <div class="flex gap-4 self-end">
-          <secondary-button
-            :label="t('label.cancel')"
-            class="btn-cancel text-sm !text-teal-500"
-            @click="resetInput"
-            :title="t('label.cancel')"
-          />
-          <primary-button
-            v-if="isCalDav || editMode"
-            :label="addMode ? t('label.connectCalendar') : t('label.saveChanges')"
-            class="btn-save text-sm"
-            @click="saveCalendar"
-            :title="t('label.save')"
-          />
+          <secondary-button class="btn-cancel" @click="resetInput" :title="t('label.cancel')">
+            {{ t('label.cancel') }}
+          </secondary-button>
+          <primary-button v-if="isCalDav || editMode" class="btn-save" @click="saveCalendar" :title="t('label.save')">
+            {{ addMode ? t('label.connectCalendar') : t('label.saveChanges') }}
+          </primary-button>
           <!-- Google Button -->
           <google-calendar-button
             v-if="isGoogle && addMode"

--- a/frontend/src/components/SettingsConnections.vue
+++ b/frontend/src/components/SettingsConnections.vue
@@ -5,10 +5,10 @@ import {
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import { storeToRefs } from 'pinia';
-import CautionButton from '@/elements/CautionButton.vue';
+import DangerButton from '@/tbpro/elements/DangerButton.vue';
 import ConfirmationModal from '@/components/ConfirmationModal.vue';
-import PrimaryButton from '@/elements/PrimaryButton.vue';
-import SecondaryButton from '@/elements/SecondaryButton.vue';
+import PrimaryButton from '@/tbpro/elements/PrimaryButton.vue';
+import SecondaryButton from '@/tbpro/elements/SecondaryButton.vue';
 import GenericModal from '@/components/GenericModal.vue';
 import CalDavProvider from '@/components/FTUE/CalDavProvider.vue';
 import {
@@ -158,29 +158,32 @@ const editProfile = async () => {
         </div>
         <div class="mx-auto mr-0" v-if="providers[provider] !== ExternalConnectionProviders.Fxa && providers[provider] !== ExternalConnectionProviders.accounts">
           <primary-button
-          v-if="!connection[0]"
-          :label="t('label.connect')"
-          class="btn-connect"
-          :data-testid="'connected-accounts-settings-' + t(provider) + '-connect-btn'"
-          @click="() => connectAccount(providers[provider])"
-          :title="t('label.connect')"
-        />
-        <caution-button
-          v-if="connection[0]"
-          :label="t('label.disconnect')"
-          class="btn-disconnect"
-          :data-testid="'connected-accounts-settings-' + t(provider) + '-disconnect-btn'"
-          @click="() => displayModal(providers[provider], connection[0].type_id)"
-          :title="t('label.disconnect')"
-        />
+            v-if="!connection[0]"
+            class="btn-connect"
+            :data-testid="'connected-accounts-settings-' + t(provider) + '-connect-btn'"
+            @click="() => connectAccount(providers[provider])"
+            :title="t('label.connect')"
+          >
+            {{ t('label.connect') }}
+          </primary-button>
+          <danger-button
+            v-if="connection[0]"
+            class="btn-disconnect"
+            :data-testid="'connected-accounts-settings-' + t(provider) + '-disconnect-btn'"
+            @click="() => displayModal(providers[provider], connection[0].type_id)"
+            :title="t('label.disconnect')"
+          >
+            {{ t('label.disconnect') }}
+          </danger-button>
         </div>
         <div class="mx-auto mr-0" v-else>
           <secondary-button
-            :label="t('label.editProfile')"
             class="btn-edit"
             @click="editProfile"
             :title="t('label.edit')"
-          />
+          >
+            {{ t('label.editProfile') }}
+          </secondary-button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/SettingsConnections.vue
+++ b/frontend/src/components/SettingsConnections.vue
@@ -22,7 +22,7 @@ import { createUserStore } from '@/stores/user-store';
 import { createExternalConnectionsStore } from '@/stores/external-connections-store';
 import { createCalendarStore } from '@/stores/calendar-store';
 
-import { Alert } from '@/models';
+import { Alert, ExternalConnection } from '@/models';
 
 // component constants
 const { t } = useI18n({ useScope: 'global' });
@@ -40,16 +40,14 @@ const isAccountsAuth = inject(isAccountsAuthKey);
  * Temp until we remove local fxa
  */
 const filteredConnections = computed(() => {
-  const newConnections = {};
+  const newConnections = {} as { [key: string]: ExternalConnection[] };
   const keys = Object.keys(connections.value);
    
   for (const connection of keys) {
     if (connection === 'fxa' && !isFxaAuth) {
-       
       continue;
     }
     if (connection === 'accounts' && !isAccountsAuth) {
-       
       continue;
     }
     newConnections[connection] = connections.value[connection];
@@ -156,7 +154,7 @@ const editProfile = async () => {
           <p v-if="connection[0]">{{ t('label.connectedAs', {name: connection[0].name}) }}</p>
           <p v-if="!connection[0]">{{ t('label.notConnected') }}</p>
         </div>
-        <div class="mx-auto mr-0" v-if="providers[provider] !== ExternalConnectionProviders.Fxa && providers[provider] !== ExternalConnectionProviders.accounts">
+        <div class="mx-auto mr-0" v-if="providers[provider] !== ExternalConnectionProviders.Fxa && providers[provider] !== ExternalConnectionProviders.Accounts">
           <primary-button
             v-if="!connection[0]"
             class="btn-connect"

--- a/frontend/src/components/SettingsGeneral.vue
+++ b/frontend/src/components/SettingsGeneral.vue
@@ -26,7 +26,7 @@ const colourSchemeOptions = Object.values(ColourSchemes).map((c) => ({
 const availableStartOfTheWeekOptions = computed(
   () => isoWeekdays.filter((day) => [7,1].includes(day.iso)).map((e) => ({
     label: e.long,
-    value: e.iso,
+    value: e.iso.toString(),
   }))
 );
 

--- a/frontend/src/components/SettingsGeneral.vue
+++ b/frontend/src/components/SettingsGeneral.vue
@@ -79,11 +79,6 @@ watch(
     }
   },
 );
-
-// @ts-expect-error ignore type err
-// See https://github.com/microsoft/TypeScript/issues/49231
-const timezones = Intl.supportedValuesOf('timeZone');
-
 </script>
 
 <template>

--- a/frontend/src/components/SettingsGeneral.vue
+++ b/frontend/src/components/SettingsGeneral.vue
@@ -13,12 +13,12 @@ const user = createUserStore(call);
 const isoWeekdays = inject(isoWeekdaysKey);
 
 const localeOptions = availableLocales.map((l) => ({
-  label: l.toUpperCase() + ' — ' + t('locales.' + l),
+  label: `${l.toUpperCase()} — ${t(`locales.${l}`)}`,
   value: l,
 }));
 
 const colourSchemeOptions = Object.values(ColourSchemes).map((c) => ({
-  label: t('label.' + c),
+  label: t(`label.${c}`),
   value: c,
 }));
 

--- a/frontend/src/components/SettingsGeneral.vue
+++ b/frontend/src/components/SettingsGeneral.vue
@@ -4,14 +4,38 @@ import { inject, watch, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { createUserStore } from '@/stores/user-store';
 import { callKey, isoWeekdaysKey } from '@/keys';
+import SelectInput from '@/tbpro/elements/SelectInput.vue';
 
 // component constants
 const { t, locale, availableLocales } = useI18n({ useScope: 'global' });
 const call = inject(callKey);
 const user = createUserStore(call);
 const isoWeekdays = inject(isoWeekdaysKey);
+
+const localeOptions = availableLocales.map((l) => ({
+  label: l.toUpperCase() + ' — ' + t('locales.' + l),
+  value: l,
+}));
+
+const colourSchemeOptions = Object.values(ColourSchemes).map((c) => ({
+  label: t('label.' + c),
+  value: c,
+}));
+
 // As long as we use Qalendar, we can only support Sunday and Monday as start of week
-const availableStartOfTheWeekOptions = computed(() => isoWeekdays.filter((day) => [7,1].includes(day.iso)));
+const availableStartOfTheWeekOptions = computed(
+  () => isoWeekdays.filter((day) => [7,1].includes(day.iso)).map((e) => ({
+    label: e.long,
+    value: e.iso,
+  }))
+);
+
+// @ts-expect-error ignore type err
+// See https://github.com/microsoft/TypeScript/issues/49231
+const timezoneOptions = Intl.supportedValuesOf('timeZone').map((timezone: string) => ({
+  label: timezone.replaceAll('_', ' '),
+  value: timezone,
+}));
 
 // handle ui languages
 watch(locale, (newValue: string) => {
@@ -71,22 +95,26 @@ const timezones = Intl.supportedValuesOf('timeZone');
       <div class="text-lg">{{ t('label.language') }}</div>
       <label class="mt-4 flex items-center pl-4">
         <div class="w-full max-w-2xs">{{ t('label.language') }}</div>
-        <select v-model="locale" class="w-full max-w-sm rounded-md" data-testid="settings-general-locale-select">
-          <option v-for="l in availableLocales" :key="l" :value="l">
-            {{ l.toUpperCase() + ' &mdash; ' + t('locales.' + l) }}
-          </option>
-        </select>
+        <select-input
+          name="timezone"
+          :options="localeOptions"
+          v-model="locale"
+          class="w-full max-w-sm"
+          data-testid="settings-general-locale-select"
+        />
       </label>
     </div>
     <div class="mt-6 pl-6">
       <div class="text-lg">{{ t('label.appearance') }}</div>
       <label class="mt-4 flex items-center pl-4">
         <div class="w-full max-w-2xs">{{ t('label.theme') }}</div>
-        <select v-model="user.data.settings.colourScheme" class="w-full max-w-sm rounded-md" data-testid="settings-general-theme-select">
-          <option v-for="value in Object.values(ColourSchemes)" :key="value" :value="value">
-            {{ t('label.' + value) }}
-          </option>
-        </select>
+        <select-input
+          name="timezone"
+          :options="colourSchemeOptions"
+          v-model="user.data.settings.colourScheme"
+          class="w-full max-w-sm"
+          data-testid="settings-general-theme-select"
+        />
       </label>
       <!-- <label class="pl-4 mt-4 flex items-center">
         <div class="w-full max-w-2xs">{{ t('label.defaultFont') }}</div>
@@ -103,15 +131,13 @@ const timezones = Intl.supportedValuesOf('timeZone');
       <div class="text-lg">{{ t('label.startOfTheWeek') }}</div>
       <label class="mt-4 flex items-center pl-4">
         <div class="w-full max-w-2xs">{{ t('label.startOfTheWeek') }}</div>
-        <select
+        <select-input
+          name="timezone"
+          :options="availableStartOfTheWeekOptions"
           v-model="user.data.settings.startOfWeek"
-          class="w-full max-w-sm rounded-md"
+          class="w-full max-w-sm"
           data-testid="settings-general-start-of-week-select"
-        >
-          <option v-for="day in availableStartOfTheWeekOptions" :key="day.iso" :value="day.iso">
-            {{ day.long }}
-          </option>
-        </select>
+        />
       </label>
     </div>
     <div class="mt-6 inline-grid grid-cols-2 gap-x-16 gap-y-8 pl-6">
@@ -138,15 +164,13 @@ const timezones = Intl.supportedValuesOf('timeZone');
       <div class="text-lg">{{ t('label.timeZone') }}</div>
       <label class="mt-4 flex items-center pl-4">
         <div class="w-full max-w-2xs">{{ t('label.primaryTimeZone') }}</div>
-        <select
+        <select-input
+          name="timezone"
+          :options="timezoneOptions"
           v-model="user.data.settings.timezone"
-          class="w-full max-w-sm rounded-md"
+          class="w-full max-w-sm"
           data-testid="settings-general-timezone-select"
-        >
-          <option v-for="tz in timezones" :key="tz" :value="tz">
-            {{ tz }}
-          </option>
-        </select>
+        />
       </label>
       <!-- <label class="pl-4 mt-6 flex items-center">
         <div class="w-full max-w-2xs">{{ t('label.showSecondaryTimeZone') }}</div>

--- a/frontend/src/definitions.ts
+++ b/frontend/src/definitions.ts
@@ -175,6 +175,7 @@ export enum ExternalConnectionProviders {
   Google = 2,
   Zoom = 3,
   Caldav = 4,
+  Accounts = 5,
 }
 
 /**

--- a/frontend/src/elements/GoogleCalendarButton.vue
+++ b/frontend/src/elements/GoogleCalendarButton.vue
@@ -9,7 +9,7 @@ defineProps<Props>();
 <template>
   <button
     class="
-      relative flex h-10 items-center justify-center gap-4 whitespace-nowrap rounded-full
+      relative flex h-10 items-center justify-center gap-4 whitespace-nowrap rounded
       border border-gray-500 bg-white px-4 font-roboto text-base text-gray-600
       transition-all ease-in-out hover:scale-102 hover:shadow-md
       active:scale-98 disabled:scale-100 disabled:opacity-50 disabled:shadow-none dark:bg-gray-800 dark:text-gray-400

--- a/frontend/src/keys.ts
+++ b/frontend/src/keys.ts
@@ -23,6 +23,7 @@ export const isoFirstDayOfWeekKey = Symbol('isoFirstDayOfWeek') as InjectionKey<
 // Provide urls for API and booking
 export const apiUrlKey = Symbol('apiUrl') as InjectionKey<string>;
 export const bookingUrlKey = Symbol('bookingUrl') as InjectionKey<string>;
+export const shortUrlKey = Symbol('shortUrl') as InjectionKey<string>;
 
 // Provide environment and authentication keys
 export const isPasswordAuthKey = Symbol('isPasswordAuth') as InjectionKey<boolean>;

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -71,6 +71,7 @@
       "setupProfile": "Dein Profil erstellen",
       "setupSchedule": "Terminverfügbarkeit einstellen"
     },
+    "usernameHelp": "So wird Dein Link aussehen",
     "videoConnectionRequired": "Zoom-Konto verbinden und einen benutzerdefinierten Meeting-Link angeben um fortzufahren.",
     "videoMeetingLink": "Videokonferenz-Link"
   },

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -313,7 +313,7 @@
     "scheduleDetails": "Zeitplan Details",
     "scheduleSettings": {
       "availabilitySubHeading": "Lege deine Verfügbarkeit fest",
-      "bookingSettingsSubHeading": "Kurzlink bearbeiten und Sonstiges",
+      "bookingSettingsSubHeading": "Buchungsbestätigung und Sonstiges",
       "meetingDetailsSubHeading": "Videos und/oder Notizen den Events hinzufügen",
       "schedulingDetailsSubHeading": "Buchungsintervalle und Dauer festlegen"
     },

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -320,6 +320,7 @@
     },
     "search": "Suche",
     "searchAppointments": "Termine durchsuchen",
+    "searchForCalendars": "Nach Kalendern suchen",
     "secondaryTimeZone": "Sekundäre Zeitzone",
     "selectCalendar": "Kalender auswählen",
     "send": "Senden",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -355,7 +355,7 @@
     "topic": "Thema",
     "unset": "Nicht gesetzt",
     "unused": "Ungenutzt",
-    "updateUsername": "Benutzername aktualisieren",
+    "updateLink": "Link aktualisieren",
     "used": "Benutzt",
     "username": "Benutzername",
     "userProfile": "Benutzerprofil",
@@ -537,7 +537,7 @@
       "link": "Kontoeinstellungen",
       "text": "Der Nutzername kann unter {link} angepasst werden. "
     },
-    "updateUsernameNotice": "Ein Ändern des Benutzernamens aktualisiert auch deinen Link. Alle alten Links werden dann nicht mehr funktionieren.",
+    "updateLinkNotice": "Ein Ändern des Benutzernamens oder des Teillinks aktualisiert deinen Link. Alle alten Links werden dann nicht mehr funktionieren.",
     "videoLinkNotice": "Der Videolink verwendet denselben Link für alle Veranstaltungen, die im Rahmen deines Zeitplans erstellt werden. Bei der Erstellung von Zoom-Meetings wird für jede erstellte Veranstaltung ein neuer Zoom-Link erstellt.",
     "yourQuickLinkIs": "Dein Kurzlink ist:\n{url}"
   },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -355,7 +355,7 @@
     "topic": "Topic",
     "unset": "Unset",
     "unused": "Unused",
-    "updateUsername": "Update username",
+    "updateLink": "Update link",
     "used": "Used",
     "username": "Username",
     "userProfile": "User profile",
@@ -537,7 +537,7 @@
       "link": "Account settings",
       "text": "To update your username, go to {link}. "
     },
-    "updateUsernameNotice": "Changing your username will also change your link. Your old link will no longer work.",
+    "updateLinkNotice": "Changing your username or slug will change your link. Your old link will no longer work.",
     "videoLinkNotice": "Video link will use the same link for all events created in this general availability. Generating zoom meetings will create a new zoom link for each event created.",
     "yourQuickLinkIs": "Your quick link is:\n{url}"
   },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -71,6 +71,7 @@
       "setupProfile": "Create your profile",
       "setupSchedule": "Set up your appointment availability"
     },
+    "usernameHelp": "This will become your quick link",
     "videoConnectionRequired": "Connect your zoom account, enter a custom meeting link to continue.",
     "videoMeetingLink": "Video meeting link"
   },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -289,6 +289,7 @@
     "online": "Online",
     "open": "Open",
     "openMyPage": "Open my page",
+    "optionalPasscode": "Optional passcode",
     "password": "Password",
     "past": "Past",
     "pending": "Pending",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -320,6 +320,7 @@
     },
     "search": "Search",
     "searchAppointments": "Search bookings",
+    "searchForCalendars": "Search for calendars",
     "secondaryTimeZone": "Secondary time zone",
     "selectCalendar": "Select calendar",
     "send": "Send",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -313,7 +313,7 @@
     "scheduleDetails": "Scheduling details",
     "scheduleSettings": {
       "availabilitySubHeading": "Set your availability days and time",
-      "bookingSettingsSubHeading": "Edit your quick link and more",
+      "bookingSettingsSubHeading": "Handle booking confirmation and more",
       "meetingDetailsSubHeading": "Add video and/or notes to events",
       "schedulingDetailsSubHeading": "Set booking intervals and duration"
     },

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,7 +1,7 @@
 // init app
 import App from '@/App.vue';
 import { createApp } from 'vue';
-import { apiUrlKey, bookingUrlKey } from '@/keys';
+import { apiUrlKey, bookingUrlKey, shortUrlKey } from '@/keys';
 import { defaultLocale } from '@/utils';
 
 // pinia state management
@@ -72,6 +72,7 @@ const port = import.meta.env.VITE_API_PORT !== undefined ? `:${import.meta.env.V
 const apiUrl = `${protocol}://${import.meta.env.VITE_API_URL}${port}`;
 app.provide(apiUrlKey, apiUrl);
 app.provide(bookingUrlKey, `${protocol}://${import.meta.env.VITE_BASE_URL}/appointments/all/`);
+app.provide(shortUrlKey, `${protocol}://${import.meta.env.VITE_SHORT_BASE_URL}`);
 
 app.use(i18ninstance);
 useDayJS(app, defaultLocale());

--- a/frontend/src/models.ts
+++ b/frontend/src/models.ts
@@ -197,7 +197,7 @@ export type Schedule = {
   end_time: string;
   earliest_booking: number;
   farthest_booking: number;
-  weekdays: number[];
+  weekdays: string[];
   slot_duration: number;
   meeting_link_provider: string;
   id?: number;
@@ -226,7 +226,8 @@ export type User = {
   signedUrl: string;
   avatarUrl: string;
   accessToken: string;
-  scheduleLinks: string[];
+  userLink: string;
+  scheduleSlugs: object;
   isSetup: boolean,
   uniqueHash: string;
 };
@@ -266,7 +267,8 @@ export type Subscriber = {
   avatar_url?: string;
   is_setup?: boolean;
   unique_hash?: string;
-  schedule_links?: string[];
+  user_link?: string;
+  schedule_slugs?: object;
   secondary_email?: string;
   invite?: Invite;
   time_created?: string;
@@ -420,7 +422,7 @@ export type TimeFormatted = Time<string>;
 
 export type SelectOption = {
   label: string;
-  value: string;
+  value: string|int;
 };
 
 export type Coloring = {

--- a/frontend/src/models.ts
+++ b/frontend/src/models.ts
@@ -420,7 +420,7 @@ export type TimeFormatted = Time<string>;
 
 export type SelectOption = {
   label: string;
-  value: number|string;
+  value: string;
 };
 
 export type Coloring = {

--- a/frontend/src/models.ts
+++ b/frontend/src/models.ts
@@ -420,7 +420,7 @@ export type TimeFormatted = Time<string>;
 
 export type SelectOption = {
   label: string;
-  value: number;
+  value: number|string;
 };
 
 export type Coloring = {

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -74,7 +74,7 @@ const routes: RouteRecordRaw[] = [
     },
   },
   {
-    path: '/user/:username/:signatureOrSlug',
+    path: '/user/:username/:signatureOrSlug?',
     name: 'availability',
     component: BookingView,
     meta: {

--- a/frontend/src/stores/schedule-store.ts
+++ b/frontend/src/stores/schedule-store.ts
@@ -190,6 +190,37 @@ export const useScheduleStore = defineStore('schedules', () => {
   };
 
   /**
+   * Update the slug of the first schedule
+   * 
+   * @param slug new slug
+   */
+  const updateFirstSlug = async (slug: string) => {
+    const id = firstSchedule.value.id;
+    const updateData = {
+      ...firstSchedule.value,
+      slug: slug,
+    };
+    // save schedule data
+    const { data, error }: ScheduleResponse = await call.value(`schedule/${id}`).put(updateData).json();
+
+    if (error.value) {
+      return {
+        error: true,
+        message: handleErrorResponse(data as Ref<Exception>),
+      } as Error;
+    }
+
+    // Update the schedule
+    await fetch(true);
+
+    if (usePosthog) {
+      posthog.capture(MetricEvents.ScheduleUpdated);
+    }
+
+    return data;
+  };
+
+  /**
    * Converts a time (startTime or endTime) to a timezone that the backend expects
    * @param {string} time
    */
@@ -230,6 +261,7 @@ export const useScheduleStore = defineStore('schedules', () => {
     $reset,
     createSchedule,
     updateSchedule,
+    updateFirstSlug,
     timeToBackendTime,
     timeToFrontendTime,
   };

--- a/frontend/src/stores/user-store.ts
+++ b/frontend/src/stores/user-store.ts
@@ -107,7 +107,7 @@ export const useUserStore = defineStore('user', () => {
    * Return the last unique URL part of the users link
    */
   const mySlug = computed((): string => {
-    const link = myLink?.value?.replace(/\/+$/, '') ?? '';
+    const link = myLink.value?.replace(/\/+$/, '') ?? '';
     return link.slice(link.indexOf(data.value.username) + data.value.username.length + 1);
   });
 

--- a/frontend/src/stores/user-store.ts
+++ b/frontend/src/stores/user-store.ts
@@ -65,7 +65,6 @@ export const useUserStore = defineStore('user', () => {
     // We have a settings object? See if all keys exists and update only the missing ones
     
     Object.keys(defaultSettings).forEach(key => {
-      console.log(key);
       data.value.settings[key] = data.value.settings[key] ?? defaultSettings[key];
     });
   }

--- a/frontend/src/stores/user-store.ts
+++ b/frontend/src/stores/user-store.ts
@@ -107,8 +107,8 @@ export const useUserStore = defineStore('user', () => {
    * Return the last unique URL part of the users link
    */
   const mySlug = computed((): string => {
-    const link = myLink?.value?.replace(/\/+$/, '');
-    return link?.slice(link.lastIndexOf('/') + 1);
+    const link = myLink?.value?.replace(/\/+$/, '') ?? '';
+    return link.slice(link.indexOf(data.value.username) + data.value.username.length + 1);
   });
 
   /**

--- a/frontend/src/stores/user-store.ts
+++ b/frontend/src/stores/user-store.ts
@@ -28,7 +28,8 @@ const initialUserObject = {
   signedUrl: null,
   avatarUrl: null,
   accessToken: null,
-  scheduleLinks: [],
+  userLink: null,
+  scheduleSlugs: {},
   isSetup: false,
   uniqueHash: null,
 } as User;
@@ -91,24 +92,42 @@ export const useUserStore = defineStore('user', () => {
   };
 
   /**
-   * Return the first schedule link or their signed url
+   * Return the first slug key, or null if they don't have one.
    */
-  const myLink = computed((): string => {
-    const scheduleLinks = data?.value?.scheduleLinks ?? [];
-    if (scheduleLinks.length > 0) {
-      return scheduleLinks[0];
+  const mySlug = computed((): string|null => {
+    const slugs = data?.value?.scheduleSlugs ?? {};
+    const slugKeys = Object.keys(slugs);
+    if (slugKeys.length == 0) {
+      return null;
     }
 
-    // TODO: Signed urls are deprecated here!
-    return data.value.signedUrl;
+    return slugs[slugKeys[0]];
   });
 
   /**
-   * Return the last unique URL part of the users link
+   * Returns their bare userlink without any slugs
    */
-  const mySlug = computed((): string => {
-    const link = myLink.value?.replace(/\/+$/, '') ?? '';
-    return link.slice(link.indexOf(data.value.username) + data.value.username.length + 1);
+  const myBaseLink = computed((): string => {
+    const userLink = data?.value?.userLink;
+    if (userLink) {
+      return userLink;
+    }
+
+    return null;
+  });
+
+  /**
+   * Return the first schedule link or their signed url
+   */
+  const myLink = computed((): string => {
+    const userLink = data?.value?.userLink;
+    const slug = mySlug?.value;
+
+    if (userLink) {
+      return slug ? `${userLink}${slug}/` : userLink;
+    }
+
+    return null;
   });
 
   /**
@@ -159,7 +178,8 @@ export const useUserStore = defineStore('user', () => {
       },
       avatarUrl: subscriber.avatar_url,
       isSetup: subscriber.is_setup,
-      scheduleLinks: subscriber.schedule_links,
+      userLink: subscriber.user_link,
+      scheduleSlugs: subscriber.schedule_slugs,
       uniqueHash: subscriber.unique_hash,
     };
   };
@@ -308,6 +328,7 @@ export const useUserStore = defineStore('user', () => {
     changeSignedUrl,
     login,
     logout,
+    myBaseLink,
     myLink,
     mySlug,
     myColourScheme,

--- a/frontend/src/tbpro/elements/BaseButton.vue
+++ b/frontend/src/tbpro/elements/BaseButton.vue
@@ -82,6 +82,23 @@ button:hover > .tooltip,
   }
 }
 
+.danger {
+  background-color: var(--colour-danger-default);
+  @mixin faded-border var(--colour-danger-hover);
+  color: var(--colour-neutral-base);
+
+  &:hover:enabled {
+    background-color: var(--colour-danger-hover);
+    border-color: var(--colour-success-pressed);
+  }
+
+  &:active:enabled {
+    background-color: var(--colour-danger-pressed);
+    border-color: var(--colour-danger-pressed);
+    box-shadow: none;
+  }
+}
+
 .link {
   background-color: transparent;
   color: var(--colour-service-primary);
@@ -104,6 +121,7 @@ button {
 
   justify-content: center;
   align-items: center;
+  gap: .75rem;
 
   border-radius: var(--border-radius);
   @mixin faded-border var(--colour-btn-border);
@@ -148,7 +166,7 @@ button {
   align-items: center;
   height: 100%;
 
-  padding-left: 1.5rem;
+  padding-left: .75rem;
   margin-right: -0.75rem;
 }
 

--- a/frontend/src/tbpro/elements/BubbleSelect.vue
+++ b/frontend/src/tbpro/elements/BubbleSelect.vue
@@ -13,7 +13,7 @@ withDefaults(defineProps<Props>(), {
   disabled: false,
 });
 
-const model = defineModel<number[]>({ default: [] });
+const model = defineModel<(string | number)[]>({ default: [] });
 
 /**
  * Adds or removes the option value from the model.

--- a/frontend/src/tbpro/elements/DangerButton.vue
+++ b/frontend/src/tbpro/elements/DangerButton.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import BaseButton from '@/tbpro/elements/BaseButton.vue';
+</script>
+
+<template>
+  <base-button type="danger">
+    <template v-for="(_, name) in $slots" v-slot:[name]="slotData">
+      <slot :name="name" v-bind="slotData" />
+    </template>
+  </base-button>
+</template>

--- a/frontend/src/tbpro/elements/SelectInput.vue
+++ b/frontend/src/tbpro/elements/SelectInput.vue
@@ -75,7 +75,6 @@ const onInvalid = (evt: HTMLInputElementEvent) => {
   color: var(--colour-ti-critical);
 
   width: 100%;
-  min-height: 0.9375rem;
   font-size: 0.625rem;
   line-height: 0.9375rem;
 }

--- a/frontend/src/tbpro/elements/SelectInput.vue
+++ b/frontend/src/tbpro/elements/SelectInput.vue
@@ -111,7 +111,7 @@ const onInvalid = (evt: HTMLInputElementEvent) => {
 }
 .dark {
   .tbpro-select {
-    background-color: var(--colour-neutral-lower);
+    background-color: var(--colour-neutral-base);
   }
 }
 </style>

--- a/frontend/src/tbpro/elements/TextInput.vue
+++ b/frontend/src/tbpro/elements/TextInput.vue
@@ -29,7 +29,8 @@ interface Props {
   error?: string;
   type?: string;
   placeholder?: string;
-  prefix?: string; // A prefix shows up at the start of the input field and moves the actual input to the right.
+  prefix?: string; // A prefix shows up inside the input field and moves the actual editable area to the right.
+  outerPrefix?: string; // A prefix shows up outside the input field and moves the whole input to the right.
   required?: boolean;
   disabled?: boolean;
   smallText?: boolean;
@@ -78,23 +79,26 @@ const onChange = () => {
       <span v-if="required && $slots.default && model?.length === 0" class="required">*</span>
     </span>
     <span class="tbpro-input" :class="{'small-text': props.smallText}" >
-      <span v-if="prefix" ref="inputPrefix" class="tbpro-input-prefix">{{ prefix }}</span>
-      <input
-        class="tbpro-input-element"
-        v-model="model"
-        :class="{ 'dirty': isDirty }"
-        :type="type"
-        :id="name"
-        :name="name"
-        :disabled="disabled"
-        :placeholder="placeholder"
-        :required="required"
-        :maxLength="maxLength"
-        @invalid.prevent="onInvalid"
-        @change="onChange"
-        ref="inputRef"
-        :style="{ paddingLeft: inputPaddingLeft }"
-      />
+      <span v-if="outerPrefix" class="tbpro-input-outer-prefix">{{ outerPrefix }}</span>
+      <span class="tbpro-input-wrapper">
+        <span v-if="prefix" ref="inputPrefix" class="tbpro-input-prefix">{{ prefix }}</span>
+        <input
+          class="tbpro-input-element"
+          v-model="model"
+          :class="{ 'dirty': isDirty }"
+          :type="type"
+          :id="name"
+          :name="name"
+          :disabled="disabled"
+          :placeholder="placeholder"
+          :required="required"
+          :maxLength="maxLength"
+          @invalid.prevent="onInvalid"
+          @change="onChange"
+          ref="inputRef"
+          :style="{ paddingLeft: inputPaddingLeft }"
+        />
+      </span>
     </span>
     <span v-if="isInvalid" class="help-label invalid">
       {{ validationMessage }}
@@ -150,63 +154,73 @@ const onChange = () => {
 }
 
 .tbpro-input {
-  display: inline-block;
-  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
   width: 100%;
 
-  .tbpro-input-prefix {
-    position: absolute;
-    top: 0.70rem;
-    left: 12px;
-    font-size: var(--txt-input);
-    line-height: var(--line-height-input);
-    color: var(--colour-ti-muted);
-    user-select: none;
-    text-overflow: '.../';
-    overflow: hidden;
-    max-width: 40%;
-    text-wrap: nowrap;
-    z-index: 1;
+  .tbpro-input-outer-prefix {
+    white-space: nowrap;
   }
 
-  .tbpro-input-element {
-    --colour-btn-border: var(--colour-neutral-border);
+  .tbpro-input-wrapper {
+    position: relative;
     width: 100%;
-    transition-property: none;
-    font-size: var(--txt-input);
-
-    background-color: var(--colour-neutral-base);
-    border-radius: var(--border-radius);
-    @mixin faded-border var(--colour-btn-border);
-
-    &:hover:enabled {
-      --colour-btn-border: var(--colour-neutral-border-intense);
-    }
-
-    &:active:enabled {
-      --colour-btn-border: var(--colour-neutral-border-intense);
-    }
-
-    &:focus:enabled {
-      border-radius: 0.125rem;
-    }
-
-    &.dirty:invalid {
-      --colour-btn-border: var(--colour-ti-critical);
-    }
-
-    &:disabled {
-      filter: grayscale(50%);
-      cursor: not-allowed;
-    }
-
-    &::placeholder {
+  
+    .tbpro-input-prefix {
+      position: absolute;
+      top: 0.70rem;
+      left: 12px;
+      font-size: var(--txt-input);
+      line-height: var(--line-height-input);
       color: var(--colour-ti-muted);
+      user-select: none;
+      text-overflow: '.../';
+      overflow: hidden;
+      max-width: 40%;
+      text-wrap: nowrap;
+      z-index: 1;
     }
-
-    &[type="time"]::-webkit-calendar-picker-indicator {
-      margin-right: -0.5rem;
-      background: none;
+  
+    .tbpro-input-element {
+      --colour-btn-border: var(--colour-neutral-border);
+      width: 100%;
+      transition-property: none;
+      font-size: var(--txt-input);
+  
+      background-color: var(--colour-neutral-base);
+      border-radius: var(--border-radius);
+      @mixin faded-border var(--colour-btn-border);
+  
+      &:hover:enabled {
+        --colour-btn-border: var(--colour-neutral-border-intense);
+      }
+  
+      &:active:enabled {
+        --colour-btn-border: var(--colour-neutral-border-intense);
+      }
+  
+      &:focus:enabled {
+        border-radius: 0.125rem;
+      }
+  
+      &.dirty:invalid {
+        --colour-btn-border: var(--colour-ti-critical);
+      }
+  
+      &:disabled {
+        filter: grayscale(50%);
+        cursor: not-allowed;
+      }
+  
+      &::placeholder {
+        color: var(--colour-ti-muted);
+      }
+  
+      &[type="time"]::-webkit-calendar-picker-indicator {
+        margin-right: -0.5rem;
+        background: none;
+      }
     }
   }
 }

--- a/frontend/src/tbpro/elements/TextInput.vue
+++ b/frontend/src/tbpro/elements/TextInput.vue
@@ -105,9 +105,6 @@ const onChange = () => {
     <span v-else-if="help" class="help-label">
       {{ help }}
     </span>
-    <span v-else class="help-label">
-      <!-- Empty space -->
-    </span>
   </label>
 </template>
 
@@ -139,7 +136,6 @@ const onChange = () => {
   color: var(--colour-ti-base);
 
   width: 100%;
-  min-height: 0.9375rem;
   font-size: 0.625rem;
   line-height: 0.9375rem;
   padding: 0.1875rem;

--- a/frontend/src/tbpro/elements/TextInput.vue
+++ b/frontend/src/tbpro/elements/TextInput.vue
@@ -75,7 +75,7 @@ const onChange = () => {
   <label class="wrapper" :for="name">
     <span class="label">
       <slot/>
-      <span v-if="required && model?.length === 0" class="required">*</span>
+      <span v-if="required && $slots.default && model?.length === 0" class="required">*</span>
     </span>
     <span class="tbpro-input" :class="{'small-text': props.smallText}" >
       <span v-if="prefix" ref="inputPrefix" class="tbpro-input-prefix">{{ prefix }}</span>

--- a/frontend/src/views/admin/InviteCodePanelView.vue
+++ b/frontend/src/views/admin/InviteCodePanelView.vue
@@ -34,6 +34,7 @@ const pageNotification = ref<Alert>(null);
 const codeFilter = ref<string>(null);
 const inviteList = computed(() => {
   if (codeFilter.value) {
+    /** @ts-expect-error escape has no baseline support yet */
     return invites.value.filter((invite) => invite.code.match(new RegExp(RegExp.escape(codeFilter.value), 'gi')));
   }
   return invites.value;

--- a/frontend/src/views/admin/SubscriberPanelView.vue
+++ b/frontend/src/views/admin/SubscriberPanelView.vue
@@ -38,6 +38,7 @@ const hardDeleteModalContext = ref<Subscriber>(null);
 const emailFilter = ref<string>(null);
 const subscriberList = computed(() => {
   if (emailFilter.value) {
+    /** @ts-expect-error escape has no baseline support yet */
     return subscribers.value.filter((sub) => sub.email.match(new RegExp(RegExp.escape(emailFilter.value), 'gi')));
   }
   return subscribers.value;

--- a/frontend/src/views/admin/WaitingListPanelView.vue
+++ b/frontend/src/views/admin/WaitingListPanelView.vue
@@ -42,6 +42,7 @@ const dataTableRef = ref(null);
 const emailFilter = ref<string>(null);
 const waitingListUsersList = computed(() => {
   if (emailFilter.value) {
+    /** @ts-expect-error escape has no baseline support yet */
     return waitingListUsers.value.filter((wl) => wl.email.match(new RegExp(RegExp.escape(emailFilter.value), 'gi')));
   }
   return waitingListUsers.value;


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

Sorry, this change turned out to be bigger than expected 😅  Here is what I changed:

- Appointment now allows to configure an empty slug for the custom user URL
- The username can be set as part of the URL in FTUE
- The slug can be changed (already possible) and removed (new) in the account settings
- @malini @solangevalverde I reused our existing input component that allows for a prefix. This isn't exactly like shown in the wireframes, so let me know if you want to change that still
- I also converted all buttons, text inputs and selects on the settings page to the new tbpro components

![appointment_settings_slug](https://github.com/user-attachments/assets/28de3d78-cea1-4983-af0a-6f39b6d0e0f5)
![appointment_ftue_username](https://github.com/user-attachments/assets/17c444a9-3fed-4ea1-a084-1aaaddb496ec)

@laurelterlesky

I also added a danger variant for our base button component:

![image](https://github.com/user-attachments/assets/3f57efb3-5e92-4b4f-8ee3-d0384df78227)


## Applicable Issues

Closes #879 
