### PR TITLE
Don't pass our scopes to the zoom auth url (Fixes #996)

### DIFF
--- a/backend/src/appointment/controller/apis/zoom_client.py
+++ b/backend/src/appointment/controller/apis/zoom_client.py
@@ -82,7 +82,10 @@ class ZoomClient:
         pass
 
     def get_redirect_url(self, state):
+        # Ensure we pass "None" to scope, as zoom doesn't accept scopes here...for some reason?
+        self.client.scope = None
         url, state = self.client.authorization_url(self.OAUTH_AUTHORIZATION_URL, state=state)
+        self.client.scope = self.scopes
 
         return url, state
 


### PR DESCRIPTION
Fixes #996 

I'm not sure why they hate having scopes in the url, since our third-party oauth library does it for us. So it's within spec, but at least it doesn't seem to affect our meeting link creation abilities. 

Tested and working fine locally.