### PR TITLE
Only use one set of scopes, and catch any scope errors that may occur.

### DIFF
--- a/backend/src/appointment/controller/apis/zoom_client.py
+++ b/backend/src/appointment/controller/apis/zoom_client.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import time
 
 import sentry_sdk

--- a/backend/src/appointment/exceptions/zoom_api.py
+++ b/backend/src/appointment/exceptions/zoom_api.py
@@ -1,0 +1,4 @@
+class ZoomScopeChanged(Exception):
+    """Raise when Zoom API lets us know the scope has changed."""
+
+    pass

--- a/backend/src/appointment/l10n/de/main.ftl
+++ b/backend/src/appointment/l10n/de/main.ftl
@@ -79,6 +79,7 @@ oauth-error = Es ist ein Fehler bei der Authentifizierung aufgetreten. Bitte ern
 
 zoom-not-connected = Es wird ein Zoom-Konto benötigt, um einen Meeting-Link zu erstellen.
 zoom-connect-to-continue = Bitte ein Zoom-Konto verbinden, einen benutzerdefinierten Meeting-Link eingeben oder auf "Videoverbindung überspringen" klicken, um fortzufahren.
+zoom-unknown-error = Es gab einen unerwarteten Fehler beim Verbinden des Zoom-Kontos. Bitte später noch einmal versuchen.
 
 ## Google Exceptions
 

--- a/backend/src/appointment/l10n/en/main.ftl
+++ b/backend/src/appointment/l10n/en/main.ftl
@@ -79,6 +79,7 @@ oauth-error = There was an error with the authentication flow. Please try again.
 
 zoom-not-connected = You need a connected Zoom account in order to create a meeting link.
 zoom-connect-to-continue = You must connect a Zoom account, enter a custom meeting link, or click "Skip Connect Video" to continue.
+zoom-unknown-error = There was an unexpected error while connecting your Zoom account. Please try again later.
 
 ## Google Exceptions
 


### PR DESCRIPTION
Fixes #996 for realies.

Basically we're experiencing a scope change error: https://thunderbird.sentry.io/issues/6561374703/?project=4505428124827648&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=0

Where we seem to have initialized our app with the old scopes instead of the new scopes...which doesn't make sense because we set an env var to use new scopes. Since everything should be using new scopes, let's just use those and delete the old ones.

This also catches the scope change error and sends the user back an error message.