### PR TITLE
Sync up tofu's mysql version with rds

### DIFF
--- a/tofu/modules/data-store/database/main.tf
+++ b/tofu/modules/data-store/database/main.tf
@@ -18,7 +18,7 @@ module "db" {
   identifier = var.name_prefix
 
   engine            = "mysql"
-  engine_version    = "8.0.35"
+  engine_version    = "8.0.40"
   instance_class    = "db.t3.medium"
   allocated_storage = 20
 


### PR DESCRIPTION
Ah the real cause of the failed deployments. It's weird how the error in tofu/terraform is reverse. But RDS is already running on *.40, so we should specify that. 