### PR TITLE
Update E2E test to match recent share link changes

### DIFF
--- a/frontend/src/components/SettingsGeneral.vue
+++ b/frontend/src/components/SettingsGeneral.vue
@@ -91,7 +91,7 @@ watch(
       <label class="mt-4 flex items-center pl-4">
         <div class="w-full max-w-2xs">{{ t('label.language') }}</div>
         <select-input
-          name="timezone"
+          name="locale"
           :options="localeOptions"
           v-model="locale"
           class="w-full max-w-sm"
@@ -104,7 +104,7 @@ watch(
       <label class="mt-4 flex items-center pl-4">
         <div class="w-full max-w-2xs">{{ t('label.theme') }}</div>
         <select-input
-          name="timezone"
+          name="theme"
           :options="colourSchemeOptions"
           v-model="user.data.settings.colourScheme"
           class="w-full max-w-sm"
@@ -127,7 +127,7 @@ watch(
       <label class="mt-4 flex items-center pl-4">
         <div class="w-full max-w-2xs">{{ t('label.startOfTheWeek') }}</div>
         <select-input
-          name="timezone"
+          name="start-of-week"
           :options="availableStartOfTheWeekOptions"
           v-model="user.data.settings.startOfWeek"
           class="w-full max-w-sm"

--- a/test/e2e/pages/settings-page.ts
+++ b/test/e2e/pages/settings-page.ts
@@ -34,7 +34,7 @@ export class SettingsPage {
   readonly profileUsernameInput: Locator;
   readonly profilePreferredEmailSelect: Locator;
   readonly profileDisplayNameInput: Locator;
-  readonly profileMyLinkInput: Locator;
+  readonly profileMyLinkOptionalInput: Locator;
   readonly profileSaveChangesBtn: Locator;
   readonly refreshLinkBtn: Locator;
   readonly confirmRefreshCancelBtn: Locator;
@@ -98,7 +98,7 @@ export class SettingsPage {
     this.profileUsernameInput = this.page.getByTestId('settings-account-user-name-input');
     this.profilePreferredEmailSelect = this.page.getByTestId('settings-account-email-select');
     this.profileDisplayNameInput = this.page.getByTestId('settings-account-display-name-input');
-    this.profileMyLinkInput = this.page.getByTestId('settings-account-mylink-input');
+    this.profileMyLinkOptionalInput = this.page.getByTestId('settings-account-mylink-input');
     this.profileSaveChangesBtn = this.page.getByTestId('settings-account-save-changes-btn');
     this.refreshLinkBtn = this.page.getByTestId('settings-account-refresh-link-btn');
     this.confirmRefreshCancelBtn = this.page.getByRole('button', { name: 'Cancel' });
@@ -255,13 +255,6 @@ export class SettingsPage {
     await this.profileDisplayNameInput.fill(newDisplayName);
     await this.profileSaveChangesBtn.click();
     await this.page.waitForTimeout(TIMEOUT_3_SECONDS); // give a few seconds to be applied
-  }
-
-  /**
-   * Get the account settings profile my link value
-   */
-  async getAccountProfileMyLink(): Promise<string> {
-    return await this.profileMyLinkInput.inputValue();
   }
 
   /**

--- a/test/e2e/tests/settings.spec.ts
+++ b/test/e2e/tests/settings.spec.ts
@@ -229,11 +229,23 @@ test.describe('account settings', {
   });
 
   test('verify profile details', async ({ page }) => {
-    // verify user name, preferred email, display name, and share link are all correct
+    // verify user name, preferred email, display name
     expect(await settingsPage.getAccountProfileUsername()).toBe(APPT_LOGIN_EMAIL);
     expect(await settingsPage.getAccountProfilePreferredEmail()).toBe(APPT_LOGIN_EMAIL);
     expect(await settingsPage.getAccountProfileDisplayName()).toBe(APPT_DISPLAY_NAME);
-    expect(await settingsPage.getAccountProfileMyLink()).toBe(APPT_MY_SHARE_LINK);
+
+    // verify the displayed share link; there are two parts to the share link, a label that contains
+    // the root URL (host and username), and an input field that contains an optional slug; note that
+    // the label may not display the entire root URL as it is limited in size. Our test/e2e/.env
+    // contains the full share link in APPT_MY_SHARE_LINK. Just verify that the first N chars of the
+    // URL displayed in the share link label, and the optional input field value / slug are both
+    // inside APPT_MY_SHARE_LINK.
+    let shareLinkLabel = await settingsPage.profileMyLinkOptionalInput.innerText();
+    expect(APPT_MY_SHARE_LINK).toContain(shareLinkLabel.substring(0, 15));
+    let shareLinkOptionalSlug: string = await settingsPage.profileMyLinkOptionalInput.inputValue();
+    if (shareLinkOptionalSlug.length) {
+      expect(APPT_MY_SHARE_LINK).toContain(shareLinkOptionalSlug);
+    }
   });
 
   test('able to change display name', async ({ page }) => {


### PR DESCRIPTION
Update the E2E settings tests to match the recent settings & share link page changes.