### PR TITLE
Increase E2E test wait time when loading dashboard

### DIFF
--- a/test/e2e/pages/dashboard-page.ts
+++ b/test/e2e/pages/dashboard-page.ts
@@ -93,7 +93,7 @@ export class DashboardPage {
     // now we have a list of future pending appointments for our host and requster; now ensure one
     // of them matches the slot that was selected by the test
     const apptLocator = this.page.getByRole('cell', { name: `${slotDate}` }).locator('div', { hasText: `${slotTime} to`});
-    await expect(apptLocator).toBeVisible( { timeout: TIMEOUT_60_SECONDS });
+    await expect(apptLocator).toBeVisible({ timeout: TIMEOUT_60_SECONDS });
   }
 
   /**
@@ -107,6 +107,6 @@ export class DashboardPage {
    * Get the availability panel header text (i.e. '<display name>'s Availability')
    */
   async getAvailabilityPanelHeader(): Promise<string> {
-    return await this.availabilityPanelHeader.inputValue();
+    return await this.availabilityPanelHeader.inputValue({ timeout: TIMEOUT_60_SECONDS });
   }
 }

--- a/test/e2e/pages/splashscreen-page.ts
+++ b/test/e2e/pages/splashscreen-page.ts
@@ -1,5 +1,5 @@
 import { expect, type Page, type Locator } from '@playwright/test';
-import { APPT_URL, APPT_LOGIN_EMAIL, FXA_PAGE_TITLE, APPT_LOGIN_PWORD, TIMEOUT_30_SECONDS } from '../const/constants';
+import { APPT_URL, APPT_LOGIN_EMAIL, FXA_PAGE_TITLE, APPT_LOGIN_PWORD, TIMEOUT_60_SECONDS } from '../const/constants';
 
 export class SplashscreenPage {
   readonly page: Page;
@@ -46,7 +46,7 @@ export class SplashscreenPage {
     expect(APPT_LOGIN_EMAIL, 'getting APPT_LOGIN_EMAIL env var').toBeTruthy();
     await this.enterLoginEmail(APPT_LOGIN_EMAIL);
     await this.clickLoginContinueBtn();
-    await expect(this.page).toHaveTitle(FXA_PAGE_TITLE, { timeout: TIMEOUT_30_SECONDS }); // be generous in case FxA is slow to load
+    await expect(this.page).toHaveTitle(FXA_PAGE_TITLE, { timeout: TIMEOUT_60_SECONDS }); // be generous in case FxA is slow to load
   }
 
   async localApptSignIn() {


### PR DESCRIPTION
Update the E2E tests to wait longer for the dashboard to fully load because sometimes the availability / settings panel on the right side is taking a very long time to load (see issue #1015).

Also using this PR to increase the wait time allowed for the FxA sign-in page to load as I notice once and awhile the tests timeout waiting for FxA.