### PR TITLE
Show navbar without menu on availability page

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -7,7 +7,6 @@ import { useRoute, useRouter } from 'vue-router';
 import { storeToRefs } from 'pinia';
 import { UAParser } from 'ua-parser-js';
 import NavBar from '@/components/NavBar.vue';
-import TitleBar from '@/components/TitleBar.vue';
 import FooterBar from '@/components/FooterBar.vue';
 import SiteNotification from '@/elements/SiteNotification.vue';
 import RouteNotFoundView from '@/views/errors/RouteNotFoundView.vue';
@@ -36,7 +35,6 @@ import { AuthSchemes } from '@/definitions';
 const user = useUserStore();
 const apiUrl = inject(apiUrlKey);
 const route = useRoute();
-const routeName = typeof route.name === 'string' ? route.name : '';
 const router = useRouter();
 
 const siteNotificationStore = useSiteNotificationStore();
@@ -143,10 +141,10 @@ const routeIsPublic = computed(
   () => route.meta?.isPublic,
 );
 const routeIsHome = computed(
-  () => ['home'].includes(routeName),
+  () => ['home'].includes(typeof route.name === 'string' ? route.name : ''),
 );
 const routeHasModal = computed(
-  () => ['login'].includes(routeName),
+  () => ['login'].includes(typeof route.name === 'string' ? route.name : ''),
 );
 
 // retrieve calendars and appointments after checking login and persisting user to db
@@ -324,12 +322,11 @@ onMounted(async () => {
     >
       {{ notificationMessage }}
     </site-notification>
-    <nav-bar v-if="user?.authenticated" :nav-items="navItems"/>
-    <title-bar v-if="routeIsPublic"/>
+    <nav-bar v-if="!(routeIsHome && !user?.authenticated)" :nav-items="navItems" />
     <main
+      class="pt-24"
       :class="{
         'mx-4 min-h-full py-32 lg:mx-8': !routeIsHome && !routeIsPublic,
-        '!pt-24': routeIsHome || user?.authenticated,
         'min-h-full': routeIsPublic && !routeHasModal,
       }"
     >

--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -41,7 +41,7 @@ const isNavEntryActive = (item: string) => {
   >
     <router-link
       class="shrink-0 border-r border-gray-300 py-4 pl-4 pr-8 dark:border-gray-600"
-      :to="{ name: 'dashboard' }"
+      :to="{ name: user?.authenticated ? 'dashboard' : 'home' }"
     >
       <img class="h-8" src="@/assets/svg/appointment_logo_beta.svg" alt="Appointment Logo" />
     </router-link>

--- a/frontend/src/components/TitleBar.vue
+++ b/frontend/src/components/TitleBar.vue
@@ -1,5 +1,0 @@
-<template>
-  <header>
-    <!-- Silence for now -->
-  </header>
-</template>


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This PR changes the visibility of the navbar:

- If a user is authenticated, the navbar is always shown with all available menu entries on all pages (even home and the availability page).
- If a user is **not** authenticated, the navbar is shown without menu entries but still with the logo on all pages, except for the homepage.

Home as authenticated user:
<img src="https://github.com/user-attachments/assets/3c9ef2ac-3e19-43d5-bd75-015471947cdd" width="50%" />

Availability as authenticated user:
<img src="https://github.com/user-attachments/assets/b561d89a-c292-487e-b86d-07c54748a2a8" width="50%" />

Home as anonymous user:
<img src="https://github.com/user-attachments/assets/b4ca9ad9-e19b-45fa-a3dd-a75f5c258a43" width="50%" />

Availability as anonymous user:
<img src="https://github.com/user-attachments/assets/358f7bb6-02cb-4ba5-97df-a8abb48d058d" width="50%" />

I also fixed a well hidden bug, where our routeIsHome or routeIsPublic checks failed, because we were using a constant in the corresponding computed properties instead of the route object itself.

## Benefits

The Thunderbird Appointment branding should now always be visible.

## Applicable Issues

Closes #1007 
