### PR TITLE
Fix URL Signing

### DIFF
--- a/backend/src/appointment/controller/auth.py
+++ b/backend/src/appointment/controller/auth.py
@@ -54,7 +54,7 @@ def user_links_by_subscriber(subscriber: models.Subscriber):
     Note1 that this contains a trailing slash
     Note2 if short url isn't supported then both return links will be the same"""
     short_url = os.getenv('SHORT_BASE_URL')
-    base_url = f"{os.getenv('FRONTEND_URL')}/user"
+    base_url = f'{os.getenv('FRONTEND_URL')}/user'
 
     # If we don't have a short url, then use the default url with /user added to it
     if not short_url:
@@ -76,7 +76,7 @@ def signed_url_by_subscriber(subscriber: schemas.Subscriber):
     signature = sign_url(url)
 
     # We return with the signed url signature
-    return ''.join([base_url, signature])
+    return ''.join([short_url, signature])
 
 
 def schedule_slugs_by_subscriber(db, subscriber: models.Subscriber) -> dict:

--- a/backend/src/appointment/controller/auth.py
+++ b/backend/src/appointment/controller/auth.py
@@ -49,9 +49,10 @@ def sign_url(url: str):
     return signature
 
 
-def user_link_by_subscriber(subscriber: models.Subscriber):
-    """Returns a user link based off the subscriber's username
-    Note that this contains a trailing slash"""
+def user_links_by_subscriber(subscriber: models.Subscriber):
+    """Returns a short link and a long link for the user's booking page.
+    Note1 that this contains a trailing slash
+    Note2 if short url isn't supported then both return links will be the same"""
     short_url = os.getenv('SHORT_BASE_URL')
     base_url = f"{os.getenv('FRONTEND_URL')}/user"
 
@@ -61,17 +62,16 @@ def user_link_by_subscriber(subscriber: models.Subscriber):
 
     url_safe_username = urllib.parse.quote_plus(subscriber.username)
 
-    return f'{short_url}/{url_safe_username}/'
+    return f'{short_url}/{url_safe_username}/', f'{base_url}/{url_safe_username}/'
 
 
 def signed_url_by_subscriber(subscriber: schemas.Subscriber):
     """helper to generated signed url for given subscriber"""
-    base_url = user_link_by_subscriber(subscriber)
+    short_url, base_url = user_links_by_subscriber(subscriber)
 
     # We sign with a different hash that the end-user doesn't have access to
-    # We also need to use the default url, as short urls are currently setup as a redirect
+    # We only sign with the long user link
     url = ''.join([base_url, subscriber.short_link_hash])
-
 
     signature = sign_url(url)
 

--- a/backend/src/appointment/routes/api.py
+++ b/backend/src/appointment/routes/api.py
@@ -17,7 +17,7 @@ from ..database import repo, schemas
 from ..controller.calendar import CalDavConnector, Tools, GoogleConnector
 from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks, Request
 from ..controller.apis.google_client import GoogleClient
-from ..controller.auth import signed_url_by_subscriber, schedule_slugs_by_subscriber, user_link_by_subscriber
+from ..controller.auth import signed_url_by_subscriber, schedule_slugs_by_subscriber, user_links_by_subscriber
 from ..database.models import Subscriber, CalendarProvider, InviteStatus
 from ..defines import DEFAULT_CALENDAR_COLOUR
 from ..dependencies.google import get_google_client
@@ -78,7 +78,7 @@ def update_me(
         timezone=me.timezone,
         is_setup=me.is_setup,
         avatar_url=me.avatar_url,
-        user_link=user_link_by_subscriber(subscriber),
+        user_link=user_links_by_subscriber(subscriber)[0],
         schedule_slugs=schedule_slugs_by_subscriber(db, subscriber),
         unique_hash=me.unique_hash,
         language=me.language,

--- a/backend/src/appointment/routes/auth.py
+++ b/backend/src/appointment/routes/auth.py
@@ -18,7 +18,7 @@ from fastapi.responses import RedirectResponse
 
 from .. import utils
 from ..controller.apis.accounts_client import AccountsClient
-from ..controller.auth import schedule_slugs_by_subscriber, user_link_by_subscriber
+from ..controller.auth import schedule_slugs_by_subscriber, user_links_by_subscriber
 from ..database import repo, schemas
 from ..database.models import Subscriber, ExternalConnectionType
 from ..defines import INVITES_TO_GIVE_OUT, AuthScheme, REDIS_USER_SESSION_PROFILE_KEY
@@ -602,7 +602,6 @@ def me(
     subscriber: Subscriber = Depends(get_subscriber),
 ):
     """Return the currently authed user model"""
-
     hash = subscriber.unique_hash
 
     return schemas.SubscriberMeOut(
@@ -614,7 +613,7 @@ def me(
         timezone=subscriber.timezone,
         avatar_url=subscriber.avatar_url,
         is_setup=subscriber.is_setup,
-        user_link=user_link_by_subscriber(subscriber),
+        user_link=user_links_by_subscriber(subscriber)[0],
         schedule_slugs=schedule_slugs_by_subscriber(db, subscriber),
         unique_hash=hash,
         language=subscriber.language,

--- a/backend/test/unit/test_auth_controller.py
+++ b/backend/test/unit/test_auth_controller.py
@@ -1,0 +1,27 @@
+import os
+from urllib.parse import quote_plus
+
+from appointment.controller.auth import signed_url_by_subscriber, sign_url
+
+
+class TestSignedUrl:
+    def test_signing_uses_long_url(self, make_basic_subscriber):
+        """Because our signing process is a little complicated with short urls this test ensures we only ever sign
+        with the long url (FRONTEND_USER/user) type urls and never the short urls."""
+        os.environ['SHORT_BASE_URL'] = 'https://example.org'
+
+        short_url = os.getenv('SHORT_BASE_URL')
+        base_url = f'{os.getenv('FRONTEND_URL')}/user'
+
+        subscriber = make_basic_subscriber()
+
+        # Setup our control url
+        url_safe_username = quote_plus(subscriber.username)
+        url_to_sign = f'{base_url}/{url_safe_username}/'  # We sign with the long url
+        url_to_return = f'{short_url}/{url_safe_username}/'  # We send the user the short url
+        url = ''.join([url_to_sign, subscriber.short_link_hash])
+
+        signed_url = signed_url_by_subscriber(subscriber)
+        control_signed_url = ''.join([url_to_return, sign_url(url)])
+
+        assert signed_url == control_signed_url


### PR DESCRIPTION
Fixes #1049 

I think we'll have to refactor this entire process as it's a bit overly complicated. 

How this entire process works:
1. User lands on a booking action (confirmation or decline) url
2. The frontend sends the current url up to the backend
3. Backend extracts the signature portion of that url and puts it aside for the moment
4. Backend resigns the url (sent by frontend request) without the signature
5. Backend compares the signature from the resign to the signature originally in the url
6. If they match, we're gooooood to gooooo!

Since the frontend never sees the short url it only sends up the normal longer-form booking url. This means we have to only sign with that longer-form booking url. I'm open to suggestions to clean this process up.