### PR TITLE
[WIP] Cancel confirmed appointment feature

### DIFF
--- a/backend/src/appointment/controller/apis/zoom_client.py
+++ b/backend/src/appointment/controller/apis/zoom_client.py
@@ -144,3 +144,8 @@ class ZoomClient:
         response = self.client.get(f'{self.OAUTH_REQUEST_URL}/meetings/{meeting_id}')
         response.raise_for_status()
         return response.json()
+
+    def delete_meeting(self, meeting_id):
+        response = self.client.delete(f'{self.OAUTH_REQUEST_URL}/meetings/{meeting_id}')
+        response.raise_for_status()
+        return response.json()

--- a/backend/src/appointment/controller/mailer.py
+++ b/backend/src/appointment/controller/mailer.py
@@ -57,7 +57,8 @@ class Mailer:
         plain: str = '',
         attachments: list[Attachment] = [],
         method: str = 'REQUEST',
-        lang: str = None
+        lang: str = None,
+        reason: str = None
     ):
         self.sender = sender
         self.to = to
@@ -68,6 +69,7 @@ class Mailer:
         self.attachments = attachments
         self.method = method
         self.lang = lang
+        self.reason = reason
 
     def html(self):
         """provide email body as html per default"""
@@ -320,6 +322,30 @@ class ConfirmationMail(BaseBookingMail):
             tbpro_logo_cid=self._attachments()[0].filename,
             calendar_icon_cid=self._attachments()[1].filename,
             clock_icon_cid=self._attachments()[2].filename,
+        )
+
+
+class CancelMail(Mailer):
+    def __init__(self, owner_name, date, reason, *args, **kwargs):
+        """Init Mailer with cancel specific defaults
+           To: Bookee
+           Reply-To: Event owner
+        """
+        self.owner_name = owner_name
+        self.date = date
+        self.reason = reason
+        default_kwargs = {'subject': l10n('cancel-mail-subject')}
+        super(CancelMail, self).__init__(*args, **default_kwargs, **kwargs)
+
+    def text(self):
+        return l10n('cancel-mail-plain', {'owner_name': self.owner_name, 'date': self.date, 'reason': self.reason})
+
+    def html(self):
+        return get_template('cancelled.jinja2').render(
+            owner_name=self.owner_name,
+            date=self.date,
+            reason=self.reason,
+            tbpro_logo_cid=self._attachments()[0].filename,
         )
 
 

--- a/backend/src/appointment/database/schemas.py
+++ b/backend/src/appointment/database/schemas.py
@@ -393,6 +393,10 @@ class AppointmentSlots(BaseModel):
     slots: list[SlotBase] = []
 
 
+class AppointmentCancelRequest(BaseModel):
+    reason: str | None = None
+
+
 class AvailabilitySlotConfirmation(BaseModel):
     slot_id: int
     slot_token: str

--- a/backend/src/appointment/l10n/en/email.ftl
+++ b/backend/src/appointment/l10n/en/email.ftl
@@ -103,6 +103,21 @@ confirm-mail-html-confirm-action = Confirm
 confirm-mail-html-deny-text = Or here if you want to deny it:
 confirm-mail-html-deny-action = Decline
 
+## Cancelled Appointment
+
+cancel-mail-subject = Booking request declined
+# Variables:
+# $owner_name (String) - Name of the person who owns the schedule
+# $date (String) - Date of the requested appointment
+# $reason (String - optional) - Reason for cancelling the appointment
+cancel-mail-html-heading = { $owner_name } denied your booking request for this time slot: { $date }. <#if $reason>Reason: { $reason }</#if>
+# Variables:
+# $owner_name (String) - Name of the person who owns the schedule
+# $date (String) - Date of the requested appointment
+# $reason (String - optional) - Reason for cancelling the appointment
+cancel-mail-plain = { $owner_name } denied your booking request for this time slot: { $date }. <#if $reason>Reason: { $reason }</#if>
+                    {-brand-footer}
+
 ## Rejected Appointment
 
 reject-mail-subject = Booking request declined

--- a/backend/src/appointment/routes/api.py
+++ b/backend/src/appointment/routes/api.py
@@ -445,6 +445,7 @@ def public_appointment_serve_ics(slug: str, slot_id: int, db: Session = Depends(
         data=Tools().create_vevent(appointment=db_appointment, slot=slot, organizer=organizer).decode('utf-8'),
     )
 
+
 @router.delete('/apmt/{id}')
 def delete_my_appointment(id: int, db: Session = Depends(get_db), subscriber: Subscriber = Depends(get_subscriber)):
     """endpoint to remove a appointment from db"""
@@ -458,7 +459,13 @@ def delete_my_appointment(id: int, db: Session = Depends(get_db), subscriber: Su
 
 
 @router.post('/apmt/{id}/cancel')
-def cancel_my_appointment(id: int, background_tasks: BackgroundTasks, payload: schemas.AppointmentCancelRequest, db: Session = Depends(get_db), subscriber: Subscriber = Depends(get_subscriber)):
+def cancel_my_appointment(
+    id: int,
+    background_tasks: BackgroundTasks,
+    payload: schemas.AppointmentCancelRequest,
+    db: Session = Depends(get_db),
+    subscriber: Subscriber = Depends(get_subscriber),
+):
     """endpoint to cancel an appointment from db"""
     if not repo.appointment.exists(db, appointment_id=id):
         raise validation.AppointmentNotFoundException()

--- a/backend/src/appointment/routes/schedule.py
+++ b/backend/src/appointment/routes/schedule.py
@@ -524,7 +524,7 @@ def handle_schedule_availability_decision(
     # check if request was denied
     if confirmed is False:
         # send rejection information to bookee
-        Tools().send_cancel_vevent(background_tasks, appointment, slot, subscriber, slot.attendee)
+        Tools().send_reject_vevent(background_tasks, appointment, slot, subscriber, slot.attendee)
         repo.slot.delete(db, slot.id)
 
         if slot.appointment_id:

--- a/backend/src/appointment/routes/schedule.py
+++ b/backend/src/appointment/routes/schedule.py
@@ -368,6 +368,7 @@ def request_schedule_availability_slot(
             status=status,
             location_type=schedule.location_type,
             location_url=schedule.location_url,
+            meeting_link_provider=schedule.meeting_link_provider,
         ),
     )
 

--- a/backend/src/appointment/tasks/emails.py
+++ b/backend/src/appointment/tasks/emails.py
@@ -14,6 +14,7 @@ from appointment.controller.mailer import (
     InviteAccountMail,
     ConfirmYourEmailMail,
     NewBookingMail,
+    CancelMail,
 )
 from appointment.defines import APP_ENV_DEV
 
@@ -63,6 +64,18 @@ def send_new_booking_email(name, email, date, duration, to, schedule_name, lang)
 def send_pending_email(owner_name, date, to, attachment):
     try:
         mail = PendingRequestMail(owner_name=owner_name, date=date, to=to, attachments=[attachment])
+        mail.send()
+    except Exception as e:
+        if os.getenv('APP_ENV') == APP_ENV_DEV:
+            logging.error('[tasks.emails] An exception has occurred: ', e)
+            traceback.print_exc()
+        if os.getenv('SENTRY_DSN'):
+            sentry_sdk.capture_exception(e)
+
+
+def send_cancel_email(owner_name, date, to, attachment, reason):
+    try:
+        mail = CancelMail(owner_name=owner_name, date=date, to=to, attachments=[attachment], reason=reason)
         mail.send()
     except Exception as e:
         if os.getenv('APP_ENV') == APP_ENV_DEV:

--- a/backend/src/appointment/templates/email/cancelled.jinja2
+++ b/backend/src/appointment/templates/email/cancelled.jinja2
@@ -1,0 +1,9 @@
+{% extends "includes/base.jinja2" %}
+{# Code begins! #}
+{% block introduction %}
+  <div style="color: {{ colour_text_base }}; text-align: center; line-height: 16px;">
+    <p>
+      {{ l10n('cancel-mail-html-heading', {'owner_name': owner_name, 'date': date, 'reason': reason}) }}
+    </p>
+  </div>
+{% endblock %}

--- a/frontend/src/components/AppointmentModal.vue
+++ b/frontend/src/components/AppointmentModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { BookingStatus } from '@/definitions';
 import { timeFormat } from '@/utils';
-import { computed, inject } from 'vue';
+import { computed, inject, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { Appointment } from '@/models';
 
@@ -38,6 +38,8 @@ interface Props {
 }
 const props = defineProps<Props>();
 
+const cancelReason = ref<string>("");
+
 // attendees list
 const attendeesSlots = computed(() => props.appointment.slots.filter((s) => s.attendee));
 
@@ -60,6 +62,13 @@ const answer = (isConfirmed: boolean) => {
 // Handle deletion
 const deleteAppointment = () => {
   apmtStore.deleteAppointment(props.appointment?.id);
+  emit('close');
+};
+
+// Handle cancel
+const cancelAppointment = () => {
+  apmtStore.cancelAppointment(props.appointment?.id, cancelReason.value);
+  cancelReason.value = "";
   emit('close');
 };
 </script>
@@ -177,7 +186,22 @@ const deleteAppointment = () => {
         <div class="rounded-lg border border-gray-400 p-4 dark:border-gray-600">{{ appointment.details }}</div>
       </div>
       <div class="p-6" v-if="status === BookingStatus.Booked">
-        <p>This booking is confirmed.</p>
+        <p class="mb-8">This booking is confirmed.</p>
+        <form class="gap-4 mx-auto" @submit.prevent>
+          <label for="cancelReason">
+            {{ t("label.cancelReason") }}
+            <textarea
+                name="cancelReason"
+                v-model="cancelReason"
+                :placeholder="t('placeholder.writeHere')"
+                class="w-full h-24 rounded-md resize-none mt-2 mb-4"
+                data-testid="appointment-modal-reason-input"
+              ></textarea>
+          </label>
+          <danger-button data-testid="appointment-modal-cancel-btn" @click="cancelAppointment()" :title="t('label.cancel')">
+            {{ t('label.cancelBooking') }}
+          </danger-button>
+        </form>
       </div>
       <div class="p-6" v-else-if="isExpired">
         <p>This booking is expired.</p>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -194,6 +194,8 @@
     "calendarDeletion": "Remove Calendar",
     "calendarUrl": "Calendar URL",
     "cancel": "Cancel",
+    "cancelBooking": "Cancel booking",
+    "cancelReason": "Reason for cancelling",
     "checkAvailableSlots": "Check available slots",
     "chooseYourAvailability": "Availability",
     "clearForm": "Clear form",

--- a/frontend/src/stores/appointment-store.ts
+++ b/frontend/src/stores/appointment-store.ts
@@ -79,6 +79,16 @@ export const useAppointmentStore = defineStore('appointments', () => {
     await fetch();
   };
 
+  /**
+   * Cancel an appointment with an optional reason
+  */
+  const cancelAppointment = async (id: number, reason?: string) => {
+    await call.value(`apmt/${id}/cancel`).post({
+      reason
+    });
+    await fetch();
+  };
+
   return {
     isLoaded,
     appointments,
@@ -89,6 +99,7 @@ export const useAppointmentStore = defineStore('appointments', () => {
     fetch,
     $reset,
     deleteAppointment,
+    cancelAppointment
   };
 });
 


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
[**Main work**]
- In the frontend, added a textarea for an optional reason and a `Cancel booking` button in the `AppointmentModal` component
- In the backend, added a new endpoint to cancel an appointment (`POST` to `/apmt/{id}/cancel`) that looks up all the slots associated with that appointment and:
   1. Sends a cancellation email with and optional reason (new email template added)
   2. If the `meeting_link_provider` is Zoom, calls the Zoom client to delete the meeting

[**Small refactor**]
- We were using `reject` and `cancel` a little bit interchangeably which creates some confusion (at least for me) in terms of _when_ that action took place. For this PR, I have separated the concepts so that `reject` means that an appointment that is pending approval has been rejected (as in, never accepted) and `cancelled` is cancelling an appointment that has already been confirmed.


[**Fix**]
- When a schedule is created and the settings for creating a zoom link is enabled, it gets set in the `meeting_link_provider` of the schedule itself. However, the appointment doesn't seem to ever get its `meeting_link_provider` updated so upon appointment creation, I've "synced" their fields so that I can later read it from appointment cancellation.



## Benefits

<!-- What benefits will be realized by the code change? -->

- New cancellation of confirmed booking feature that also deletes Zoom meetings if any
- Separation of cancel vs. reject concepts

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/171
https://github.com/thunderbird/appointment/issues/1061