### PR TITLE
Update schedules' meeting_link_provider upon Zoom connection

### DIFF
--- a/backend/src/appointment/controller/zoom.py
+++ b/backend/src/appointment/controller/zoom.py
@@ -4,6 +4,16 @@ from appointment.database import repo, models
 from appointment.database.models import ExternalConnectionType
 
 
+def update_schedules_meeting_link_provider(db: Session, subscriber_id: int) -> bool:
+    """Updates existing schedules' meeling link provider to be zoom"""
+    schedules = repo.schedule.get_by_subscriber(db, subscriber_id)
+    for schedule in schedules:
+        schedule.meeting_link_provider = models.MeetingLinkProviderType.zoom
+        db.add(schedule)
+    db.commit()
+    return True
+
+
 def disconnect(db: Session, subscriber_id: int, type_id: str) -> bool:
     """Disconnects a zoom external connection from a given subscriber id and zoom type id"""
     repo.external_connection.delete_by_type(db, subscriber_id, ExternalConnectionType.zoom, type_id)

--- a/backend/src/appointment/routes/zoom.py
+++ b/backend/src/appointment/routes/zoom.py
@@ -111,6 +111,9 @@ def zoom_callback(
     ):
         repo.external_connection.create(db, external_connection_schema)
 
+    # Update existing schedules' so that the zoom link generation setting is set
+    zoom.update_schedules_meeting_link_provider(db, subscriber.id)
+
     # Redirect non-setup subscribers back to the setup page
     if not subscriber.is_setup:
         return RedirectResponse(f"{os.getenv('FRONTEND_URL', 'http://localhost:8080')}/setup")

--- a/backend/test/integration/test_zoom.py
+++ b/backend/test/integration/test_zoom.py
@@ -1,8 +1,39 @@
+from unittest import mock
 from appointment.database import models
 from defines import auth_headers, TEST_USER_ID
 
 
 class TestZoom:
+    def test_zoom_callback_updates_schedule(
+        self, monkeypatch, with_db, with_client, make_schedule, make_external_connections
+    ):
+        # Mock the Zoom API calls
+        mock_zoom_client = mock.Mock()
+        mock_zoom_client.get_credentials.return_value = '{"access_token": "token", "refresh_token": "refresh"}'
+        mock_zoom_client.get_me.return_value = {"id": "zoom_id", "email": "test@test.com"}
+
+        def mock_get_zoom_client(*args, **kwargs):
+            return mock_zoom_client
+
+        monkeypatch.setattr('appointment.routes.zoom.get_zoom_client', mock_get_zoom_client)
+
+        schedule = make_schedule(meeting_link_provider=models.MeetingLinkProviderType.none)
+        assert schedule.meeting_link_provider == models.MeetingLinkProviderType.none
+
+        # Mock the request.session checks
+        with mock.patch('fastapi.Request.session', new_callable=mock.PropertyMock) as mock_session:
+            mock_session.return_value = {'zoom_state': 'state', 'zoom_user_id': TEST_USER_ID}
+            with_client.get(
+                '/zoom/callback', params={'code': 'code', 'state': 'state'}, headers=auth_headers
+            )
+
+        # Refresh the schedule now to see the meeting_link_provider change
+        with with_db() as db:
+            db.add(schedule)
+            db.refresh(schedule)
+
+        assert schedule.meeting_link_provider == models.MeetingLinkProviderType.zoom
+
     def test_zoom_disconnect_without_connection(self, with_client):
         response = with_client.post('/zoom/disconnect', headers=auth_headers)
         assert response.status_code == 200


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
Upon Zoom disconnection, we are resetting the schedule's `meeting_link_provider` but we were not setting it back upon re connection, so now whenever Zoom is successfully connected, upon its callback, set the subscriber's schedules' `meeting_link_provider` to be `zoom`.

## Benefits

<!-- What benefits will be realized by the code change? -->
Prevents confusion / extra steps on connecting Zoom and finding out that the meeting link generation setting is off.

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/1008
