### PR TITLE
Add explainer to "generate Zoom meeting checkbox" when Zoom is not connected

### DIFF
--- a/frontend/src/components/ScheduleCreation.vue
+++ b/frontend/src/components/ScheduleCreation.vue
@@ -389,6 +389,9 @@ const copyLink = async () => {
   }, 4000);
 };
 
+// controls the generate zoom link checkbox
+const isZoomEnabled = computed(() => scheduleInput.value.active && hasZoomAccount.value);
+
 // track schedule activation toggle changes
 watch(
   () => scheduleInput.value.active,
@@ -688,9 +691,16 @@ watch(
             name="generateZoomLink"
             :label="t('label.generateZoomLink')"
             v-model="generateZoomLink"
-            :disabled="!scheduleInput.active || !hasZoomAccount"
+            :disabled="!isZoomEnabled"
             @change="toggleZoomLinkCreation"
           />
+          <i18n-t v-if="!isZoomEnabled" keypath="text.generateZoomMeetingHelpDisabled.text" tag="span" scope="global" class="text-xs">
+            <template v-slot:link>
+              <router-link class="underline" to="settings/connectedAccounts">
+                {{ t('text.generateZoomMeetingHelpDisabled.link') }}
+              </router-link>
+            </template>
+          </i18n-t>
           <label class="relative flex flex-col gap-1">
             <div class="input-label ">
               {{ t("label.notes") }}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -461,6 +461,10 @@
     "defineDaysAndTimeSlots": "Definiere Tage und Zeitfenster, damit Teilnehmer die Zeit des Events auswählen können …",
     "denialSentToAddress": "Die Informationen über die Ablehnung der Anfrage wurde per E-Mail an {address} geschickt.",
     "disclaimerGABooking": "Bitte beachten: Der Eigentümer muss die Buchung bestätigen.",
+    "generateZoomMeetingHelpDisabled": {
+      "link": "ein Zoom-Konto verbinden",
+      "text": "Zoom ist nicht verbunden. Bitte {link}, um diese Funktion zu verwenden."
+    },
     "googlePermissionCalendarName": "Anzeigen und Herunterladen aller Kalender des Google-Kontos",
     "googlePermissionCalendarReason": "Thunderbird Appointment benötigt diese Berechtigung, um eine Liste von Kalendern anzuzeigen, die verbunden werden können.",
     "googlePermissionDisclaimer": "Thunderbird Appointment benötigt die folgenden Berechtigungen von Google, um korrekt zu funktionieren",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -462,6 +462,10 @@
     "defineDaysAndTimeSlots": "Choose the days and time this event can be booked.",
     "denialSentToAddress": "We've let the booker ({address}) know you can't make this event.",
     "disclaimerGABooking": "Your booking will be confirmed by the calendar owner.",
+    "generateZoomMeetingHelpDisabled": {
+      "link": "connect a Zoom account",
+      "text": "Zoom is not connected. Please {link} to use this feature."
+    },
     "googlePermissionCalendarName": "See and download your calendars using Google Calendar",
     "googlePermissionCalendarReason": "Thunderbird Appointment requires this permission to display a list of calendars you can connect with.",
     "googlePermissionDisclaimer": "Thunderbird Appointment requires the following permissions from Google Calendar for optimal functionality.",

--- a/frontend/src/tbpro/elements/CheckboxInput.vue
+++ b/frontend/src/tbpro/elements/CheckboxInput.vue
@@ -153,6 +153,11 @@ const onChange = () => {
 
   &:disabled {
     cursor: not-allowed;
+    opacity: .5;
+
+    & ~ span {
+      color: var(--colour-ti-muted);
+    }
   }
 }
 </style>

--- a/frontend/src/tbpro/elements/CheckboxInput.vue
+++ b/frontend/src/tbpro/elements/CheckboxInput.vue
@@ -150,5 +150,9 @@ const onChange = () => {
     border-color: var(--colour-highlight);
     color: var(--colour-neutral-raised);
   }
+
+  &:disabled {
+    cursor: not-allowed;
+  }
 }
 </style>


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->

In case Zoom is not enabled, there was no message to the subscriber explaining why they can't click on the checkbox to generate zoom meeting. This adds a message with a link to the related setting (`/settings/connectedAccounts`) and changes the cursor to `not-allowed` when checkboxes are disabled.

![Jun-23-2025 14-37-33](https://github.com/user-attachments/assets/45632bb4-3bfc-4ee0-b210-f7babfc4d252)


## Benefits

<!-- What benefits will be realized by the code change? -->

- Better feedback to the subscriber on the available actions around Zoom's settings to generate meeting link.
- Cursor update when checkbox is disabled for all usages of the `CheckboxInput` component

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/973