### PR TITLE
Switch appointment UUID type

### DIFF
--- a/backend/src/appointment/database/models.py
+++ b/backend/src/appointment/database/models.py
@@ -11,8 +11,8 @@ import uuid
 import zoneinfo
 from functools import cached_property
 
-from sqlalchemy import Column, ForeignKey, Integer, String, DateTime, Enum, Boolean, JSON, Date, Time
-from sqlalchemy_utils import StringEncryptedType, ChoiceType, UUIDType
+from sqlalchemy import Column, ForeignKey, Integer, String, DateTime, Enum, Boolean, JSON, Date, Time, UUID
+from sqlalchemy_utils import StringEncryptedType, ChoiceType
 from sqlalchemy_utils.types.encrypted.encrypted_type import AesEngine
 from sqlalchemy.orm import relationship, as_declarative, declared_attr, Mapped
 from sqlalchemy.sql import func
@@ -248,7 +248,7 @@ class Appointment(Base):
     __tablename__ = 'appointments'
 
     id = Column(Integer, primary_key=True, index=True)
-    uuid = Column(UUIDType(native=False), default=uuid.uuid4, index=True, unique=True)
+    uuid = Column(UUID(as_uuid=True), default=uuid.uuid4, index=True, unique=True)
     calendar_id = Column(Integer, ForeignKey('calendars.id'))
     duration = Column(Integer)
     title = Column(encrypted_type(String))

--- a/backend/src/appointment/migrations/versions/2025_06_26_1629-88dbe32dc40d_switch_appointment_uuid_type.py
+++ b/backend/src/appointment/migrations/versions/2025_06_26_1629-88dbe32dc40d_switch_appointment_uuid_type.py
@@ -1,0 +1,35 @@
+"""switch appointment uuid type
+
+Revision ID: 88dbe32dc40d
+Revises: 2b40448be2f5
+Create Date: 2025-06-26 16:29:19.679356
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+
+# revision identifiers, used by Alembic.
+revision = '88dbe32dc40d'
+down_revision = '2b40448be2f5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create a temporary uuid_str as CHAR(32), convert BINARY(16) to CHAR(32) and rename it to uuid
+    op.add_column('appointments', sa.Column('uuid_str', sa.CHAR(32), nullable=True))
+    op.execute('UPDATE appointments SET uuid_str = LOWER(HEX(uuid))')
+    op.alter_column('appointments', 'uuid_str', existing_type=sa.CHAR(32), nullable=False)
+    op.drop_column('appointments', 'uuid')
+    op.alter_column('appointments', 'uuid_str', new_column_name='uuid', existing_type=sa.CHAR(32))
+
+
+def downgrade() -> None:
+    # Create a temporary uuid_str as MySQL's BINARY(16), convert CHAR(32) to BINARY(16) and rename it to uuid
+    op.alter_column('appointments', 'uuid', new_column_name='uuid_str', existing_type=sa.CHAR(32))
+    op.add_column('appointments', sa.Column('uuid', mysql.BINARY(16), nullable=True))
+    op.execute('UPDATE appointments SET uuid = UNHEX(uuid_str)')
+    op.alter_column('appointments', 'uuid', existing_type=mysql.BINARY(16), nullable=False)
+    op.drop_column('appointments', 'uuid_str')


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->

This PR prepares the move from MySQL -> Postgresql. The pending point was that the `appointments` table had a `uuid` column as `BINARY(16)` but that can be converted to either `CHAR(36)` (if using uuid with hyphens) or `CHAR(32)` (otherwise) [[ref](https://dev.mysql.com/blog-archive/storing-uuid-values-in-mysql-tables/)].

Changes:
- Using [SQLAlchemy's UUID](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Uuid) type instead of [SQLAlchemy Utils' UUID](https://sqlalchemy-utils.readthedocs.io/en/latest/data_types.html#module-sqlalchemy_utils.types.uuid) type.
- Add a migration that:
  - Creates a temporary column `uuid_str` to host the new CHAR(32) values
  - Converts the existing BINARY(16) into CHAR(32) and inserts into `uuid_str` table to maintain potential existing data
  - Deletes `uuid` column
  - Rename `uuid_str` to `uuid`


## Benefits

<!-- What benefits will be realized by the code change? -->
It makes our DB code more agnostic in the uuid usage as SQLAlchemy's UUID states: "_For backends that have no 'native' UUID datatype, the value will make use of CHAR(32) and store the UUID as a 32-character alphanumeric hex string._" [[ref](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Uuid)]

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/487