### PR TITLE
Change appointment uuid type from UUID to Uuid

### DIFF
--- a/backend/src/appointment/database/models.py
+++ b/backend/src/appointment/database/models.py
@@ -11,7 +11,7 @@ import uuid
 import zoneinfo
 from functools import cached_property
 
-from sqlalchemy import Column, ForeignKey, Integer, String, DateTime, Enum, Boolean, JSON, Date, Time, UUID
+from sqlalchemy import Column, ForeignKey, Integer, String, DateTime, Enum, Boolean, JSON, Date, Time, Uuid
 from sqlalchemy_utils import StringEncryptedType, ChoiceType
 from sqlalchemy_utils.types.encrypted.encrypted_type import AesEngine
 from sqlalchemy.orm import relationship, as_declarative, declared_attr, Mapped
@@ -248,7 +248,7 @@ class Appointment(Base):
     __tablename__ = 'appointments'
 
     id = Column(Integer, primary_key=True, index=True)
-    uuid = Column(UUID(as_uuid=True), default=uuid.uuid4, index=True, unique=True)
+    uuid = Column(Uuid(as_uuid=True), default=uuid.uuid4, index=True, unique=True)
     calendar_id = Column(Integer, ForeignKey('calendars.id'))
     duration = Column(Integer)
     title = Column(encrypted_type(String))


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
There was a typo mistake on the `uuid` column type from the `appointments` table. It was supposed to use `Uuid` instead of `UUID`. Original problem was introduced in this PR: https://github.com/thunderbird/appointment/pull/1075

## Benefits

<!-- What benefits will be realized by the code change? -->
Database initialization and migrations actually work.

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/1080