### PR TITLE
Switch from MySQL to PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Copy the Client ID and Client Secret values to your backend's .env file as `TB_A
 * Backend can be accessed via: <http://localhost:5000>
 * OpenAPI docs can be accessed via: <http://localhost:5000/docs> or <http://localhost:5000/redoc>
 
-A MySQL database will be accessible via `localhost:3306` with username and password set to: `tba`
+A PostgreSQL database will be accessible via `localhost:5433` with username and password set to: `tba`
 
 On first-run the database will initialize, and a first time setup command will be triggered. Going forward database migrations will automatically run on `docker-compose up`.
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,14 +22,16 @@ SHORT_BASE_URL=
 # -- DATABASE --
 # The use of DATABASE_URL is being phased out. It should only be used for offline migrations.
 #  DATABASE_URL="mysql+mysqldb://tba:tba@mysql:3306/appointment"
+#  DATABASE_URL="postgresql+psycopg://tba:tba@mysql:5432/appointment"
 
 # Instead, use these values to engage the ORM's built-in URL factory
-DATABASE_ENGINE=mysql
-DATABASE_HOST=mysql
+DATABASE_ENGINE=postgresql
+DATABASE_HOST=postgresql
 DATABASE_NAME=appointment
 DATABASE_PASSWORD=abcd%efgh
-DATABASE_PORT=3306
+DATABASE_PORT=5432
 DATABASE_USERNAME=tba
+
 # Secret phrase for database encryption (e.g. create it by running `openssl rand -hex 32`)
 DB_SECRET=
 

--- a/backend/alembic.ini.example
+++ b/backend/alembic.ini.example
@@ -57,6 +57,7 @@ version_path_separator = os  # Use os.pathsep. Default configuration used for ne
 
 # We prefer to use the ORM's built-in URL factory, but you should set this value if you want to do an "offline" migration
 # sqlalchemy.url = mysql+mysqlconnector://user:pass@localhost:port/appointment
+# sqlalchemy.url = postgresql+psycopg://user:pass@localhost:port/appointment
 
 
 [post_write_hooks]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,6 +17,7 @@ cli = [
     "ruff",
 ]
 db = [
+    "mysqlclient==2.2.5",
     "psycopg==3.2.9",
 ]
 test = [

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,7 +17,7 @@ cli = [
     "ruff",
 ]
 db = [
-    "mysqlclient==2.2.5",
+    "psycopg==3.2.9",
 ]
 test = [
     "Faker==26.0.0",

--- a/backend/src/appointment/utils.py
+++ b/backend/src/appointment/utils.py
@@ -119,7 +119,7 @@ def determine_database_driver(dialect: str) -> str:
     if dialect == 'mysql':
         return 'mysqldb'
     elif dialect == 'postgresql':
-        return 'psycopg2'
+        return 'psycopg'
     else:
         return None
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,10 +19,12 @@ services:
       
       # The use of DATABASE_URL is problematic and deprecated
       # - DATABASE_URL=mysql+mysqldb://tba:abcd%efgh@mysql:3306/appointment
+      # - DATABASE_URL=postgresql+psycopg://tba:abcd%efgh@postgres:5432/appointment
       - IS_LOCAL_DEV=yes
       - RELEASE_VERSION=localdev
+
     depends_on:
-      mysql:
+      postgres:
         condition: service_healthy
 
   frontend:
@@ -35,23 +37,23 @@ services:
     environment:
       - WATCHPACK_POLLING=true
 
-  mysql:
-    image: mysql:8
+  postgres:
+    image: postgres:17
     volumes:
-      - apmt_db:/var/lib/mysql
+      - apmt_db:/var/lib/postgresql/data
     ports:
-      - 3306:3306
+      - 5433:5432
     environment:
-      - MYSQL_DATABASE=appointment
-      - MYSQL_USER=tba
-      - MYSQL_PASSWORD=abcd%efgh
-      - MYSQL_RANDOM_ROOT_PASSWORD=true
+      - POSTGRES_DB=appointment
+      - POSTGRES_USER=tba
+      - POSTGRES_PASSWORD=abcd%efgh
+      - PGDATA=/var/lib/postgresql/data
     healthcheck:
-      test: mysqladmin ping -h 127.0.0.1 -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
-      start_period: 5s
+      test: ["CMD-SHELL", "pg_isready"]
       interval: 5s
       timeout: 5s
       retries: 55
+    shm_size: 128mb
 
   redis:
     image: redis/redis-stack

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,12 +19,12 @@ services:
       
       # The use of DATABASE_URL is problematic and deprecated
       # - DATABASE_URL=mysql+mysqldb://tba:abcd%efgh@mysql:3306/appointment
-      # - DATABASE_URL=postgresql+psycopg://tba:abcd%efgh@postgres:5432/appointment
+      # - DATABASE_URL=postgresql+psycopg://tba:abcd%efgh@postgresql:5432/appointment
       - IS_LOCAL_DEV=yes
       - RELEASE_VERSION=localdev
 
     depends_on:
-      postgres:
+      postgresql:
         condition: service_healthy
 
   frontend:
@@ -37,7 +37,7 @@ services:
     environment:
       - WATCHPACK_POLLING=true
 
-  postgres:
+  postgresql:
     image: postgres:17
     volumes:
       - apmt_db:/var/lib/postgresql/data

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ This are the general components, Thunderbird Appointment consists of.
 ```mermaid
 C4Component
 
-  ContainerDb(c4, "Database", "MySQL", "Subscribers, calendars,<br>appointments, attendees, ...")
+  ContainerDb(c4, "Database", "PostgreSQL", "Subscribers, calendars,<br>appointments, attendees, ...")
   Container(c1, "Frontend", "Vue3 / Tailwind", "Provides all Appointment<br>functionality to customers<br>via their web browser")
   Container_Boundary(b1, "Backend") {
     Component(c3, "Subscriber Area", "FastAPI, JWT auth", "Provides functionality related<br>to calendar connections,<br>appointments, general availability")
@@ -87,6 +87,7 @@ erDiagram
   CALENDARS {
     int id PK "Unique calendar key"
     int owner_id FK "Person who owns this calendar"
+    int external_connection_id FK "External connection for this calendar"
     enum provider "Calendar provider [Google, CalDAV]"
     string title "Calendar title to identify connection in lists"
     string color "Color to visually identify calendars"
@@ -147,7 +148,7 @@ erDiagram
     bool keep_open "If true appointment accepts selection of multiple slots (future feature)"
     enum status "Appointment state [draft, ready, close]"
     string meeting_link_provider "Name of the provider for meeting links (e.g. Zoom)"
-    uuid uuid "Binary field holding a universal unique identifier"
+    uuid uuid "Uuid field holding a universal unique identifier"
   }
   CALENDARS ||--|{ SCHEDULES : connected_to
   SCHEDULES {


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
- Changed adapter from `mysqldb` to `[psycopg](https://pypi.org/project/psycopg/)` (psycopg3)
- Updated `docker-compose.yml`
- Updated project architecture diagram with the recent DB changes
  - Added `external_connection_id` foreign key in `Calendars`
  - Changed `uuid` comment to be `Uuid` instead of `Binary`

Note: I did not update the `tofu` / `infra` yet so that it can be done alongside the Neon (?) integration

> [!WARNING]  
> It is necessary to delete all the container / volumes for this to work so you will lose all your data when testing this

To remove all your volumes, navigate to your `appointment` root folder and:
```bash
$ docker-compose down -v
```

## Benefits

<!-- What benefits will be realized by the code change? -->
- Hopefully a more seamless transition to Neon's Postgresql and having a local dev environment that will use the same DB backend as the other environments

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/855
https://github.com/thunderbird/appointment/issues/1067