### PR TITLE
Add copy link icon and email to navbar

### DIFF
--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -7,7 +7,8 @@ import UserAvatar from '@/elements/UserAvatar.vue';
 import DropDown from '@/elements/DropDown.vue';
 import NavBarItem from '@/elements/NavBarItem.vue';
 import TextButton from '@/elements/TextButton.vue';
-import LinkButton from '@/tbpro/elements/LinkButton.vue';
+import ToolTip from '@/tbpro/elements/ToolTip.vue';
+import { TooltipPosition } from '@/definitions';
 import { IconExternalLink, IconLink } from '@tabler/icons-vue';
 
 // component constants
@@ -85,10 +86,20 @@ const copyLink = async () => {
           :label="t(`label.${item}`)"
           :link-name="item"
         />
-        <div v-if="user.myLink" class="flex items-center justify-center pl-8 pr-12">
-          <link-button class="cursor-pointer" @click="copyLink" aria-labelledby="copy-meeting-link-button" :tooltip="myLinkTooltip">
+        <div v-if="user.myLink" class="flex items-center justify-center pl-8 pr-12 relative">
+          <button
+            class="cursor-pointer bg-transparent border-none font-semibold min-w-0 p-0 flex items-center relative group active:text-teal-500"
+            @click="copyLink"
+            aria-labelledby="copy-meeting-link-button"
+          >
             <icon-link id="copy-meeting-link-button"></icon-link>
-          </link-button>
+            <tool-tip
+              :position="TooltipPosition.Top"
+              class="absolute top-full left-1/2 transform -translate-x-1/2 mt-2 opacity-0 transition-opacity duration-250 ease-out group-hover:opacity-100 group-hover:pointer-events-auto whitespace-nowrap text-xs min-w-max"
+            >
+              {{ myLinkTooltip }}
+            </tool-tip>
+          </button>
         </div>
       </div>
 

--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -86,7 +86,7 @@ const copyLink = async () => {
           :label="t(`label.${item}`)"
           :link-name="item"
         />
-        <div v-if="user.myLink" class="flex items-center justify-center pl-8 pr-12 relative">
+        <div v-if="user.myLink" class="flex items-center justify-center px-4 relative">
           <button
             class="cursor-pointer bg-transparent border-none font-semibold min-w-0 p-0 flex items-center relative group active:text-teal-500"
             @click="copyLink"
@@ -105,7 +105,7 @@ const copyLink = async () => {
 
       <drop-down class="self-center" ref="profileDropdown">
         <template #trigger>
-          <div class="flex items-center gap-4 border rounded-md border-gray-300 px-3 py-1 bg-white">
+          <div class="flex items-center gap-4 border rounded-md border-gray-300 pl-3 pr-1 py-1 bg-white">
             <span class="text-sm text-gray-500">
               {{ user.data.email }}
             </span>

--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -7,7 +7,8 @@ import UserAvatar from '@/elements/UserAvatar.vue';
 import DropDown from '@/elements/DropDown.vue';
 import NavBarItem from '@/elements/NavBarItem.vue';
 import TextButton from '@/elements/TextButton.vue';
-import { IconExternalLink } from '@tabler/icons-vue';
+import LinkButton from '@/tbpro/elements/LinkButton.vue';
+import { IconExternalLink, IconLink } from '@tabler/icons-vue';
 
 // component constants
 const user = useUserStore();
@@ -21,6 +22,7 @@ interface Props {
 defineProps<Props>();
 
 const profileDropdown = ref();
+const myLinkTooltip = ref(t('label.copyLink'));
 
 /**
  * Is this nav entry active?
@@ -33,6 +35,18 @@ const isNavEntryActive = (item: string) => {
   }
   return route.name === item;
 };
+
+// Link copy
+const copyLink = async () => {
+  await navigator.clipboard.writeText(user.myLink);
+
+  myLinkTooltip.value = t('info.copiedToClipboard');
+
+  setTimeout(() => {
+    myLinkTooltip.value = t('label.copyLink');
+  }, 2000);
+};
+
 </script>
 
 <template>
@@ -71,10 +85,22 @@ const isNavEntryActive = (item: string) => {
           :label="t(`label.${item}`)"
           :link-name="item"
         />
+        <div v-if="user.myLink" class="flex items-center justify-center pl-8 pr-12">
+          <link-button class="cursor-pointer" @click="copyLink" aria-labelledby="copy-meeting-link-button" :tooltip="myLinkTooltip">
+            <icon-link id="copy-meeting-link-button"></icon-link>
+          </link-button>
+        </div>
       </div>
+
       <drop-down class="self-center" ref="profileDropdown">
         <template #trigger>
-          <user-avatar />
+          <div class="flex items-center gap-4 border rounded-md border-gray-300 px-3 py-1 bg-white">
+            <span class="text-sm text-gray-500">
+              {{ user.data.email }}
+            </span>
+
+            <user-avatar />
+          </div>
         </template>
         <template #default>
           <div

--- a/frontend/src/elements/UserAvatar.vue
+++ b/frontend/src/elements/UserAvatar.vue
@@ -7,7 +7,7 @@ const user = useUserStore();
 
 <template>
 <div
-  class="flex-center mr-4 size-12 self-center rounded-full bg-white text-lg font-normal text-white"
+  class="flex-center size-10 self-center rounded-full bg-white text-lg font-normal text-white"
   :class="{'!bg-teal-500': user.data.avatarUrl === null}"
   data-testid="user-menu-avatar"
 >

--- a/frontend/src/elements/UserAvatar.vue
+++ b/frontend/src/elements/UserAvatar.vue
@@ -7,7 +7,7 @@ const user = useUserStore();
 
 <template>
 <div
-  class="flex-center size-10 self-center rounded-full bg-white text-lg font-normal text-white"
+  class="flex-center size-8 self-center rounded-full bg-white text-sm font-semibold text-white"
   :class="{'!bg-teal-500': user.data.avatarUrl === null}"
   data-testid="user-menu-avatar"
 >


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the 
concepts. -->
As part of the UI overhaul, adding a copy link icon button and user email to the navbar per wireframes.

![Jul-08-2025 14-42-18](https://github.com/user-attachments/assets/ac4907ba-89aa-46ed-a0f5-2e707e66ad35)



## Benefits

<!-- What benefits will be realized by the code change? -->
Be able to copy the appointment link from anywhere is handy! Also, seeing the name of the account is more clear than just the initials on the user avatar.

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/1088