### PR TITLE
Lock Terraform AWS provider version

### DIFF
--- a/tofu/environments/prod/environment.hcl
+++ b/tofu/environments/prod/environment.hcl
@@ -17,7 +17,7 @@ generate "versions" {
       required_providers {
         aws = {
           source = "hashicorp/aws"
-          version = ">= 5.60.0"
+          version = "~> 5.60"
         }
         random = {
           source = "hashicorp/random"

--- a/tofu/environments/stage/environment.hcl
+++ b/tofu/environments/stage/environment.hcl
@@ -17,7 +17,7 @@ generate "versions" {
       required_providers {
         aws = {
           source = "hashicorp/aws"
-          version = ">= 5.60.0"
+          version = "~> 5.60"
         }
         random = {
           source = "hashicorp/random"


### PR DESCRIPTION
AWS released a new major version of their Terraform provider with a number of significant changes in it. Since we are replacing this Terraform code with Pulumi code, it's not worth it to do a full provider upgrade here. Instead, I'm replacing the [version constraint](https://developer.hashicorp.com/terraform/language/providers/requirements#version-constraints) with this `~=` constraint, which allows the rightmost semver digit to increment. This will prevent us from using the new major version while still getting the latest from the old major version.