### PR TITLE
Fix user avatar image styling + remove Tailwind classes

### DIFF
--- a/frontend/src/elements/UserAvatar.vue
+++ b/frontend/src/elements/UserAvatar.vue
@@ -7,15 +7,39 @@ const user = useUserStore();
 
 <template>
 <div
-  class="flex-center size-8 self-center rounded-full bg-white text-sm font-semibold text-white"
-  :class="{'!bg-teal-500': user.data.avatarUrl === null}"
+  class="user-avatar"
+  :class="{'user-avatar--fallback': user.data.avatarUrl === null}"
   data-testid="user-menu-avatar"
 >
   <span v-if="user.data.avatarUrl === null">
     {{ initials(user.data.name) }}
   </span>
   <span v-else>
-    <img class="size-[48px] rounded-full" :alt="initials(user.data.name)" :src="user.data.avatarUrl"/>
+    <img class="user-avatar__image" :alt="initials(user.data.name)" :src="user.data.avatarUrl"/>
   </span>
 </div>
 </template>
+
+<style scoped>
+.user-avatar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  align-self: center;
+  border-radius: 50%;
+  background-color: var(--colour-neutral-base);
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--colour-neutral-base);
+}
+
+.user-avatar--fallback {
+  background-color: var(--colour-accent-teal);
+}
+
+.user-avatar__image {
+  border-radius: 50%;
+}
+</style>


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
There as a forced height on the user avatar image that was causing distortions. This PR now removes the forced height in favor of its container's.

It also moves the `UserAvatar` component away from Tailwind-specific classes as we transition over to vanilla CSS. Note that we were using the `teal` color from Tailwind and our shade of teal in the CSS variables is slightly different.

Before:
![image](https://github.com/user-attachments/assets/3d035952-914e-42c3-ac90-b58e7373a2f2)


![image](https://github.com/user-attachments/assets/7409422a-7db7-4962-a0e4-3d23ececfc0e)



After:
![image](https://github.com/user-attachments/assets/70fc78fa-8d71-40a1-a501-f4b6c15b9611)

![image](https://github.com/user-attachments/assets/05e6c554-63e0-43bd-ba40-4c87b1d59be0)


## Benefits

<!-- What benefits will be realized by the code change? -->
No more image distortions + one component at a time to help the Tailwind -> vanilla CSS transition

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/1088