### PR TITLE
Fix backend's base URL paths for Mailpit & Fluent

### DIFF
--- a/backend/src/appointment/controller/mailer.py
+++ b/backend/src/appointment/controller/mailer.py
@@ -7,6 +7,7 @@ import logging
 import os
 import smtplib
 import ssl
+import sys
 from email.message import EmailMessage
 
 import jinja2
@@ -18,9 +19,11 @@ from fastapi.templating import Jinja2Templates
 
 from ..l10n import l10n
 
+# Resolves to absolute appointment package path
+BASE_PATH = f'{sys.modules["appointment"].__path__[0]}'
 
 def get_jinja():
-    path = 'src/appointment/templates/email'
+    path = f'{BASE_PATH}/templates/email'
 
     templates = Jinja2Templates(path)
     # Add our l10n function
@@ -80,7 +83,7 @@ class Mailer:
 
     def _attachments(self):
         """provide all attachments as list, add tbpro logo to every mail"""
-        with open('src/appointment/templates/assets/img/tbpro_logo.png', 'rb') as fh:
+        with open(f'{BASE_PATH}/templates/assets/img/tbpro_logo.png', 'rb') as fh:
             tbpro_logo = fh.read()
 
         return [
@@ -207,7 +210,7 @@ class BaseBookingMail(Mailer):
 
     def _attachments(self):
         """We need these little icons for the message body"""
-        path = 'src/appointment/templates/assets/img/icons'
+        path = f'{BASE_PATH}/templates/assets/img/icons'
 
         with open(f'{path}/calendar.png', 'rb') as fh:
             calendar_icon = fh.read()

--- a/backend/src/appointment/controller/mailer.py
+++ b/backend/src/appointment/controller/mailer.py
@@ -7,7 +7,6 @@ import logging
 import os
 import smtplib
 import ssl
-import sys
 from email.message import EmailMessage
 
 import jinja2
@@ -17,13 +16,12 @@ import validators
 from html import escape
 from fastapi.templating import Jinja2Templates
 
+from ..defines import BASE_PATH
 from ..l10n import l10n
 
-# Resolves to absolute appointment package path
-BASE_PATH = f'{sys.modules["appointment"].__path__[0]}'
 
 def get_jinja():
-    path = f'{BASE_PATH}/templates/email'
+    path = os.path.join(BASE_PATH, 'templates/email')
 
     templates = Jinja2Templates(path)
     # Add our l10n function
@@ -83,7 +81,9 @@ class Mailer:
 
     def _attachments(self):
         """provide all attachments as list, add tbpro logo to every mail"""
-        with open(f'{BASE_PATH}/templates/assets/img/tbpro_logo.png', 'rb') as fh:
+        path = os.path.join(BASE_PATH, 'templates/assets/img/tbpro_logo.png')
+
+        with open(path, 'rb') as fh:
             tbpro_logo = fh.read()
 
         return [
@@ -210,7 +210,7 @@ class BaseBookingMail(Mailer):
 
     def _attachments(self):
         """We need these little icons for the message body"""
-        path = f'{BASE_PATH}/templates/assets/img/icons'
+        path = os.path.join(BASE_PATH, 'templates/assets/img/icons')
 
         with open(f'{path}/calendar.png', 'rb') as fh:
             calendar_icon = fh.read()

--- a/backend/src/appointment/defines.py
+++ b/backend/src/appointment/defines.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from enum import StrEnum
 
 SUPPORTED_LOCALES = ['en', 'de']
@@ -30,6 +31,8 @@ DEFAULT_CALENDAR_COLOUR = '#c276c5'
 # List of Google CalDAV domains
 GOOGLE_CALDAV_DOMAINS = ['googleusercontent.com', 'google.com', 'gmail.com']
 
+# Resolves to absolute appointment package path
+BASE_PATH = f'{sys.modules["appointment"].__path__[0]}'
 
 class AuthScheme(StrEnum):
     """Enum for authentication scheme"""

--- a/backend/src/appointment/middleware/l10n.py
+++ b/backend/src/appointment/middleware/l10n.py
@@ -1,3 +1,5 @@
+import sys
+
 from starlette_context.plugins import Plugin
 from fastapi import Request
 from fluent.runtime import FluentLocalization, FluentResourceLoader
@@ -12,7 +14,8 @@ def get_fluent(locales: list[str]):
     if FALLBACK_LOCALE not in locales:
         locales.append(FALLBACK_LOCALE)
 
-    base_url = 'src/appointment/l10n'
+    # Resolves to absolute appointment package path
+    base_url = f'{sys.modules["appointment"].__path__[0]}/l10n'
 
     loader = FluentResourceLoader(f'{base_url}/{{locale}}')
     fluent = FluentLocalization(locales, ['main.ftl', 'email.ftl', 'fields.ftl'], loader)

--- a/backend/src/appointment/middleware/l10n.py
+++ b/backend/src/appointment/middleware/l10n.py
@@ -1,10 +1,9 @@
-import sys
-
+from os import path
 from starlette_context.plugins import Plugin
 from fastapi import Request
 from fluent.runtime import FluentLocalization, FluentResourceLoader
 
-from ..defines import SUPPORTED_LOCALES, FALLBACK_LOCALE
+from ..defines import SUPPORTED_LOCALES, FALLBACK_LOCALE, BASE_PATH
 
 
 def get_fluent(locales: list[str]):
@@ -15,7 +14,7 @@ def get_fluent(locales: list[str]):
         locales.append(FALLBACK_LOCALE)
 
     # Resolves to absolute appointment package path
-    base_url = f'{sys.modules["appointment"].__path__[0]}/l10n'
+    base_url = path.join(BASE_PATH, 'l10n')
 
     loader = FluentResourceLoader(f'{base_url}/{{locale}}')
     fluent = FluentLocalization(locales, ['main.ftl', 'email.ftl', 'fields.ftl'], loader)


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
Although the backend service works well, when mail templates are referenced, they fail to resolve correctly as the copy from the Dockerfile says `COPY src .` and the expected path for Mailpit Jinja templates is `src/appointment/templates/email`.

We could either do the change back from the Dockerfile _or_ change the [`get_jinja()` function from the mailer](https://github.com/thunderbird/appointment/blob/main/backend/src/appointment/controller/mailer.py#L23) and [`get_fluent()` function from the I10n](https://github.com/thunderbird/appointment/blob/main/backend/src/appointment/middleware/l10n.py#L15) and potentially other places that I might be missing.

~~For brevity, changing the Dockerfile back makes it work it again locally but unsure if this breaks other parts of the infra.~~

As @MelissaAutumn suggested, let's go with changing the base paths to be `sys.modules["appointment"].__path__[0]`

## Benefits

<!-- What benefits will be realized by the code change? -->
Emails & I18n work again!

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/pull/1079