### PR TITLE
Lock random package so it doesn't depend on newer aws package

### DIFF
--- a/tofu/environments/prod/environment.hcl
+++ b/tofu/environments/prod/environment.hcl
@@ -21,7 +21,7 @@ generate "versions" {
         }
         random = {
           source = "hashicorp/random"
-          version = ">= 3.6.1"
+          version = "~> 3.6"
         }
       }
     }

--- a/tofu/environments/stage/environment.hcl
+++ b/tofu/environments/stage/environment.hcl
@@ -21,7 +21,7 @@ generate "versions" {
         }
         random = {
           source = "hashicorp/random"
-          version = ">= 3.6.1"
+          version = "~> 3.6"
         }
       }
     }


### PR DESCRIPTION
I think this should push along the Tofu deployments.