### PR TITLE
Fix the version number so the operator works right

### DIFF
--- a/tofu/environments/prod/environment.hcl
+++ b/tofu/environments/prod/environment.hcl
@@ -21,7 +21,7 @@ generate "versions" {
         }
         random = {
           source = "hashicorp/random"
-          version = "~> 3.6"
+          version = "~> 3.6.1"
         }
       }
     }

--- a/tofu/environments/prod/environment.hcl
+++ b/tofu/environments/prod/environment.hcl
@@ -21,7 +21,7 @@ generate "versions" {
         }
         random = {
           source = "hashicorp/random"
-          version = ">= 3.6.1"
+          version = "~> 3.6"
         }
       }
     }

--- a/tofu/environments/stage/environment.hcl
+++ b/tofu/environments/stage/environment.hcl
@@ -21,7 +21,7 @@ generate "versions" {
         }
         random = {
           source = "hashicorp/random"
-          version = "~> 3.6"
+          version = "~> 3.6.1"
         }
       }
     }

--- a/tofu/environments/stage/environment.hcl
+++ b/tofu/environments/stage/environment.hcl
@@ -21,7 +21,7 @@ generate "versions" {
         }
         random = {
           source = "hashicorp/random"
-          version = ">= 3.6.1"
+          version = "~> 3.6"
         }
       }
     }


### PR DESCRIPTION
We need to keep this below 3.7, so we have to have a third digit here. Without this, the `~>` operator still allows upgrading to 3.7 and onward.