### PR TITLE
Move Pulumi build to separate job

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -250,6 +250,15 @@ jobs:
           name: ecr_tag
           path: ecr_tag.zip
 
+  build-backend-image-pulumi:
+    needs:
+      - detect-changes
+    environment: staging
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
       - name: Configure AWS credentials (Pulumi)
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -257,18 +266,28 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_PULUMI }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_PULUMI }}
 
-      - name: Tag image for ECR repo (Pulumi)
-        env:
-          OLD_ECR_TAG: '${{ steps.build-backend.outputs.image_backend }}'
-          NEW_ECR_TAG: '${{ steps.login-ecr.outputs.registry }}/thunderbird/appointment:${{ github.sha }}'
-        run: |
-          docker tag $OLD_ECR_TAG $NEW_ECR_TAG
-          docker push $NEW_ECR_TAG
-          echo "new_ecr_tag=$NEW_ECR_TAG" >> $GITHUB_OUTPUT
-          echo $NEW_ECR_TAG > new_ecr_tag.txt
-          zip new_ecr_tag.zip new_ecr_tag.txt
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          mask-password: 'true'
 
-      - name: Archive ECR tag (Pulumi)
+      - name: Build, tag, and push backend image to Amazon ECR
+        id: build-backend
+        env:
+          ECR_TAG: '${{ steps.login-ecr.outputs.registry }}/thunderbird/appointment:${{ github.sha }}'
+          RELEASE_VERSION: ${{ github.sha }}
+        run: |
+          # Build a docker container and
+          # push it to ECR so that it can
+          # be deployed to ECS.
+          docker build --build-arg "RELEASE_VERSION=$RELEASE_VERSION" -t $ECR_TAG ./backend -f ./backend/Dockerfile
+          docker push $ECR_TAG
+          echo "image_backend=$ECR_TAG" >> $GITHUB_OUTPUT
+          echo $ECR_TAG > ecr_tag.txt
+          zip ecr_tag.zip ecr_tag.txt
+
+      - name: Archive ECR tag
         uses: actions/upload-artifact@v4
         with:
           name: new_ecr_tag

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -212,6 +212,7 @@ jobs:
       - detect-changes
     environment: staging
     runs-on: ubuntu-latest
+    if: needs.detect-changes.outputs.deploy-backend == 'true'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The problem solved here is that the second setting of AWS credentials fails to swap the new session out for the old one. So here we separate the Pulumi env image build into its own job context.