### PR TITLE
[WIP] Bookings page UI overhaul - Part 2 (Filters on URL + declined / cancelled BookingStatus)

### DIFF
--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -971,6 +971,10 @@ class Tools:
 
         # handle already requested time slots
         for slot in schedule.slots:
+            # don't consider declined or cancelled slots as taken
+            if slot.booking_status == BookingStatus.declined or slot.booking_status == BookingStatus.cancelled:
+                continue
+
             existing_events.append(
                 schemas.Event(
                     title=schedule.name,

--- a/backend/src/appointment/database/models.py
+++ b/backend/src/appointment/database/models.py
@@ -44,6 +44,8 @@ class BookingStatus(enum.Enum):
     none = 1  # slot status doesn't matter, because the parent object holds the state
     requested = 2  # booking slot was requested
     booked = 3  # booking slot was assigned
+    declined = 4 # booking slot was declined
+    cancelled = 5 # booking slot was cancelled
 
 
 class LocationType(enum.Enum):

--- a/backend/src/appointment/migrations/versions/2023_10_19_1535-2b1d96fb4058_extend_slots_table_for_.py
+++ b/backend/src/appointment/migrations/versions/2023_10_19_1535-2b1d96fb4058_extend_slots_table_for_.py
@@ -12,7 +12,6 @@ import sqlalchemy as sa
 from sqlalchemy import DateTime
 from sqlalchemy_utils import StringEncryptedType
 from sqlalchemy_utils.types.encrypted.encrypted_type import AesEngine
-from database.models import BookingStatus
 
 
 def secret():
@@ -33,7 +32,7 @@ def upgrade() -> None:
         sa.Column('booking_tkn', StringEncryptedType(sa.String, secret, AesEngine, 'pkcs5', length=512), index=False),
     )
     op.add_column('slots', sa.Column('booking_expires_at', DateTime()))
-    op.add_column('slots', sa.Column('booking_status', sa.Enum(BookingStatus), default=BookingStatus.none))
+    op.add_column('slots', sa.Column('booking_status', sa.Enum('none', 'requested', 'booked'), default='none'))
 
 
 def downgrade() -> None:

--- a/backend/src/appointment/migrations/versions/2025_07_17_1924-b2f516cb40cc_update_booking_status_enum_.py
+++ b/backend/src/appointment/migrations/versions/2025_07_17_1924-b2f516cb40cc_update_booking_status_enum_.py
@@ -1,0 +1,30 @@
+"""update booking status enum values
+
+Revision ID: b2f516cb40cc
+Revises: fb27de54e731
+Create Date: 2025-07-17 19:24:54.607556
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b2f516cb40cc'
+down_revision = 'fb27de54e731'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column('slots', 'booking_status',
+               existing_type=sa.Enum('none', 'requested', 'booked'),
+               type_=sa.Enum('none', 'requested', 'booked', 'declined', 'cancelled'),
+               existing_nullable=True)
+
+
+def downgrade() -> None:
+     op.alter_column('slots', 'booking_status',
+               existing_type=sa.Enum('none', 'requested', 'booked', 'declined', 'cancelled'),
+               type_=sa.Enum('none', 'requested', 'booked'),
+               existing_nullable=True)

--- a/backend/src/appointment/routes/api.py
+++ b/backend/src/appointment/routes/api.py
@@ -469,6 +469,9 @@ def cancel_my_appointment(
                 zoom_client.delete_meeting(slot.meeting_link_id)
             except Exception as ex:
                 sentry_sdk.capture_exception(ex)
+        
+        # Mark the slot as BookingStatus.cancelled
+        repo.slot.cancel(db, slot.id)
 
     # Delete the remote calendar event
     uuid = appointment.external_id if appointment.external_id else str(appointment.uuid)
@@ -477,9 +480,6 @@ def cancel_my_appointment(
         remote_calendar_connection.delete_event(uid=uuid)
     except EventNotDeletedException:            
         raise EventCouldNotBeDeleted
-
-    # Delete the appointment, this will also delete the slot
-    repo.appointment.delete(db, appointment.id)
 
 
 @router.post('/support')

--- a/backend/src/appointment/routes/schedule.py
+++ b/backend/src/appointment/routes/schedule.py
@@ -520,14 +520,9 @@ def handle_schedule_availability_decision(
     if confirmed is False:
         # send rejection information to bookee
         Tools().send_reject_vevent(background_tasks, appointment, slot, subscriber, slot.attendee)
-        repo.slot.delete(db, slot.id)
 
-        if slot.appointment_id:
-            # delete the appointment, this will also delete the slot.
-            repo.appointment.delete(db, slot.appointment_id)
-        else:
-            # delete the scheduled slot to make the time available again
-            repo.slot.delete(db, slot.id)
+        # mark the slot as BookingStatus.declined
+        repo.slot.reject(db, slot.id)
 
         # Delete remote HOLD event if existing
         if appointment:

--- a/frontend/src/composables/useQueryParamState.ts
+++ b/frontend/src/composables/useQueryParamState.ts
@@ -1,0 +1,43 @@
+import { computed, onMounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+
+/*
+*  For using queryParams as state. It uses the standard
+*  format of ?paramName=value and supports arrays too. Ex: 
+*
+*   URL:
+*     ?filters=a&filters=b 
+*   Code:
+*     const selectedFilters = useQueryParamState('filters')
+*     selectedFilters.value = ['a', 'b']
+*/
+export function useQueryParamState(paramName: string, defaultValue: string[] = []) {
+  const route = useRoute();
+  const router = useRouter();
+
+  const param = computed({
+    get() {
+      const value = route.query[paramName];
+      return Array.isArray(value) ? value : value ? [value] : [];
+    },
+    set(newValue: string[]) {
+      router.replace({
+        query: {
+          ...route.query,
+          [paramName]: newValue.length ? newValue : undefined
+        }
+      })
+    }
+  });
+
+  // Initializes / auto-adds queryParams if passed in defaultValue 
+  onMounted(() => {
+    const hasParam = param.value.length > 0;
+
+    if (!hasParam && defaultValue.length > 0) {
+      param.value = defaultValue;
+    }
+  });
+
+  return param;
+}

--- a/frontend/src/composables/useQueryParamState.ts
+++ b/frontend/src/composables/useQueryParamState.ts
@@ -8,33 +8,75 @@ import { useRoute, useRouter } from 'vue-router';
 *   URL:
 *     ?filters=a&filters=b 
 *   Code:
-*     const selectedFilters = useQueryParamState('filters')
-*     selectedFilters.value = ['a', 'b']
+*     const selectedFilters = useQueryParamState('filters', ['pending', 'confirmed'])
+*     selectedFilters.value = ['pending', 'confirmed']
+*
 */
-export function useQueryParamState(paramName: string, defaultValue: string[] = []) {
+
+type QueryPrimitive = string | number | boolean;
+type QueryValue = QueryPrimitive | QueryPrimitive[];
+
+export function useQueryParamState<T extends QueryValue>(
+  paramName: string,
+  defaultValue: T
+) {
   const route = useRoute();
   const router = useRouter();
 
-  const param = computed({
+  const isArray = Array.isArray(defaultValue);
+
+  function parseValue(v: string): QueryPrimitive {
+    if (typeof defaultValue === 'boolean') {
+      return v === 'true';
+    }
+
+    if (typeof defaultValue === 'number' || (isArray && typeof defaultValue[0] === 'number')) {
+      const num = Number(v);
+      return isNaN(num) ? 0 : num;
+    }
+
+    return v;
+  }
+
+  const param = computed<T>({
     get() {
-      const value = route.query[paramName];
-      return Array.isArray(value) ? value : value ? [value] : [];
+      const raw = route.query[paramName];
+
+      if (isArray) {
+        const rawArray = Array.isArray(raw) ? raw : raw ? [raw] : [];
+        return rawArray.map((v) => parseValue(v)) as T;
+      } else {
+        const single = Array.isArray(raw) ? raw[0] : raw;
+        return single !== undefined ? (parseValue(single) as T) : defaultValue;
+      }
     },
-    set(newValue: string[]) {
+    set(newValue: T) {
+      const stringify = (v: QueryPrimitive) => String(v);
+
+      const value = isArray
+        ? (newValue as QueryPrimitive[]).length
+          ? (newValue as QueryPrimitive[]).map(stringify)
+          : undefined
+        : newValue !== undefined && newValue !== null
+          ? stringify(newValue as QueryPrimitive)
+          : undefined;
+
       router.replace({
         query: {
           ...route.query,
-          [paramName]: newValue.length ? newValue : undefined
-        }
-      })
-    }
+          [paramName]: value,
+        },
+      });
+    },
   });
 
-  // Initializes / auto-adds queryParams if passed in defaultValue 
   onMounted(() => {
-    const hasParam = param.value.length > 0;
+    const current = param.value;
 
-    if (!hasParam && defaultValue.length > 0) {
+    if (
+      (isArray && (current as QueryPrimitive[]).length === 0) ||
+      (!isArray && current === undefined)
+    ) {
       param.value = defaultValue;
     }
   });

--- a/frontend/src/definitions.ts
+++ b/frontend/src/definitions.ts
@@ -72,6 +72,19 @@ export enum BookingStatus {
   None = 1,
   Requested = 2,
   Booked = 3,
+  Declined = 4,
+  Cancelled = 5
+}
+
+/**
+ * Booking status for filter query params. Don't i18n
+ */
+export enum BookingStatusFilterQueryParams {
+  None = 'none',
+  Requested = 'pending',
+  Booked = 'confirmed',
+  Declined = 'declined',
+  Cancelled = 'cancelled'
 }
 
 /**

--- a/frontend/src/views/BookingsView/components/AppointmentMultiSelectFilter.vue
+++ b/frontend/src/views/BookingsView/components/AppointmentMultiSelectFilter.vue
@@ -93,7 +93,8 @@ const displayText = computed(() => {
 */
 watch(
   () => props.selected,
-  () => initializeCheckboxStates()
+  () => initializeCheckboxStates(),
+  { immediate: true }
 )
 </script>
 

--- a/frontend/src/views/BookingsView/constants.ts
+++ b/frontend/src/views/BookingsView/constants.ts
@@ -1,0 +1,15 @@
+import { BookingStatus, BookingStatusFilterQueryParams } from '@/definitions'
+
+export const BOOKING_STATUS_TO_FILTER_QUERY_PARAM = {
+  [BookingStatus.Requested]: BookingStatusFilterQueryParams.Requested,
+  [BookingStatus.Booked]: BookingStatusFilterQueryParams.Booked,
+  [BookingStatus.Declined]: BookingStatusFilterQueryParams.Declined,
+  [BookingStatus.Cancelled]: BookingStatusFilterQueryParams.Cancelled,
+}
+
+export const FILTER_QUERY_PARAM_TO_BOOKING_STATUS = {
+  [BookingStatusFilterQueryParams.Requested]: BookingStatus.Requested,
+  [BookingStatusFilterQueryParams.Booked]: BookingStatus.Booked,
+  [BookingStatusFilterQueryParams.Declined]: BookingStatus.Declined,
+  [BookingStatusFilterQueryParams.Cancelled]: BookingStatus.Cancelled,
+}

--- a/frontend/src/views/BookingsView/index.vue
+++ b/frontend/src/views/BookingsView/index.vue
@@ -35,7 +35,7 @@ const selectedFilters = useQueryParamState(
 );
 
 // Handle sorting by unconfirmed first
-const unconfirmedFirst = ref(false);
+const unconfirmedFirst = useQueryParamState<boolean>('unconfirmed', false);
 
 // Handle table column sorting
 type TableColumn = 'date' | 'title' | 'calendar';

--- a/frontend/src/views/BookingsView/index.vue
+++ b/frontend/src/views/BookingsView/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, inject, computed, onMounted } from 'vue';
+import { ref, inject, computed, onMounted, nextTick } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 import { storeToRefs } from 'pinia';
@@ -128,16 +128,24 @@ const getSortIndicator = (column: string) => {
 // handle single appointment modal
 const selectedAppointment = ref(null);
 
-const showAppointmentSlidingPanel = (appointment) => {
+const showAppointmentSlidingPanel = async (appointment) => {
   selectedAppointment.value = appointment;
   appointmentSlidingPanelRef.value?.showPanel()
-  router.replace(`/bookings/${appointment.slug}`);
+
+  router.replace({
+    name: 'bookings',
+    params: { slug: appointment.slug },
+    query: route.query
+  });
 };
 
 const handleCloseAppointmentSlidingPanel = () => {
   selectedAppointment.value = null;
-  // Shuffle them back to the appointments route.
-  router.replace('/bookings');
+
+  router.replace({
+    path: '/bookings',
+    query: route.query
+  });
 };
 
 const ariaSortForColumn = (column: TableColumn) => {
@@ -261,7 +269,11 @@ export default {
             <td class="table-cell">
               <!-- Hidden link spanning the whole table row -->
               <router-link
-                :to="`/bookings/${appointment.slug}`"
+                :to="{
+                  name: 'bookings',
+                  params: { slug: appointment.slug },
+                  query: route.query
+                }"
                 class="absolute inset-0 z-10 opacity-0"
                 aria-label="Open appointment in new tab"
               ></router-link>


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
- Added a `useQueryParamState` composable so that we can sync query params to a piece of reactive state. Now the dropdown filters are tracked on the URL alongside the `unconfirmed` checkbox as well.
- Added `cancelled` and `declined` to the `BookingStatus` enum both in the backend and in the frontend. In the frontend specifically, I had to create some conversions between the number <-> query param (which is not i18n intentionally as it is only in the URL).
- Appointments and slots are not deleted anymore, upon schedule request and showing availability we are now ignoring the slots that have the booking status mentioned above.

## Benefits

<!-- What benefits will be realized by the code change? -->
- Keeping the state as queryParams allow the user to do a page refresh and keep the table filtered
- Not deleting the appointment / slot allows us to have a tracking history of previously denied or cancelled appointments

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/1095