### PR TITLE
Transfer Pulumi IaC into release env

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -275,6 +275,12 @@ jobs:
           version: ${{ github.event.release.id }}
           file: new_ecr_tag.txt
       
+      - name: Download Pulumi IaC artifact
+        uses: dsaltares/fetch-gh-release-asset@master
+        with:
+          version: ${{ github.event.release.id }}
+          file: pulumi.tbz
+      
       - name: Extract ECR tag from artifact
         id: pulumi-tag-extract
         run: |
@@ -310,7 +316,7 @@ jobs:
         shell: bash
         # source ./venv/bin/activate
         run: |
-          cd pulumi
+          tar -xvf pulumi.tbz
           curl -fsSL https://get.pulumi.com | sh
 
       - name: Deploy to prod

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - fix-releases
 
 permissions:
   id-token: write # required for OIDC connectiong to AWS
@@ -33,7 +32,6 @@ jobs:
               - 'tofu/modules/**'
               - 'tofu/environments/stage/**'
               - '.github/workflows/deploy-staging.yml'
-              # TODO: Remove prod listings from here
               - '.github/workflows/deploy-production.yml'
             deploy-backend:
               - 'backend/**'
@@ -528,6 +526,16 @@ jobs:
       - name: Zip IaC
         run: zip -r iac.zip tofu -x "tofu/environments/stage/*" "tofu/environments/prod/*/*/.terragrunt-cache/*"
 
+      - name: Zip Pulumi
+        run: |
+          # Remove any lingering build pieces that may exist
+          pushd pulumi
+          rm -rf appointment_pulumi.egg-info build __pycache__ .ruff_cache venv
+          popd
+
+          # Tarbizz the Pulumi IaC
+          tar -cvjf pulumi.tbz pulumi/
+
       - name: Create release tag
         id: create-release-tag
         run: echo "tag_name=r-$(printf %04d $GITHUB_RUN_NUMBER)" >> $GITHUB_OUTPUT
@@ -552,6 +560,7 @@ jobs:
             frontend.zip
             pulumifrontend.zip
             iac.zip
+            pulumi.tbz
 
   e2e-tests-browserstack-stage:
     name: e2e-tests-browserstack-stage


### PR DESCRIPTION
The deploy steps are failing because we are not bringing the Pulumi code into the workflow environment we're running the deploy out of.