### PR TITLE
Job deps

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -9,7 +9,7 @@ on:
     types: [published]
 
 permissions:
-  id-token: write # required for OIDC connectiong to AWS
+  id-token: write # required for OIDC connecting to AWS
   contents: read
 
 jobs:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -156,11 +156,6 @@ jobs:
           aws cloudfront create-invalidation --distribution-id ${{ steps.get-frontend-resources.outputs.distribution }} --paths "/*"
       
   build-and-deploy-stage-frontend-pulumi:
-    needs:
-      - deploy-stage-iac
-    if: |
-      always() &&
-      (needs.deploy-stage-iac.result == 'success' || needs.deploy-stage-iac.result == 'skipped')
     environment: staging
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -10,45 +10,11 @@ on:
       - main
 
 permissions:
-  id-token: write # required for OIDC connectiong to AWS
+  id-token: write # required for OIDC connecting to AWS
   contents: write # This is required to create a release
 
 jobs:
-  detect-changes:
-    runs-on: ubuntu-latest
-    environment: staging
-    outputs:
-      deploy-iac: ${{ steps.check.outputs.deploy-iac }}
-      deploy-backend: ${{ steps.check.outputs.deploy-backend }}
-      deploy-frontend: ${{ steps.check.outputs.deploy-frontend }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dorny/paths-filter@v3
-        id: check
-        with:
-          filters: |
-            deploy-iac:
-              - 'tofu/modules/**'
-              - 'tofu/environments/stage/**'
-              - '.github/workflows/deploy-staging.yml'
-              - '.github/workflows/deploy-production.yml'
-            deploy-backend:
-              - 'backend/**'
-              - 'tofu/modules/services/backend-service/**'
-              - 'tofu/environments/stage/services/backend-service/**'
-              - '.github/workflows/deploy-staging.yml'
-              - '.github/workflows/deploy-production.yml'
-            deploy-frontend:
-              - 'frontend/**'
-              - 'tofu/modules/services/frontend-infra/**'
-              - 'tofu/environments/stage/services/frontend-infra/**'
-              - '.github/workflows/deploy-staging.yml'
-              - '.github/workflows/deploy-production.yml'
-
   deploy-stage-iac:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.deploy-iac == 'true'
     environment: staging
     runs-on: ubuntu-latest
     env:
@@ -122,12 +88,10 @@ jobs:
 
   build-and-deploy-stage-frontend:
     needs:
-      - detect-changes
       - deploy-stage-iac
     if: |
       always() &&
-      (needs.deploy-stage-iac.result == 'success' || needs.deploy-stage-iac.result == 'skipped') &&
-      needs.detect-changes.outputs.deploy-frontend == 'true'
+      (needs.deploy-stage-iac.result == 'success' || needs.deploy-stage-iac.result == 'skipped')
     environment: staging
     runs-on: ubuntu-latest
     env:
@@ -193,12 +157,10 @@ jobs:
       
   build-and-deploy-stage-frontend-pulumi:
     needs:
-      - detect-changes
       - deploy-stage-iac
     if: |
       always() &&
-      (needs.deploy-stage-iac.result == 'success' || needs.deploy-stage-iac.result == 'skipped') &&
-      needs.detect-changes.outputs.deploy-frontend == 'true'
+      (needs.deploy-stage-iac.result == 'success' || needs.deploy-stage-iac.result == 'skipped')
     environment: staging
     runs-on: ubuntu-latest
     steps:
@@ -231,12 +193,8 @@ jobs:
           aws cloudfront create-invalidation --distribution-id ${{ secrets.FRONTEND_CF_DISTRO_ID }} --paths '/*'
 
   build-backend-image:
-    needs:
-      - detect-changes
     environment: staging
     runs-on: ubuntu-latest
-    if: needs.detect-changes.outputs.deploy-backend == 'true'
-
     steps:
       - uses: actions/checkout@v4
 
@@ -274,11 +232,8 @@ jobs:
           path: ecr_tag.txt
 
   build-backend-image-pulumi:
-    needs:
-      - detect-changes
     environment: staging
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
 
@@ -318,12 +273,10 @@ jobs:
   deploy-stage-backend:
     needs:
       - build-backend-image
-      - detect-changes
       - deploy-stage-iac
     if: |
       always() &&
-      (needs.deploy-stage-iac.result == 'success' || needs.deploy-stage-iac.result == 'skipped') &&
-      needs.detect-changes.outputs.deploy-backend == 'true'
+      (needs.deploy-stage-iac.result == 'success' || needs.deploy-stage-iac.result == 'skipped')
     environment: staging
     runs-on: ubuntu-latest
     env:
@@ -388,10 +341,6 @@ jobs:
   deploy-stage-backend-pulumi:
     needs:
       - build-backend-image-pulumi
-      - detect-changes
-    if: |
-      always() &&
-      needs.detect-changes.outputs.deploy-backend == 'true'
     environment: staging
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The thinking here is that the production deployment steps require a whole bunch of artifacts to be present in order to succeed. The stage deployment steps end (when they are successful) with a `create-release` step that gathers the artifacts necessary for a prod release to succeed. Because we need all of these artifacts to be built, we cannot do itemized builds on merge where only certain artifacts get prepared.

So this PR removes the entire `detect-changes` step and every dependency other steps have on it. In this way, the only thing that would prevent a release is if something went wrong during this merge process.