### PR TITLE
Add tb_pulumi.ec2 import

### DIFF
--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -4,6 +4,7 @@ import cloudfront
 import pulumi
 import tb_pulumi
 import tb_pulumi.ci
+import tb_pulumi.ec2
 import tb_pulumi.cloudwatch
 import tb_pulumi.network
 import tb_pulumi.secrets


### PR DESCRIPTION
This only pops up if you try to build a bastion. I tried that today and got a missing import error that this change fixes.