### PR TITLE
Fix General Availability SwitchToggles

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "@sentry/vue": "^9.10.1",
         "@tabler/icons-vue": "^3.7.0",
         "@tailwindcss/forms": "^0.5.3",
-        "@thunderbirdops/services-ui": "^0.6.18",
+        "@thunderbirdops/services-ui": "^0.6.20",
         "@types/ua-parser-js": "^0.7.39",
         "@vitejs/plugin-vue": "^6.0.1",
         "@vueuse/components": "^13.0.0",
@@ -2383,9 +2383,9 @@
       }
     },
     "node_modules/@thunderbirdops/services-ui": {
-      "version": "0.6.19",
-      "resolved": "https://registry.npmjs.org/@thunderbirdops/services-ui/-/services-ui-0.6.19.tgz",
-      "integrity": "sha512-totaTlMK/k9j40PxylPR52eTw8Kuqfw3UsJnZBu8cNJxi4bHmzna3Ru56a+wHenHorldZxVZCG2dEH8qCjj0Ew==",
+      "version": "0.6.20",
+      "resolved": "https://registry.npmjs.org/@thunderbirdops/services-ui/-/services-ui-0.6.20.tgz",
+      "integrity": "sha512-304qsfTP++FWxf+y8XpLnbGBTWj5YNB4JU6hkQsRzbPH6ya7VzLMG6U+y8yLUyEPJWnr/oG1bS8jTQBVnzW62Q==",
       "license": "MPL-2.0",
       "dependencies": {
         "vue": "^3.4.29",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "@sentry/vue": "^9.10.1",
     "@tabler/icons-vue": "^3.7.0",
     "@tailwindcss/forms": "^0.5.3",
-    "@thunderbirdops/services-ui": "^0.6.18",
+    "@thunderbirdops/services-ui": "^0.6.20",
     "@types/ua-parser-js": "^0.7.39",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vueuse/components": "^13.0.0",

--- a/frontend/src/views/AvailabilityView/components/ScheduleCreation.vue
+++ b/frontend/src/views/AvailabilityView/components/ScheduleCreation.vue
@@ -101,7 +101,7 @@ const defaultSchedule: Schedule = {
   slot_duration: DEFAULT_SLOT_DURATION,
   meeting_link_provider: MeetingLinkProviderType.None,
   slug: user.mySlug,
-  booking_confirmation: true,
+  booking_confirmation: props.schedule?.booking_confirmation ?? true,
   availabilities: [],
   use_custom_availabilities: false,
 };


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
Updating `services-ui` fixes half of the problems here as it is now emitting the `change` events on the SwitchToggle per the change in the [newest version fix](https://github.com/thunderbird/services-ui/pull/95).

However, the `booking_confirmation` had a second problem where it wasn't being initialized properly. The `deepClone` call in the `onMounted` hook ([ref](https://github.com/thunderbird/appointment/compare/fix-general-availability-toggles?expand=1#diff-1ba5ada7f435e4d1f83537e333373409187f31fc53195039ab464a36cff55879R118)) is breaking the Vue's reactivity for this field. This will be a non-issue with the upcoming changes for the [Availability page overhaul / rewrite](https://github.com/thunderbird/appointment/issues/1094) so the fix in this PR is enough for now.

## Benefits

<!-- What benefits will be realized by the code change? -->
Toggles behave as expected

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/1145
https://github.com/thunderbird/services-ui/issues/94