### PR TITLE
Set up new task def for stage/mysql

### DIFF
--- a/pulumi/Pulumi.stage.yaml
+++ b/pulumi/Pulumi.stage.yaml
@@ -24,3 +24,11 @@ config:
     secure: AAABAOP+nuT7/b1bIzb9R+6lUz9IX7ME2K9ksAvzWvJiaIR2Ivu4zIpOlEr0uXIsKUzC4cf/aPrKANdF4VCs
   appointment:oidc-client-secret:
     secure: AAABAEDX8K02kpnnSY67Vtg0yEwZYqWixRmRUZng9dBwZQgHzlM66NJe2AgRjxjumPCuBHRwEl1iP5i0cEelJA==
+  appointment:database-host:
+    secure: AAABAE6wnBYxRd2CfjZfo7Jdwt9R900byg5QHM+b7uYDQBYzQ/f7rYA5baT/D1qMAp6ZP2Y/ZNSSMgBYEr4+3yUQ7YE/DG+2i5dHBXfs/7zSS+ZcKviODV+/NtkucF2GC7c=
+  appointment:database-user:
+    secure: AAABAJttbIhI89Ge0zS1dt+UsUaxjmkwkj6Yp8IHK3A8qcqec8ye5usY
+  appointment:database-password:
+    secure: AAABAJuE3CUyQD5hDyzclgpbk/84LICjd9hAHFqyX7R9Pa7eNhMvc7qO1vjLxU2nAo4AlNRqXQMaQT9aSTu9LA==
+  appointment:database-name:
+    secure: AAABAO1hR9ZPKJVVwH++5ale2yMui2KLNiYe2aR3diaaKNiBhhqqU0r11A==

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -89,6 +89,10 @@ resources:
       secret_names:
         - database-connection
         - database-encryption
+        - database-host
+        - database-name
+        - database-password
+        - database-user
         - fxa-secrets
         - google-oauth
         - neon-database-connection
@@ -141,7 +145,7 @@ resources:
           - FARGATE
         container_definitions:
           backend:
-            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/appointment:0d290eecdec3d434ce8d033b624c0825dd5d9bda
+            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/appointment:5cb8b4c36ce6e6527184d01010284b9153ed4b70
             portMappings:
               - name: backend
                 containerPort: 5000
@@ -151,8 +155,14 @@ resources:
             linuxParameters:
               initProcessEnabled: True
             secrets:
-              - name: DATABASE_SECRETS
-                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/database-connection-cugbJu
+              - name: DATABASE_HOST
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/database-host-cMwTdY
+              - name: DATABASE_NAME
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/database-name-bNiiOY
+              - name: DATABASE_USERNAME
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/database-user-cfbYYI
+              - name: DATABASE_PASSWORD
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/database-password-h8xPx9
               - name: DB_ENC_SECRET
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/database-encryption-fY5K5W
               - name: FXA_SECRETS
@@ -168,6 +178,12 @@ resources:
               - name: ZOOM_SECRETS
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/zoom-secrets-KdyrDH
             environment:
+              - name: DATABASE_ENGINE
+                # value: postgresql
+                value: mysql
+              - name: DATABASE_PORT
+                # value: 5432
+                value: '3306'
               - name: LOG_LEVEL
                 value: ERROR
               - name: FRONTEND_URL


### PR DESCRIPTION
If Phase One was "Fix DB Connection Strings and the Variables that Construct It", then this is Phase Two: Make the Task Definition Use Those Variables. This keeps the service pointed at the existing MySQL database and gives us a safe rollback point in case the Postgres migration doesn't go well.