### PR TITLE
Update VITE_SUPPORT_URL to new self-hosted Zendesk form

### DIFF
--- a/frontend/.env.prod.example
+++ b/frontend/.env.prod.example
@@ -23,4 +23,4 @@ VITE_REPORT_BUG_URL=https://github.com/thunderbird/appointment/issues/new?assign
 # If the browser's hour setting is empty or missing fallback to this value
 VITE_DEFAULT_HOUR_FORMAT=12
 
-VITE_SUPPORT_URL=https://tbpro.zendesk.com/hc/requests/new
+VITE_SUPPORT_URL=https://accounts.tb.pro/contact

--- a/frontend/.env.pulumiprod.example
+++ b/frontend/.env.pulumiprod.example
@@ -23,7 +23,7 @@ VITE_REPORT_BUG_URL=https://github.com/thunderbird/appointment/issues/new?assign
 # If the browser's hour setting is empty or missing fallback to this value
 VITE_DEFAULT_HOUR_FORMAT=12
 
-VITE_SUPPORT_URL=https://tbpro.zendesk.com/hc/requests/new
+VITE_SUPPORT_URL=https://accounts.tb.pro/contact
 
 VITE_OIDC_CLIENT_ID=thunderbird-appointment-frontend
 VITE_OIDC_ROOT_URL=https://auth.tb.pro/realms/tbpro/

--- a/frontend/.env.pulumistage.example
+++ b/frontend/.env.pulumistage.example
@@ -23,7 +23,7 @@ VITE_REPORT_BUG_URL=https://github.com/thunderbird/appointment/issues/new?assign
 # If the browser's hour setting is empty or missing fallback to this value
 VITE_DEFAULT_HOUR_FORMAT=12
 
-VITE_SUPPORT_URL=https://tbpro.zendesk.com/hc/requests/new
+VITE_SUPPORT_URL=https://accounts-stage.tb.pro/contact/
 
 VITE_OIDC_CLIENT_ID=thunderbird-appointment-frontend
 VITE_OIDC_ROOT_URL=https://auth-stage.tb.pro/realms/tbpro/

--- a/frontend/.env.stage.example
+++ b/frontend/.env.stage.example
@@ -23,4 +23,4 @@ VITE_REPORT_BUG_URL=https://github.com/thunderbird/appointment/issues/new?assign
 # If the browser's hour setting is empty or missing fallback to this value
 VITE_DEFAULT_HOUR_FORMAT=12
 
-VITE_SUPPORT_URL=https://tbpro.zendesk.com/hc/requests/new
+VITE_SUPPORT_URL=https://accounts-stage.tb.pro/contact/


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
Updates to `VITE_SUPPORT_URL` across the various `*.example` files

## Benefits

<!-- What benefits will be realized by the code change? -->
- Self-hosted Zendesk form allows us to keep a more cohesive experience across products instead of yeeting the user to Zendesk's domain.

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/892