### PR TITLE
Fix psycopg and sqlalchemy comparison fail between boolean and integer

### DIFF
--- a/backend/src/appointment/database/repo/calendar.py
+++ b/backend/src/appointment/database/repo/calendar.py
@@ -46,7 +46,9 @@ def get_by_subscriber(db: Session, subscriber_id: int, include_unconnected: bool
     query = db.query(models.Calendar).filter(models.Calendar.owner_id == subscriber_id)
 
     if not include_unconnected:
-        query = query.filter(models.Calendar.connected)
+        # Skipping ruff check here since we need to compare a boolean to an integer in Postgresql
+        # and "models.Calendar.connected is True" always evaluates to false.
+        query = query.filter(models.Calendar.connected == True)  # noqa: E712
 
     return query.all()
 


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
We no longer may compare boolean and integers while using sqlalchemy + psycopg. This breaks the inner workings of the SQL layer translation and requires an explicit cast.

```
 File "/app/appointment/routes/schedule.py", line 207, in read_schedule_availabilities
    calendars = repo.calendar.get_by_subscriber(db, subscriber.id, False)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

sqlalchemy.exc.ProgrammingError: (psycopg.errors.UndefinedFunction) operator does not exist: boolean = integer
LINE 3: ...rs.owner_id = $1::INTEGER AND calendars.connected = $2::INTE...
                                                             ^
HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
```

## Benefits

<!-- What benefits will be realized by the code change? -->
- Booker availability page loads correctly!

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/1173