### PR TITLE
Set specific playwright version to fix E2E BrowserStack test jobs

### DIFF
--- a/test/e2e/browserstack-desktop.yml
+++ b/test/e2e/browserstack-desktop.yml
@@ -80,6 +80,7 @@ debug: false # <boolean> # Set to true if you need screenshots for every seleniu
 networkLogs: false # <boolean> Set to true to enable HAR logs capturing; off as may contain sensitive info like login API requests
 consoleLogs: info # <string> Remote browser's console debug levels to be printed (`disable`, `errors`, `warnings`, `info`, or `verbose`)
 framework: playwright
+browserstack.playwrightVersion: 1.53.0 # must match our client playwright version in package.json; this is the latest supported in BrowserStack
 browserstack.playwrightLogs: false # disable playwright logs appearing on browserstack builds as may contain sensitive info like credentials
 # CUSTOM_TAG_<INT>: # <string> (Default: parent folder name of the test file) Custom tag for your test suite
 browserstack.maskBasicAuth: true # mask username and passwords from browserstack session logs

--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -10,9 +10,9 @@
       "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.49.0",
+        "@playwright/test": "1.53.0",
         "@types/node": "^24.1.0",
-        "browserstack-node-sdk": "^1.34.34",
+        "browserstack-node-sdk": "^1.40.8",
         "dotenv": "^17.2.1"
       }
     },
@@ -249,13 +249,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.54.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.1.tgz",
-      "integrity": "sha512-FS8hQ12acieG2dYSksmLOF7BNxnVf2afRJdCuM1eMSxj6QTSE6G4InGF7oApGgDb65MX7AwMVlIkpru0yZA4Xw==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.0.tgz",
+      "integrity": "sha512-15hjKreZDcp7t6TL/7jkAo6Df5STZN09jGiv5dbP9A6vMVncXRqE7/B2SncsyOwrkZRBH2i6/TPOL8BVmm3c7w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.54.1"
+        "playwright": "1.53.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1054,9 +1054,9 @@
       }
     },
     "node_modules/browserstack-node-sdk": {
-      "version": "1.40.2",
-      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.40.2.tgz",
-      "integrity": "sha512-daU+frwEaEUUm4p+Bc7RYdl7+21ZJTtY3aG4HNBn/lGYNQer7toPRiAm/GhtLjAVhuwFigukcbphEUYo24kD4A==",
+      "version": "1.40.8",
+      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.40.8.tgz",
+      "integrity": "sha512-6XPXltfmRqjB3yGS9i/UZwHIRXqy1F4ufEMUvqZ+819e4q8F+URcTSwOYELqcdO/DNyCZH0MClZk0k3Pt9FfHQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
@@ -4274,13 +4274,13 @@
       "license": "MIT"
     },
     "node_modules/playwright": {
-      "version": "1.54.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.1.tgz",
-      "integrity": "sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.0.tgz",
+      "integrity": "sha512-ghGNnIEYZC4E+YtclRn4/p6oYbdPiASELBIYkBXfaTVKreQUYbMUYQDwS12a8F0/HtIjr/CkGjtwABeFPGcS4Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.54.1"
+        "playwright-core": "1.53.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4293,9 +4293,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.54.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.1.tgz",
-      "integrity": "sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.0.tgz",
+      "integrity": "sha512-mGLg8m0pm4+mmtB7M89Xw/GSqoNC+twivl8ITteqvAndachozYe2ZA7srU6uleV1vEdAHYqjq+SV8SNxRRFYBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -21,9 +21,9 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
-    "@playwright/test": "^1.49.0",
+    "@playwright/test": "1.53.0",
     "@types/node": "^24.1.0",
-    "browserstack-node-sdk": "^1.34.34",
+    "browserstack-node-sdk": "^1.40.8",
     "dotenv": "^17.2.1"
   }
 }


### PR DESCRIPTION
The E2E tests run fine locally but recently they started failing when they run in BrowserStack. In BrowserStack the session just hangs and the E2E tests timeout as the browsers don't even startup.

The E2E BrowserStack test jobs just use the newest playwright and browser versions however after upgrading to the latest playwright browsers the tests won't run in BrowserStack.

After some investigation the solution is to use a specific playwright version on the client side (test/e2e/package.json) and also tell BrowserStack to use this same playwright version (browserstack-desktop.yml); and use the latest version that BrowserStack specifies in their [documentation here](https://www.browserstack.com/docs/automate/playwright/browsers-and-os?fw-lang=nodejs) which is `1.53.0`. I tried this out, and using this playwright version fixes the BrowserStack issue and the E2E tests startup and run.