### PR TITLE
Fix deploys

### DIFF
--- a/backend/src/appointment/utils.py
+++ b/backend/src/appointment/utils.py
@@ -157,8 +157,17 @@ def get_database_url() -> str | sqlalchemy_url:
     username = os.environ.get('DATABASE_USERNAME')
     password = os.environ.get('DATABASE_PASSWORD')
 
-    if not all([db_name, dialect, host, password, port, username]):
-        raise ValueError('Missing one or more database configuration value. Review your environment.')
+    requirements = {
+        'db_name': db_name,
+        'dialect': dialect,
+        'host': host,
+        'password': password,
+        'port': port,
+        'username': username,
+    }
+    missing_requirements = [key for key, value in requirements.items() if not value]
+    if len(missing_requirements) > 0:
+        raise ValueError(f'Missing the following database options: {missing_requirements}')
 
     # If we've had to compose this from parts, use the SQLAlchemy URL class
     return sqlalchemy_url(

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -145,7 +145,7 @@ resources:
           - FARGATE
         container_definitions:
           backend:
-            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/appointment:be8a94d940e85d58f8b825f21092ca1d954e3dad
+            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/appointment:ff60cf81214d3aace5058406cb66e77380dd7b63
             portMappings:
               - name: backend
                 containerPort: 5000


### PR DESCRIPTION
This restores a piece of code that we still need to operate our old stage environment. If the `DATABASE_SECRETS` variable is set, we will set the `DATABASE_URL` variable, which then triggers an admonishment of the configuration and the reluctant carrying out of the old way of configuring the DB.