### PR TITLE
Add tags on Redis instances

### DIFF
--- a/pulumi/redis.py
+++ b/pulumi/redis.py
@@ -1,3 +1,4 @@
+import pulumi
 import pulumi_aws as aws
 import pulumi_cloudflare as cloudflare
 
@@ -36,11 +37,14 @@ def redis_cache(
         f'{project.name_prefix}-cache-backend',
         security_group_ids=[security_group.resources.get('sg').id],
         subnet_ids=[subnet.id for subnet in vpc.resources.get('subnets', {})],
+        tags=project.common_tags,
         **resources.get('aws:elasticache:ServerlessCache', {}).get('backend', {}),
+        opts=pulumi.ResourceOptions(depends_on=[vpc]),
     )
+    project.resources['backend_cache'] = backend_cache
 
     backend_cache_primary_endpoint = backend_cache.endpoints.apply(lambda endpoints: endpoints[0]['address'])
-    cache_dns = cloudflare.DnsRecord(
+    backend_cache_dns = cloudflare.DnsRecord(
         f'{project.name_prefix}-dns-redis',
         name=resources.get('domains', {}).get('redis', None),
         ttl=60,
@@ -49,5 +53,6 @@ def redis_cache(
         content=backend_cache_primary_endpoint,
         proxied=False,
     )
+    project.resources['backend_cache_dns'] = backend_cache_dns
 
-    return (backend_cache, cache_dns)
+    return (backend_cache, backend_cache_dns)


### PR DESCRIPTION
## Description of the Change

@Sancus noticed we didn't have our usual tags on the Appointment Redis instances. This change fixes that.

It also fixes a couple other small things I found in here...

1. This resource requires the VPC, but did not have a dependency set for it.
2. This resource was not being placed into the project after it is created (and therefore would be left out from aggregate functions).
3. I didn't like that we had a "backend_cache" as opposed to just a "cache", but then we have a "cache_dns" rather than a "backend_cache_dns". So now we have this latter name and my mind experiences order once more.

## Benefits

Proper tags for cost assessment. Improved code quality.

## Applicable Issues

Didn't bother filing one, but I can if necessary.