### PR TITLE
[Hotfix?] First schedule may not exist when accounts are disconnected / reconnected

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -603,6 +603,9 @@
             "title": "Zoom trennen"
           }
         }
+      },
+      "calendars": {
+        "noCalendars": "Keine Kalenderkonten verbunden. Füge ein Konto hinzu, um zu beginnen."
       }
     },
     "timesAreDisplayedInLocalTimezone": "Die Zeiten werden in deiner lokalen Zeitzone {timezone} angezeigt.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -602,6 +602,9 @@
             "title": "Disconnect Zoom"
           }
         }
+      },
+      "calendars": {
+        "noCalendars": "No calendar accounts connected. Add an account to get started."
       }
     },
     "timesAreDisplayedInLocalTimezone": "Times are displayed in your local timezone {timezone}.",

--- a/frontend/src/models.ts
+++ b/frontend/src/models.ts
@@ -205,7 +205,7 @@ export type AvailabilityFormFields = {
   end_time?: string;
   farthest_booking?: number;
   id?: number;
-  link_slug?: string;
+  slug?: string;
   location_url?: string;
   meeting_link_provider?: string;
   name?: string;

--- a/frontend/src/stores/availability-store.ts
+++ b/frontend/src/stores/availability-store.ts
@@ -75,7 +75,7 @@ export const useAvailabilityStore = defineStore('availability', () => {
     hasZoom.value = !!externalConnectionStore.zoom[0];
 
     // Booking Page Link data
-    initialState.value.link_slug = userStore.mySlug;
+    initialState.value.slug = userStore.mySlug;
 
     // Copy initialState
     currentState.value = deepClone({ ...initialState.value }); 

--- a/frontend/src/stores/availability-store.ts
+++ b/frontend/src/stores/availability-store.ts
@@ -2,6 +2,7 @@ import { computed, ref, toRefs } from "vue";
 import { defineStore } from "pinia";
 import { Fetch, AvailabilityFormFields } from "@/models";
 import { deepClone } from "@/utils";
+import { DEFAULT_SLOT_DURATION } from "@/definitions";
 
 import { createCalendarStore } from "./calendar-store";
 import { createUserStore } from "./user-store";
@@ -68,6 +69,20 @@ export const useAvailabilityStore = defineStore('availability', () => {
       const calendar = connectedCalendars.value.find((cal) => cal.id === calendarId);
       if (!calendar || !calendar.connected) {
         initialState.value.calendar_id = connectedCalendars.value[0].id;
+      }
+    } else {
+      // Initialize schedule with minimum default values
+      initialState.value = {
+        active: false,
+        name: `${userStore.data.name}'s Availability`,
+        start_time: '09:00',
+        end_time: '17:00',
+        slot_duration: DEFAULT_SLOT_DURATION,
+        booking_confirmation: true,
+        earliest_booking:	1440,
+        farthest_booking: 20160,
+        weekdays: [1, 2, 3, 4, 5],
+        details: '',
       }
     }
 

--- a/frontend/src/stores/settings-store.ts
+++ b/frontend/src/stores/settings-store.ts
@@ -58,7 +58,7 @@ export const useSettingsStore = defineStore('settings', () => {
     initialState.value.timeFormat = userStore.data.settings.timeFormat;
 
     // Connected Applications section
-    initialState.value.defaultCalendarId = scheduleStore.firstSchedule.calendar_id;
+    initialState.value.defaultCalendarId = scheduleStore.firstSchedule?.calendar_id;
     initialState.value.changedCalendars = {};
     initialState.value.changedCalendarColors = {};
 

--- a/frontend/src/views/AvailabilityView/components/AvailabilitySettings/index.vue
+++ b/frontend/src/views/AvailabilityView/components/AvailabilitySettings/index.vue
@@ -7,6 +7,7 @@ import { BubbleSelect, TextInput, SwitchToggle, CheckboxInput, LinkButton } from
 import { dayjsKey, isoWeekdaysKey } from '@/keys';
 import { useUserStore } from '@/stores/user-store';
 import { useAvailabilityStore } from '@/stores/availability-store';
+import { useCalendarStore } from '@/stores/calendar-store';
 import { Availability, SelectOption } from '@/models';
 
 import AvailabilityCalendarSelect from './components/AvailabilityCalendarSelect.vue';
@@ -20,8 +21,10 @@ const isoWeekdays = inject(isoWeekdaysKey);
 
 const userStore = useUserStore();
 const availabilityStore = useAvailabilityStore();
+const calendarStore = useCalendarStore();
 const router = useRouter();
 
+const { connectedCalendars } = storeToRefs(calendarStore);
 const { currentState } = storeToRefs(availabilityStore);
 
 const isBookable = computed({
@@ -103,6 +106,7 @@ export default {
       v-model="isBookable"
       :title="t('label.activateSchedule')"
       data-testid="availability-set-availability-toggle"
+      :disabled="!connectedCalendars.length"
     />
   </header>
 

--- a/frontend/src/views/AvailabilityView/components/BookingPageLink/index.vue
+++ b/frontend/src/views/AvailabilityView/components/BookingPageLink/index.vue
@@ -20,9 +20,9 @@ const refreshLinkModalOpen = ref(false);
 const copyButtonLabel = ref(t('label.copy'));
 
 const linkSlug = computed({
-  get: () => currentState.value.link_slug,
+  get: () => currentState.value.slug || userStore.mySlug,
   set: (value) => {
-    availabilityStore.$patch({ currentState: { link_slug: value } })
+    availabilityStore.$patch({ currentState: { slug: value } })
   }
 })
 
@@ -39,6 +39,13 @@ function closeRefreshLinkModal() {
 async function refreshLinkConfirm() {
   await userStore.changeSignedUrl();
   await userStore.profile();
+
+  // Update link slug in the "Customize Your Link" text field
+  // We need to update both initialState and currentState for the isDirty comparison
+  availabilityStore.$patch({
+    initialState: { slug: userStore.mySlug },
+    currentState: { slug: userStore.mySlug }
+  })
 
   closeRefreshLinkModal();
 

--- a/frontend/src/views/AvailabilityView/index.vue
+++ b/frontend/src/views/AvailabilityView/index.vue
@@ -69,8 +69,10 @@ async function onSaveChanges() {
     return;
   }
 
-  // save schedule data
-  const response = await scheduleStore.updateSchedule(obj.id, obj);
+  // create or update schedule data
+  const response = obj.id
+    ? await scheduleStore.updateSchedule(obj.id, obj)
+    : await scheduleStore.createSchedule(obj);
 
   if (Object.prototype.hasOwnProperty.call(response, 'error')) {
     // error message is in data
@@ -88,6 +90,14 @@ async function onSaveChanges() {
 
   // Reload data form backend to reset currentState vs initialState
   availabilityStore.$reset();
+
+  // Need to refresh the booking page link schedule slug
+  await userStore.profile();
+
+  availabilityStore.$patch({
+    initialState: { slug: userStore.mySlug },
+    currentState: { slug: userStore.mySlug }
+  })
 }
 
 function onRevertChanges() {

--- a/frontend/src/views/SettingsView/components/ConnectedApplications.vue
+++ b/frontend/src/views/SettingsView/components/ConnectedApplications.vue
@@ -191,54 +191,60 @@ async function refreshData() {
       {{ t('label.calendar', initialCalendars.length) }}
     </label>
 
-    <template v-for="calendar in initialCalendars" :key="calendar.id">
-      <div class="calendar-details-container">
-        <checkbox-input
-          name="calendarConnected"
-          class="calendar-connected-checkbox"
-          @change="(event) => onCalendarChecked(event, calendar.id)"
-          :checked="currentState.changedCalendars?.[calendar.id] !== undefined ? currentState.changedCalendars[calendar.id] : calendar.connected"
-        />
-        <primary-badge v-if="currentState.defaultCalendarId === calendar.id">
-          {{ t('label.default') }}
-        </primary-badge>
-        <p>{{ calendar.title }}</p>
-      </div>
+    <template v-if="initialCalendars.length > 0">
+      <template v-for="calendar in initialCalendars" :key="calendar.id">
+        <div class="calendar-details-container">
+          <checkbox-input
+            name="calendarConnected"
+            class="calendar-connected-checkbox"
+            @change="(event) => onCalendarChecked(event, calendar.id)"
+            :checked="currentState.changedCalendars?.[calendar.id] !== undefined ? currentState.changedCalendars[calendar.id] : calendar.connected"
+          />
+          <primary-badge v-if="currentState.defaultCalendarId === calendar.id">
+            {{ t('label.default') }}
+          </primary-badge>
+          <p>{{ calendar.title }}</p>
+        </div>
+  
+        <div class="calendar-color" :style="{ backgroundColor: calendar.color }">
+          <input
+            type="color"
+            :value="calendar.color"
+            @change="(event) => onCalendarColorChanged(event as HTMLInputElementEvent, calendar.id)"
+          />
+        </div>
+  
+        <p class="calendar-provider">{{ calendar.provider_name }}</p>
+  
+        <drop-down class="dropdown" :ref="(el) => calendarDropdownRefs[calendar.id] = el">
+          <template #trigger>
+            <icon-dots size="24" />
+          </template>
+          <template #default>
+            <div class="dropdown-inner" @click="calendarDropdownRefs[calendar.id].close()">
+              <button
+                v-if="calendar.connected && currentState.defaultCalendarId !== calendar.id"
+                @click="() => onSetAsDefaultClicked(calendar.id)"
+              >
+                {{ t('text.settings.connectedApplications.setAsDefault') }}
+              </button>
+              <!-- TODO: Rename Calendar not implemented -->
+              <!-- <button>
+                {{ t('text.settings.connectedApplications.renameCalendar') }}
+              </button> -->
+              <button @click="() => displayModal(calendar.provider, calendar.type_id, calendar.connection_name)">
+                {{ t('label.disconnect') }}
+              </button>
+            </div>
+          </template>
+        </drop-down>
+  
+        <br />
+      </template>
+    </template>
 
-      <div class="calendar-color" :style="{ backgroundColor: calendar.color }">
-        <input
-          type="color"
-          :value="calendar.color"
-          @change="(event) => onCalendarColorChanged(event as HTMLInputElementEvent, calendar.id)"
-        />
-      </div>
-
-      <p class="calendar-provider">{{ calendar.provider_name }}</p>
-
-      <drop-down class="dropdown" :ref="(el) => calendarDropdownRefs[calendar.id] = el">
-        <template #trigger>
-          <icon-dots size="24" />
-        </template>
-        <template #default>
-          <div class="dropdown-inner" @click="calendarDropdownRefs[calendar.id].close()">
-            <button
-              v-if="calendar.connected && currentState.defaultCalendarId !== calendar.id"
-              @click="() => onSetAsDefaultClicked(calendar.id)"
-            >
-              {{ t('text.settings.connectedApplications.setAsDefault') }}
-            </button>
-            <!-- TODO: Rename Calendar not implemented -->
-            <!-- <button>
-              {{ t('text.settings.connectedApplications.renameCalendar') }}
-            </button> -->
-            <button @click="() => displayModal(calendar.provider, calendar.type_id, calendar.connection_name)">
-              {{ t('label.disconnect') }}
-            </button>
-          </div>
-        </template>
-      </drop-down>
-
-      <br />
+    <template v-else>
+      <p class="calendar-accounts-not-connected">{{ t('text.settings.calendars.noCalendars') }}</p>
     </template>
   </div>
 
@@ -311,6 +317,10 @@ h2 {
       text-decoration: underline;
       color: var(--colour-apmt-primary);
     }
+  }
+
+  .calendar-accounts-not-connected {
+    grid-column: span 4;
   }
 
   .calendar-provider {

--- a/frontend/src/views/SettingsView/index.vue
+++ b/frontend/src/views/SettingsView/index.vue
@@ -136,6 +136,12 @@ async function updateCalendarConnections() {
 }
 
 async function updateScheduleDefaultCalendar() {
+  // It is possible for the first / default schedule not to exist at this point
+  // (e.g. disconnecting all accounts and calendars and reconnecting a account)
+  if (!scheduleStore.firstSchedule) {
+    return;
+  }
+
   const firstScheduleId = scheduleStore.firstSchedule.id;
 
   // Only make the request if the default calendar has been changed


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
This PR fixes a few problems but also opens up new questions on how to handle some scenarios:

1. In the Settings page, we were coupling the calendar updates with the first / default schedule since the `default` calendar can be changed in this page to any other connected calendar. This is a problem because if a user removes all of the accounts / has no calendars, they would also have no schedule anymore. [Adding a check here solves it](https://github.com/thunderbird/appointment/pull/1200/files#diff-f09242ff792588c8b0041051932ba73857622a2d2057991ca39ae2db73c09e12R139-R143). [I've also added a placeholder message](https://github.com/thunderbird/appointment/pull/1200/files#diff-fdd0b20f6fd56a7487b6aa97d100fe585694f85bd7db1c531ee100dc8a8d942aR247) (copy not approved yet) for the empty state.

2. After the FTUE, we were also not accounting for the possibility of not having a first / default schedule at all. This means that the Availability page was only doing an update when clicking `save` instead of being able to create a schedule. Now, [if there is no schedule id, we are creating a schedule instead](https://github.com/thunderbird/appointment/pull/1200/files#diff-69283f1479f03baa0f0bd773b09e7a82cf9621d38cca5941b0d44d16777204c5R72-R75) using pre-populated default values (similar logic as the FTUE).

3. Booking page slug was not working as expected / not reflecting changes instantly. We are syncing backend data with local storage here and there were some caching problems. Now both the auto-generated refreshed slug and the custom one get synced correctly.

> [!IMPORTANT]  
> The core issue that started it all is still not fixed (accepting booked appointments is still failing the `verify_link`) but this PR should fix the "blank screen of death"

## Testing
- After going through the FTUE, go to the Settings page and disconnect all your calendar accounts.
- See that there is an empty state message `**[NEW]**`
- Connect a Google Account (haven't tested with CalDav)
- See that there are no connected calendars. Click on the checkbox next to the calendar and click "Save" to apply the change. `**[NEW - This was failing before per point number 1 described above]**`
- Go to the Availability page, toggle the "You're not bookable" switch and select your connected calendar. Note that the schedule settings here has default values. Click on "Save" to apply the change. At this point a schedule will be created instead of being updated. `**[NEW - This did not exist before]**`
- Still in the Availability page, customize your booking page slug to any text and hit "Save". The change should be reflected instantly. `**[NEW - This was not working before]**`
- Still in the Availability page, click on the "refresh" icon in the booking page slug and confirm on the modal. The change should be reflected instantly `**[NEW - This was not being reflected instantly before and required a page refresh]**`

## Benefits

<!-- What benefits will be realized by the code change? -->
- App works again and folks can disconnect all accounts and upon re-connection of one, it would create a schedule.
- Slugs edits are reflected correctly.

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/1201
