### PR TITLE
Update verify_link to always compare with long urls

### DIFF
--- a/backend/src/appointment/controller/auth.py
+++ b/backend/src/appointment/controller/auth.py
@@ -66,7 +66,7 @@ def user_links_by_subscriber(subscriber: models.Subscriber):
 
 
 def signed_url_by_subscriber(subscriber: schemas.Subscriber):
-    """helper to generated signed url for given subscriber"""
+    """helper to generate signed url for given subscriber"""
     short_url, base_url = user_links_by_subscriber(subscriber)
 
     # We sign with a different hash that the end-user doesn't have access to

--- a/backend/src/appointment/database/repo/subscriber.py
+++ b/backend/src/appointment/database/repo/subscriber.py
@@ -5,6 +5,7 @@ Repository providing CRUD functions for subscriber database models.
 
 import datetime
 import secrets
+import os
 
 from sqlalchemy.orm import Session
 from .. import models, schemas
@@ -132,24 +133,20 @@ def verify_link(db: Session, url: str):
     """Check if a given url is a valid signed subscriber profile link
     Return subscriber if valid.
     """
-    print(f'==== verify_link called with {url} ====')
+
+    if os.getenv('SHORT_BASE_URL'):
+        # If the url is a short url, we need to reconstruct the long url
+        # otherwise it will fail the signature check as we always sign with the long url
+        url = url.replace(os.getenv('SHORT_BASE_URL'), f'{os.getenv("FRONTEND_URL")}/user')
 
     username, signature, clean_url = utils.retrieve_user_url_data(url)
 
-    print(f'{username}, {signature}, {clean_url}')
-
     subscriber = get_by_username(db, username)
     if not subscriber:
-        print('Subscriber not found!')
         return False
-
-    print('Subscriber found!')
 
     clean_url_with_short_link = clean_url + f'{subscriber.short_link_hash}'
     signed_signature = sign_url(clean_url_with_short_link)
-
-    print(f'clean_url_with_short_link = {clean_url_with_short_link}')
-    print(f'signed_signature = {signed_signature}')
 
     # Verify the signature matches the incoming one
     if signed_signature == signature:

--- a/backend/test/unit/test_subscriber.py
+++ b/backend/test/unit/test_subscriber.py
@@ -1,0 +1,26 @@
+import os
+
+from appointment.database.repo.subscriber import verify_link
+from appointment.controller.auth import signed_url_by_subscriber
+
+
+class TestSubscriber:
+    def test_verify_link_uses_long_url(self, with_db, make_basic_subscriber):
+        """Upon link verification, we should make sure that we are always comparing
+        long (FRONTEND_USER/user) type urls since we are always signing with the long url."""
+
+        os.environ['SHORT_BASE_URL'] = 'https://example.org'
+        os.environ['FRONTEND_URL'] = 'https://example-long.org'
+
+        subscriber = make_basic_subscriber()
+
+        with with_db() as db:
+            signed_url = signed_url_by_subscriber(subscriber)
+
+            assert os.environ['FRONTEND_URL'] not in signed_url
+            assert '/user' not in signed_url
+
+            verified_subscriber = verify_link(db, signed_url)
+
+            assert verified_subscriber is not False
+            assert verified_subscriber.id == subscriber.id


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
When we have `SHORT_BASE_URL` env var set, we are returning a signed url for the user with a `short_url`. This gets stored in frontend's user data and it is currently used to confirm / decline bookings. This is a problem because the verification of the signed url always compares it with the long url and not the short ones.

This used to work before because the frontend was sending **`window.location.href` while being in a route that had the long url** but it is now broken because, instead, we are now sending the `signedUrl` back to the backend for verification (and the initial signage of the url was using the short url and not the long one).

- On the backend, if the `SHORT_BASE_URL` env var is set, we are now replacing it with the long url upon link verification so that we are comparing long urls with long urls.

- Removed previous print debug statements

## Benefits

<!-- What benefits will be realized by the code change? -->
- Folks who have the `SHORT_BASE_URL` env var set (like us, in stage/prod) will be able to confirm / decline bookings again

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/1049