### PR TITLE
Add display name input back in Settings

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -271,7 +271,7 @@
     "disable": "Disable",
     "disconnect": "Disconnect",
     "disconnected": "Disconnected",
-    "displayName": "Display name",
+    "displayName": "Display Name",
     "download": "Download",
     "downloadInvitation": "Download invitation",
     "downloadTheIcsFile": "Add to your calendar",

--- a/frontend/src/models.ts
+++ b/frontend/src/models.ts
@@ -270,6 +270,7 @@ export type SettingsForm = {
   colourScheme?: string;
   defaultTimeZone?: string;
   defaultCalendarId?: number;
+  displayName?: string;
   language?: string;
   startOfWeek?: number;
   timeFormat?: number;

--- a/frontend/src/stores/settings-store.ts
+++ b/frontend/src/stores/settings-store.ts
@@ -50,6 +50,9 @@ export const useSettingsStore = defineStore('settings', () => {
       await scheduleStore.fetch();
     }
 
+    // Account Settings section
+    initialState.value.displayName = userStore.data.name;
+
     // Preferences section
     initialState.value.colourScheme = userStore.data.settings.colourScheme;
     initialState.value.language = userStore.data.settings.language;

--- a/frontend/src/views/SettingsView/components/AccountSettings.vue
+++ b/frontend/src/views/SettingsView/components/AccountSettings.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
-import { inject, ref } from 'vue';
+import { computed, inject, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
+import { storeToRefs } from 'pinia';
 import { callKey } from '@/keys';
 import { DangerButton, SecondaryButton, TextInput } from '@thunderbirdops/services-ui';
 import { IconCopy, IconArrowRight } from '@tabler/icons-vue';
 import { createUserStore } from '@/stores/user-store';
+import { useSettingsStore } from '@/stores/settings-store';
 import { BooleanResponse } from '@/models';
 import { posthog, usePosthog } from '@/composables/posthog';
 import { MetricEvents } from '@/definitions';
@@ -16,9 +18,18 @@ const router = useRouter();
 
 const call = inject(callKey);
 const userStore = createUserStore(call);
+const settingsStore = useSettingsStore();
+const { currentState } = storeToRefs(settingsStore);
 
 const copyLinkTooltip = ref(t('label.copyLink'));
 const cancelAccountModalOpen = ref(false);
+
+const displayName = computed({
+  get: () => currentState.value.displayName,
+  set: (value) => {
+    settingsStore.$patch({ currentState: { displayName: value }})
+  }
+})
 
 // Link copy
 const copyLink = async () => {
@@ -60,6 +71,13 @@ const actuallyDeleteAccount = async () => {
   <header>
     <h2>{{ t('heading.accountSettings') }}</h2>
   </header>
+
+  <div class="booking-page-display-name-container">
+    <label for="booking-page-display-name">
+      {{ t('label.displayName') }}
+    </label>
+    <text-input name="booking-page-display-name" v-model="displayName" />
+  </div>
 
   <div class="booking-page-url-container">
     <label for="booking-page-url">
@@ -114,6 +132,14 @@ h2 {
   font-size: 1.5rem;
 }
 
+.booking-page-display-name-container {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-gap: 1.5rem;
+  align-items: center;
+  margin-block-end: 1.5rem;
+}
+
 .booking-page-url-container {
   display: grid;
   grid-template-columns: 1fr;
@@ -165,6 +191,10 @@ h2 {
 }
 
 @media (--md) {
+  .booking-page-display-name-container {
+    grid-template-columns: 20% 1fr;
+  }
+
   .booking-page-url-container {
     grid-template-columns: 20% 1fr;
   }

--- a/frontend/src/views/SettingsView/index.vue
+++ b/frontend/src/views/SettingsView/index.vue
@@ -62,6 +62,7 @@ const redirectSetupUsers = (view: string) => {
 async function updatePreferences() {
   const obj = {
     username: userStore.data.username,
+    name: currentState.value.displayName,
     timezone: currentState.value.defaultTimeZone,
     language: currentState.value.language,
     colour_scheme: currentState.value.colourScheme,
@@ -71,6 +72,7 @@ async function updatePreferences() {
 
   const originalValues = {
     username: userStore.data.username,
+    name: userStore.data.name,
     timezone: userStore.data.settings.timezone,
     language: userStore.data.settings.language,
     colour_scheme: userStore.data.settings.colourScheme,


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->

Wireframes
<img width="1277" height="655" alt="image" src="https://github.com/user-attachments/assets/999ab36b-8c2b-4f16-b59a-823b5d114a9c" />


Light
<img width="1396" height="573" alt="image" src="https://github.com/user-attachments/assets/a319047a-9d39-4bc2-9e17-9cc7b3779209" />


Dark
<img width="1394" height="571" alt="image" src="https://github.com/user-attachments/assets/2583f53b-01d8-45af-a570-de84d7c0d99c" />


## Benefits

<!-- What benefits will be realized by the code change? -->
- Users can edit their display name (it shows up in the Availability page)

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/1203