### PR TITLE
Fix browserstack jobs by updating playwright version

### DIFF
--- a/test/e2e/browserstack-desktop.yml
+++ b/test/e2e/browserstack-desktop.yml
@@ -80,7 +80,7 @@ debug: false # <boolean> # Set to true if you need screenshots for every seleniu
 networkLogs: false # <boolean> Set to true to enable HAR logs capturing; off as may contain sensitive info like login API requests
 consoleLogs: info # <string> Remote browser's console debug levels to be printed (`disable`, `errors`, `warnings`, `info`, or `verbose`)
 framework: playwright
-browserstack.playwrightVersion: 1.53.0 # must match our client playwright version in package.json; this is the latest supported in BrowserStack
+browserstack.playwrightVersion: 1.55.0 # must match our client playwright version in package.json; this is the latest supported in BrowserStack
 browserstack.playwrightLogs: false # disable playwright logs appearing on browserstack builds as may contain sensitive info like credentials
 # CUSTOM_TAG_<INT>: # <string> (Default: parent folder name of the test file) Custom tag for your test suite
 browserstack.maskBasicAuth: true # mask username and passwords from browserstack session logs

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -21,7 +21,7 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
-    "@playwright/test": "1.53.0",
+    "@playwright/test": "1.55.0",
     "@types/node": "^24.1.0",
     "browserstack-node-sdk": "^1.40.8",
     "dotenv": "^17.2.1"


### PR DESCRIPTION
BrowserStack test jobs starting failing out of the blue (see #1215) however updating the Playwright version locally and in BrowserStack appears to fix the issue.
