### PR TITLE
Upgrade tb_pulumi; built StackAccessPolicies

### DIFF
--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -4,8 +4,9 @@ import cloudfront
 import pulumi
 import tb_pulumi
 import tb_pulumi.ci
-import tb_pulumi.ec2
 import tb_pulumi.cloudwatch
+import tb_pulumi.ec2
+import tb_pulumi.iam
 import tb_pulumi.network
 import tb_pulumi.secrets
 
@@ -111,3 +112,8 @@ if ci_opts:
         project=project,
         **automaton_opts,
     )
+
+sap = tb_pulumi.iam.StackAccessPolicies(
+    f'{project.name_prefix}-sap',
+    project=project,
+)

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -143,7 +143,7 @@ resources:
           - FARGATE
         container_definitions:
           backend:
-            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/appointment:be8a94d940e85d58f8b825f21092ca1d954e3dad
+            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/appointment:ddd147e76509ede8927a0760572ef3b4a838e738
             portMappings:
               - name: backend
                 containerPort: 5000

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -145,7 +145,7 @@ resources:
           - FARGATE
         container_definitions:
           backend:
-            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/appointment:ff60cf81214d3aace5058406cb66e77380dd7b63
+            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/appointment:435f248011868501cc2a739c039801b04bc13085
             portMappings:
               - name: backend
                 containerPort: 5000

--- a/pulumi/requirements.txt
+++ b/pulumi/requirements.txt
@@ -1,2 +1,2 @@
-tb_pulumi @ git+https://github.com/thunderbird/pulumi.git@main
+tb_pulumi @ git+https://github.com/thunderbird/pulumi.git@v0.0.15
 pulumi_cloudflare==6.3.1


### PR DESCRIPTION
This is a step toward securing our CI processes by creating a permissions boundary between environments. In a later change, we will swap the existing CI auth data with these new accounts.

Also pins the tb_pulumi version to 0.0.15.

Also updates the images to what's actually deployed right now.