### PR TITLE
E2E settings test updates

### DIFF
--- a/test/e2e/pages/settings-page.ts
+++ b/test/e2e/pages/settings-page.ts
@@ -24,11 +24,13 @@ export class SettingsPage {
   readonly startOfWeekMondayBtn: Locator;
   readonly startOfWeekSundayBtn: Locator;
   readonly accountSettingsHeader: Locator;
+  readonly displayNameInput: Locator;
   readonly bookingPageURLInput: Locator;
   readonly copyLinkBtn: Locator;
   readonly cancelServiceBtn: Locator;
   readonly cancelServiceConfirmCancelBtn: Locator;
   readonly bookingPageSettingsBtn: Locator;
+  readonly downloadDataBtn: Locator;
   readonly connectedAppsHdr: Locator;
   readonly addCaldavBtn: Locator;
   readonly addCaldavUsernameInput: Locator;
@@ -59,11 +61,13 @@ export class SettingsPage {
     // account settings section
     this.accountSettingsBtn = this.page.getByTestId('settings-accountSettings-settings-btn');
     this.accountSettingsHeader = this.page.getByRole('heading', { name: 'Account Settings' });
+    this.displayNameInput = this.page.locator('#booking-page-display-name');
     this.bookingPageURLInput = this.page.locator('#booking-page-url');
     this.copyLinkBtn = this.page.locator('#copy-booking-page-url-button');
     this.cancelServiceBtn = this.page.getByRole('button', { name: 'Cancel Service' });
     this.cancelServiceConfirmCancelBtn = this.page.getByRole('button', { name: 'Cancel', exact: true });
     this.bookingPageSettingsBtn = this.page.getByRole('button', { name: 'Booking Page Settings' });
+    this.downloadDataBtn = this.page.getByTestId('settings-account-download-data-btn');
 
     // preferences section
     this.preferencesBtn = this.page.getByTestId('settings-preferences-settings-btn');
@@ -194,5 +198,18 @@ export class SettingsPage {
     await this.saveBtnEN.click();
     await this.page.waitForTimeout(TIMEOUT_1_SECOND);
     await expect(this.savedSuccessfullyTextEN).toBeVisible();
+  }
+
+  /**
+   * Change the display name setting
+   */
+  async changeDisplaName(newName: string) {
+    await this.displayNameInput.scrollIntoViewIfNeeded();
+    await this.page.waitForTimeout(TIMEOUT_1_SECOND);
+    await this.displayNameInput.fill(newName);
+    await this.page.waitForTimeout(TIMEOUT_1_SECOND);
+    await this.saveBtnEN.scrollIntoViewIfNeeded();
+    await this.saveBtnEN.click();
+    await this.page.waitForTimeout(TIMEOUT_3_SECONDS);
   }
 }

--- a/test/e2e/tests/settings-account.spec.ts
+++ b/test/e2e/tests/settings-account.spec.ts
@@ -2,10 +2,13 @@ import { test, expect } from '@playwright/test';
 import { SettingsPage } from '../pages/settings-page';
 import { DashboardPage } from '../pages/dashboard-page';
 import { AvailabilityPage } from '../pages/availability-page';
+import { BookingPage } from '../pages/booking-page';
+import { getUserDisplayNameFromLocalStore } from '../utils/utils';
 
 import {
   PLAYWRIGHT_TAG_E2E_SUITE,
   PLAYWRIGHT_TAG_PROD_NIGHTLY,
+  APPT_DISPLAY_NAME,
   APPT_MY_SHARE_LINK,
   TIMEOUT_1_SECOND,
   TIMEOUT_30_SECONDS,
@@ -15,6 +18,7 @@ import { URL } from 'url';
 let settingsPage: SettingsPage;
 let dashboardPage: DashboardPage;
 let availabilityPage: AvailabilityPage;
+let bookApptPage: BookingPage;
 
 test.describe('account settings', {
   tag: [PLAYWRIGHT_TAG_E2E_SUITE, PLAYWRIGHT_TAG_PROD_NIGHTLY],
@@ -24,6 +28,7 @@ test.describe('account settings', {
     settingsPage = new SettingsPage(page);
     dashboardPage = new DashboardPage(page);
     availabilityPage = new AvailabilityPage(page);
+    bookApptPage = new BookingPage(page);
 
     // navigate to settings page, account settings section
     await settingsPage.gotoAccountSettings();
@@ -31,9 +36,14 @@ test.describe('account settings', {
 
   test('verify account settings', async ({ page }) => {
     // verify section header
-    expect(settingsPage.accountSettingsHeader).toBeVisible();
+    await expect(settingsPage.accountSettingsHeader).toBeVisible();
+
+    // verify display name displayed is as expected
+    await expect(settingsPage.displayNameInput).toBeVisible();
+    expect(await settingsPage.displayNameInput.inputValue()).toBe(APPT_DISPLAY_NAME);
 
     // verify booking page url displayed is correct
+    await settingsPage.bookingPageURLInput.scrollIntoViewIfNeeded();
     expect(await settingsPage.bookingPageURLInput.inputValue()).toBe(APPT_MY_SHARE_LINK);
 
     // click copy link button and verify copied link is correct
@@ -55,6 +65,12 @@ test.describe('account settings', {
     const afterPasteBookingUrl = await settingsPage.bookingPageURLInput.inputValue();
     expect(afterPasteBookingUrl).toEqual(correctBookingUrl);
 
+    // just ensure the download your data button exists and is enabled as don't want to actually
+    // download and leave potenial sensitive data on the test instance
+    await settingsPage.downloadDataBtn.scrollIntoViewIfNeeded();
+    await expect(settingsPage.downloadDataBtn).toBeVisible();
+    await expect(settingsPage.downloadDataBtn).toBeEnabled();
+
     // cancel service button brings up confirmation dialog (just cancel out)
     await settingsPage.cancelServiceBtn.scrollIntoViewIfNeeded();
     await settingsPage.cancelServiceBtn.click();
@@ -69,4 +85,27 @@ test.describe('account settings', {
     await page.waitForURL('**/availability');
     await expect(availabilityPage.setAvailabilityText).toBeVisible();
   });
+
+    test('able to change display name', async ({ page }) => {
+      // change display name and verify
+      const newDisplayName = `Name modified by E2E test at ${Date.now()}`;
+      await settingsPage.changeDisplaName(newDisplayName);
+  
+      // verify setting saved in browser local storage
+      expect.soft(await getUserDisplayNameFromLocalStore(page)).toBe(newDisplayName);
+  
+      // go to share link/book appointment page and verify display name was changed;
+      // expect soft so that display name will be changed back even if the test fails
+      await page.goto(APPT_MY_SHARE_LINK);
+      await page.waitForTimeout(TIMEOUT_1_SECOND);
+      await expect.soft(bookApptPage.invitingText).toContainText(newDisplayName);
+
+      // change display name back
+      await settingsPage.gotoAccountSettings();
+      await page.waitForTimeout(TIMEOUT_1_SECOND);
+      await settingsPage.changeDisplaName(APPT_DISPLAY_NAME);
+  
+      // verify setting saved in browser local storage
+      expect.soft(await getUserDisplayNameFromLocalStore(page)).toBe(APPT_DISPLAY_NAME);
+    });
 });

--- a/test/e2e/tests/settings-language.spec.ts
+++ b/test/e2e/tests/settings-language.spec.ts
@@ -32,12 +32,12 @@ test.describe('settings - language', {
     // change language setting to DE and verify; we use expect.soft here because if the expect fails
     // we still want the test to continue so that the test will change the setting back to original value
     await settingsPage.changeLanguageSetting(APPT_LANGUAGE_SETTING_EN, APPT_LANGUAGE_SETTING_DE);
-    await expect(settingsPage.settingsHeaderDE).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
-    await expect(settingsPage.preferencesHeaderDE).toBeVisible();
+    await expect.soft(settingsPage.settingsHeaderDE).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+    await expect.soft(settingsPage.preferencesHeaderDE).toBeVisible();
 
     // verify setting saved in browser local storage
     let localStore = await getUserSettingsFromLocalStore(page);
-    expect(localStore['language']).toBe(APPT_BROWSER_STORE_LANGUAGE_DE);
+    expect.soft(localStore['language']).toBe(APPT_BROWSER_STORE_LANGUAGE_DE);
 
     // change language settings back to EN and verify
     await settingsPage.changeLanguageSetting(APPT_LANGUAGE_SETTING_DE, APPT_LANGUAGE_SETTING_EN);

--- a/test/e2e/tests/settings-start-of-week.spec.ts
+++ b/test/e2e/tests/settings-start-of-week.spec.ts
@@ -36,12 +36,13 @@ test.describe('settings - start of week', {
 
     // verify setting saved in browser local storage
     let localStore = await getUserSettingsFromLocalStore(page);
-    expect(localStore['startOfWeek']).toBe(APPT_BROWSER_STORE_START_WEEK_MON);
+    expect.soft(localStore['startOfWeek']).toBe(APPT_BROWSER_STORE_START_WEEK_MON);
 
+    // note: temporarily removed until dashboard calendar UI is finsished being overhauled
     // verify on dashboard
-    await dashboardPage.gotoToDashboardMonthView();
-    var firstDayOfWeekText = await dashboardPage.firstDayOfWeekMonthView.innerText();
-    expect(firstDayOfWeekText).toEqual(APPT_START_OF_WEEK_DASHBOARD_MON);
+    // await dashboardPage.gotoToDashboardMonthView();
+    // var firstDayOfWeekText = await dashboardPage.firstDayOfWeekMonthView.innerText();
+    // expect.soft(firstDayOfWeekText).toEqual(APPT_START_OF_WEEK_DASHBOARD_MON);
 
     // change start of week back to Sunday and verify
     await page.waitForTimeout(TIMEOUT_3_SECONDS);
@@ -52,9 +53,10 @@ test.describe('settings - start of week', {
     localStore = await getUserSettingsFromLocalStore(page);
     expect(localStore['startOfWeek']).toBe(APPT_BROWSER_STORE_START_WEEK_SUN);
 
+    // note: temporarily removed until dashboard calendar UI is finsished being overhauled
     // verify on dashboard
-    await dashboardPage.gotoToDashboardMonthView();
-    firstDayOfWeekText = await dashboardPage.firstDayOfWeekMonthView.innerText();
-    expect(firstDayOfWeekText).toEqual(APPT_START_OF_WEEK_DASHBOARD_SUN);
+    // await dashboardPage.gotoToDashboardMonthView();
+    // firstDayOfWeekText = await dashboardPage.firstDayOfWeekMonthView.innerText();
+    // expect(firstDayOfWeekText).toEqual(APPT_START_OF_WEEK_DASHBOARD_SUN);
   });
 });

--- a/test/e2e/tests/settings-theme.spec.ts
+++ b/test/e2e/tests/settings-theme.spec.ts
@@ -34,7 +34,7 @@ test.describe('settings - theme', {
 
     // verify setting saved in browser local storage
     let localStore = await getUserSettingsFromLocalStore(page);
-    expect(localStore['colourScheme']).toBe(APPT_BROWSER_STORE_THEME_DARK);
+    expect.soft(localStore['colourScheme']).toBe(APPT_BROWSER_STORE_THEME_DARK);
 
     // change theme setting back to light mode and verify
     await settingsPage.changeThemeSetting(APPT_THEME_SETTING_LIGHT);

--- a/test/e2e/tests/settings-timezone.spec.ts
+++ b/test/e2e/tests/settings-timezone.spec.ts
@@ -34,7 +34,7 @@ test.describe('settings - timezone', {
 
     // verify setting saved in browser local storage
     let localStore = await getUserSettingsFromLocalStore(page);
-    expect(localStore['timezone']).toBe(APPT_TIMEZONE_SETTING_HALIFAX);
+    expect.soft(localStore['timezone']).toBe(APPT_TIMEZONE_SETTING_HALIFAX);
 
     // change time format setting back
     await settingsPage.gotoPreferencesSettings()

--- a/test/e2e/utils/utils.ts
+++ b/test/e2e/utils/utils.ts
@@ -61,6 +61,15 @@ export const getUserSettingsFromLocalStore = async (page: Page) => {
 }
 
 /**
+ * Read and return the appointment user display name value from the local browser store
+ */
+export const getUserDisplayNameFromLocalStore = async (page: Page) => {
+    const localUserStoreData = JSON.parse(await page.evaluate("localStorage.getItem('tba/user')"));
+    console.log(`User display name from local browser store: ${JSON.stringify(localUserStoreData['name'])}`);
+    return localUserStoreData['name'];
+}
+
+/**
  * Set the appointment user settings in the local browser store to default values required by the tests
  */
 export const setDefaultUserSettingsLocalStore = async (page: Page) => {


### PR DESCRIPTION
More additions and improvements to settings tests:

- Update account settings test to check for display name and download data button
- Add a test to change the display name, verify changed on book appointment (share link) page
- Add some `expect.soft`'s to some of the settings tests to ensure the test continues to run (and set the settings back to their original state) even if the test assert fails (test is still marked as a failure in that case)
- In the `able to change start of week` test temporarily remove the start of week check on the dashboard, as this is currently failing because the dashboard calendar UI is being overhauled; will add this back after that is complete
