### PR TITLE
Create a CI user, add to environmental admin group

### DIFF
--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -113,6 +113,7 @@ if ci_opts:
         **automaton_opts,
     )
 
+
 def __sap_on_apply(resources):
     ci_user_name = f'{project.name_prefix}-ci'
     tb_pulumi.iam.UserWithAccessKey(
@@ -129,4 +130,3 @@ sap = tb_pulumi.iam.StackAccessPolicies(
     project=project,
     on_apply=__sap_on_apply,
 )
-

--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -113,7 +113,20 @@ if ci_opts:
         **automaton_opts,
     )
 
+def __sap_on_apply(resources):
+    ci_user_name = f'{project.name_prefix}-ci'
+    tb_pulumi.iam.UserWithAccessKey(
+        ci_user_name,
+        project=project,
+        user_name=ci_user_name,
+        groups=[resources['admin_group']],
+        opts=pulumi.ResourceOptions(depends_on=[sap]),
+    )
+
+
 sap = tb_pulumi.iam.StackAccessPolicies(
     f'{project.name_prefix}-sap',
     project=project,
+    on_apply=__sap_on_apply,
 )
+

--- a/pulumi/requirements.txt
+++ b/pulumi/requirements.txt
@@ -1,2 +1,3 @@
-tb_pulumi @ git+https://github.com/thunderbird/pulumi.git@v0.0.15
+tb_pulumi @ git+https://github.com/thunderbird/pulumi.git@main
 pulumi_cloudflare==6.3.1
+


### PR DESCRIPTION
## Description of the Change

When the stack access policies have been built, create a CI user for the environment and place it in that environment's admin group.

## Benefits

We get a cleaner separation of powers between the environments. In the current model, we have one CI account with limited access to all environments. This grants admin access to the CI user, but only to a single environment.

## Warning

This is dependent upon [this PR](https://github.com/thunderbird/pulumi/pull/211).