### PR TITLE
Reinstate AwsAutomationUser

### DIFF
--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -3,6 +3,7 @@
 import cloudfront
 import pulumi
 import tb_pulumi
+import tb_pulumi.ci
 import tb_pulumi.cloudwatch
 import tb_pulumi.ec2
 import tb_pulumi.iam
@@ -103,19 +104,11 @@ monitoring = tb_pulumi.cloudwatch.CloudWatchMonitoringGroup(
 )
 
 
-def __sap_on_apply(resources):
-    ci_user_name = f'{project.name_prefix}-ci'
-    tb_pulumi.iam.UserWithAccessKey(
-        ci_user_name,
-        project=project,
-        user_name=ci_user_name,
-        groups=[resources['admin_group']],
-        opts=pulumi.ResourceOptions(depends_on=[sap]),
-    )
-
+auto_users_opts = resources.get('tb:ci:AwsAutomationUser', {})
+for user, user_opts in auto_users_opts.items():
+    tb_pulumi.ci.AwsAutomationUser(f'{project.name_prefix}-{user}', project=project, **user_opts)
 
 sap = tb_pulumi.iam.StackAccessPolicies(
     f'{project.name_prefix}-sap',
     project=project,
-    on_apply=__sap_on_apply,
 )

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -236,3 +236,20 @@ resources:
         - thunderbird-services-monitoring@thunderbird.net
       config:
         alarms: {}
+
+  tb:ci:AwsAutomationUser:
+    ci:
+      additional_policies:
+        - arn:aws:iam::768512802988:policy/appointment-prod-frontend-cache-invalidation
+      enable_ecr_image_push: True
+      ecr_repositories:
+        - thunderbird/appointment
+      enable_fargate_deployments: True
+      fargate_clusters:
+        - appointment-prod-fargate-backend
+      fargate_task_role_arns:
+        - arn:aws:iam::768512802988:role/appointment-prod-fargate-backend
+      enable_full_s3_access: False
+      enable_s3_bucket_upload: True
+      s3_upload_buckets:
+        - tb-appointment-prod-frontend

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -246,3 +246,20 @@ resources:
         - thunderbird-services-monitoring@thunderbird.net
       config:
         alarms: {}
+
+  tb:ci:AwsAutomationUser:
+    ci:
+      additional_policies:
+        - arn:aws:iam::768512802988:policy/appointment-stage-frontend-cache-invalidation
+      enable_ecr_image_push: True
+      ecr_repositories:
+        - thunderbird/appointment
+      enable_fargate_deployments: True
+      fargate_clusters:
+        - appointment-stage-fargate-backend
+      fargate_task_role_arns:
+        - arn:aws:iam::768512802988:role/appointment-stage-fargate-backend
+      enable_full_s3_access: False
+      enable_s3_bucket_upload: True
+      s3_upload_buckets:
+        - tb-appointment-stage-frontend


### PR DESCRIPTION
## Description of the Change

We just switched over to using StackAccessPolicies for access, and it seems the issue with that is we lack certain policies for resources that exist outside the scope of a stack (like an ECR repository, for example). These are the things that the AwsAutomationUser was built for, and I just got rid of those. That was a mistake.

When reinstating those CI permissions, I found a number of improvements to make in this code, and therfore this PR has come to exist.

## Benefits

Get appropriate CI permissions scoped to the environment.