### PR TITLE
Add MAX_LENGTH help & check to Availability Page Description

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -23,6 +23,7 @@
     "dataSourceIsEmpty": "{name} konnte nicht gefunden werden.",
     "externalAccountHasNoCalendars": "Dein {external}-Konto enthält keine Kalender. Bitte verbinde ein anderes Konto.",
     "fieldIsRequired": "{field} darf nicht leer sein.",
+    "fieldIsTooLong": "{field} darf höchstens {value} Zeichen lang sein.",
     "generalBookingError": "Beim Abrufen des Zeitplans ist ein Problem aufgetreten. Bitte später nochmal versuchen.",
     "googleRefreshError": "Es gab ein Problem mit Google, bitte erneut verbinden.",
     "invalidTimeConfiguration": "Das Ende muss mindestens {value} nach dem Start sein und angrenzende Zeiten dürfen sich nicht überlappen.",
@@ -40,6 +41,7 @@
     "weCouldntConnect": "Es konnte keine Verbindung hergestellt werden."
   },
   "fields": {
+    "details": "Seitenbeschreibung",
     "slot_duration": "Dauer",
     "unknown": "Unbekannt"
   },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -23,6 +23,7 @@
     "dataSourceIsEmpty": "No {name} could be found.",
     "externalAccountHasNoCalendars": "Your {external} account contains no calendars. Please connect a different account.",
     "fieldIsRequired": "{field} cannot be empty.",
+    "fieldIsTooLong": "{field} should have at most {value} characters.",
     "generalBookingError": "Sorry, there was a problem retrieving the schedule details. Please try again later.",
     "googleRefreshError": "Error connecting with Google API, please re-connect.",
     "invalidTimeConfiguration": "Please make sure the end time is at least {value} after the start and adjacent times are valid.",
@@ -40,6 +41,7 @@
     "weCouldntConnect": "We couldn't connect to your calendar."
   },
   "fields": {
+    "details": "Page Description",
     "slot_duration": "Slot Duration",
     "unknown": "Unknown"
   },

--- a/frontend/src/models.ts
+++ b/frontend/src/models.ts
@@ -367,7 +367,7 @@ export type ExceptionDetail = {
   status?: number;
 }
 export type PydanticExceptionDetail = {
-  ctx: { reason: string, ge?: string },
+  ctx: { reason: string, ge?: string, max_length?: number },
   input: string,
   loc: string[],
   msg: string,

--- a/frontend/src/stores/schedule-store.ts
+++ b/frontend/src/stores/schedule-store.ts
@@ -139,6 +139,9 @@ export const useScheduleStore = defineStore('schedules', () => {
           const timeZoned = dj(err.ctx['err_value'], 'HH:mm:ss').utc(true).tz(dj.tz.guess());
           message = err.msg.replace('{field}', i18n.t('label.endTime'));
           message = message.replace('{value}', timeZoned.format(timeFormat()));
+        } else if (err.type === 'string_too_long') {
+          const maxLength = err.ctx.max_length;
+          message = i18n.t('error.fieldIsTooLong', { field: fieldLocalized, value: maxLength })
         }
 
         return message;

--- a/frontend/src/views/AvailabilityView/components/BookingPageDetails/index.vue
+++ b/frontend/src/views/AvailabilityView/components/BookingPageDetails/index.vue
@@ -27,6 +27,9 @@ const pageDescription = computed({
   }
 })
 
+const MAX_DESCRIPTION_LENGTH = 250;
+const pageDescriptionHelpLabel = computed(() => `${pageDescription.value?.length.toString() ?? 0}/${MAX_DESCRIPTION_LENGTH}`)
+
 const autoGenerateZoomLink = computed({
   get: () => currentState.value.meeting_link_provider === MeetingLinkProviderType.Zoom,
   set: (value) => {
@@ -84,8 +87,11 @@ export default {
     <!-- Page description -->
     <text-area
       name="pageDescription"
-      :placeholder="t('label.enterDescriptionToSchedulingPage')"
+      class="page-description"
       v-model="pageDescription"
+      :placeholder="t('label.enterDescriptionToSchedulingPage')"
+      :max-length="MAX_DESCRIPTION_LENGTH"
+      :help="pageDescriptionHelpLabel"
     >
       {{ t('label.pageDescription') }}:
     </text-area>
@@ -151,6 +157,13 @@ h3 {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+
+  .page-description {
+    /* Help text (character count) */
+    & :last-child {
+      justify-content: end;
+    }
+  }
 }
 
 .auto-generate-link-container {

--- a/frontend/src/views/AvailabilityView/index.vue
+++ b/frontend/src/views/AvailabilityView/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { inject, ref } from 'vue';
+import { inject, ref, useTemplateRef } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { storeToRefs } from 'pinia';
 import { callKey, dayjsKey } from '@/keys';
@@ -28,6 +28,7 @@ const { currentState, isDirty } = storeToRefs(availabilityStore)
 const savingInProgress = ref(false);
 const validationError = ref<Alert>(null);
 const saveSuccess = ref<Alert>(null);
+const availabilityPageForm = useTemplateRef('availability-form');
 
 function validateSchedule(schedule) {
   // Schedule name is empty
@@ -64,6 +65,14 @@ async function onSaveChanges() {
   const validationErrorMessage = validateSchedule(obj);
   if (validationErrorMessage) {
     validationError.value = { title: validationErrorMessage };
+    savingInProgress.value = false;
+    window.scrollTo(0, 0);
+    return;
+  }
+
+  // Use built-in form field validations
+  if (!availabilityPageForm.value.checkValidity()) {
+    availabilityPageForm.value.reportValidity();
     savingInProgress.value = false;
     window.scrollTo(0, 0);
     return;
@@ -129,7 +138,7 @@ export default {
     @close="saveSuccess = null"
   />
 
-  <form @submit.prevent>
+  <form ref="availability-form" @submit.prevent>
     <div class="page-content" :class="{ 'is-dirty': isDirty }">
       <section>
         <availability-settings />


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->

- (Re?) Added the character count to the Page Description text area in the Availability page.
- Even though it shouldn't be possible due to the `max-length` definition on the field, in case somehow it gets sent to the backend, parse the error type and show a more meaning error message. We probably need to refactor this soon but this has already been captured in this issue: https://github.com/thunderbird/appointment/issues/270.
- Even though it should prevent adding more than 250 characters, add a standard HTML form validation to the whole form during submission to show the 'red border' in case it is invalid.

https://github.com/user-attachments/assets/2b96f091-ccc7-4763-984a-5127a63ce5f3




## Benefits

<!-- What benefits will be realized by the code change? -->
- Better guardrails for users in terms of Availability page description
- Better error handling / error message for this type of error

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/1230
https://github.com/thunderbird/appointment/issues/270