### PR TITLE
Fix Availability times visually changing upon navigation

### DIFF
--- a/frontend/src/stores/availability-store.ts
+++ b/frontend/src/stores/availability-store.ts
@@ -122,6 +122,10 @@ export const useAvailabilityStore = defineStore('availability', () => {
 
 export const createAvailabilityStore = (call: Fetch) => {
   const store = useAvailabilityStore();
-  store.init(call);
+
+  if (!store.isLoaded) {
+    store.init(call);
+  }
+
   return store;
 };


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
The initialization process upon the Availability Pinia store creation should be done only once upon creation. In case a user of the store wants to re-initialize it, one must call `$reset` instead.

The problem happened because upon page mount, the store was being initialized again which was wrongly re-initializing the form which tried to convert the `start_time` and `end_time` again (double conversion upon the same value).

## Benefits

<!-- What benefits will be realized by the code change? -->
- None of the form data is reinitialized all the time upon route navigation / page mount.
- The `start_time` and `end_time` of availability doesn't get double (or triple, etc) converted every time you navigate back n forth.

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/1206