### PR TITLE
Separate JSONified values into individual config values in stage

### DIFF
--- a/pulumi/Pulumi.stage.yaml
+++ b/pulumi/Pulumi.stage.yaml
@@ -32,3 +32,41 @@ config:
     secure: AAABAJ+sz3uATNZnjNUsspGwsrxF3FUD4DQZNlimM/Je7tw33yuAEI5Re1pDiEwr
   appointment:database-name:
     secure: AAABACPpIYxhnKi5BeFbr1WQTH6QnKGG6tvQF8Woyo9axIjU9oKHHQxQFQ==
+  appointment:database-encryption-secret:
+    secure: AAABAONEkCTrlE2n9FRbrrgA1Ly8G1HKd9rsY0ZlL/vDKm5f/dMLCLhKdx98kS2u2bl7kxPmfCvlgLg6/bDBdaefff5XGaW69LT6t4q8Yw/tAqt11Y/uoN03LbhlNqF26iCbrCVpKeSXZKPQQM7xbiSPHuwahKRoLVf/MTiFGRJWNV6YSnI4nz8GheEpPjppPn8+RCf04NyeejLUrTgZVA==
+  appointment:signed-url-secret:
+    secure: AAABAEp0VoLRwzlD0Uw5UaNo3QDVnwf7VNcJP9VrE8JUs2qK2Nena+kUsM+cdYYkaAyFNPXdzMIbGjXxcX9YnUANze+jvHJHJTZGrVt/HULedX8QPR4dWF8TTUHq+hzMfHzeGOxfyJlnJ4yrsglz3MkPDZ3bEJbYN6VVCPobqzaGGREHtRRGT5T/Wb0E84OiPKt0jKmnrqyVIFR+jX8Xxw==
+  appointment:session-encryption-secret:
+    secure: AAABAKDl3l0FXqWodAEonWD80QAKrDsKH1ytc4Lf7cPyF395J9C/NAyGrXqIs16A9URuduL7Rz6eDHkgv0nSf4Gxm10hV4KZUu1gUyPbLeT1Hn+bd7phElnSsmEXPBT4NaYfEoUzkCqEPv4cXarD4/Wg7H6cZykywrJ/lf/9fIxrFeqUDndEf042SY+D6sbDBggYKHQyNyXcMlDoK4itj1xzoGAmXgjQvECxTSnt6PCZvMInv8hAXPZQlRjMgvnlUUnV4caKhXpBR0TUGcn7utL4Ahs8AWYM8zpDQtuGVdcOmoPkYIY0hiZNfqZo6sv4eyFdWWTsarVX8mgTa/9IjliLHSng5DTXTHmertbr4qQiXt1rIw2CaMyVd4oS2uIR
+  appointment:jwt-secret:
+    secure: AAABAK37QHYPTuklLMtHEQkpZMYdt09BPe0wALOdu9KOoTwsYPVK6URChKlNTU6ZZ0aDdj4Usx97pAF03asio/yLtKmGTj1gavlILE1GD5WMbQnTsl2t+2SlUCADq6I3hweXMqkZ9uzLDLlxTs/eGjC4+DfWC5b4BZgpcYtmWQJjc49fxQKkOUSdzPvv0/ClxWZ0je7cg7rs/m4H7tBmoTmRJQRhbYzcr6P/eNnYVJWE6mV8thQdetv+x1++urWubYsZDBJ8/3+gZb9zESGaRs7QBvzG2+/O0A1da1TL87e2plgrCqrd4RHDgLU0GA+UsayBPJr1xy8tWiQXsH2gPhFJr1sLXbqEu9oF9cEHsf8HSV9rLRblMoOjEUdK6h3J
+  appointment:smtp-url:
+    secure: AAABAGCCHzyl6yc3vM0W3hfiUQF1L0IIds2KBzt810Nxu8Yi34LJh9bVqXOrb3P+e/7e
+  appointment:smtp-username:
+    secure: AAABAIN028LcusZZscxxCdvf1SiEE60+lfzfb/Ku8t/tSpDnTnwMRmGnBw==
+  appointment:smtp-password:
+    secure: AAABANTxCZ62b6B7k6GSJZxgn7VUr4hsT1HZxmBBIRabwFudgJKnaEcyiYA3UhwjKw==
+  appointment:google-auth-client-id:
+    secure: AAABAAMrqmYmPwQP3ZgR338lvvQ5Ey1Dj+3272MhKfOXLGZXB6gVFDWA2MXmiVxV2uf0jm68pKtAEwJu59J0TZsky9lRN48OWBelyD9p5SJ0C/5gY5eczX4kMCnkpADU95l6FNz4Bpo=
+  appointment:google-auth-secret:
+    secure: AAABADJNOxV6J586G4uvjxAdH/Koo7bI7uk0wrCre9dV8OASESPqAe7rWynpIYRMgNReSJHt0+PdIrsv+8mW1JI88Q==
+  appointment:google-auth-project-id:
+    secure: AAABAK2nIGUSF8PQmSwqgn6WZcdjYjP5qVMyEbD3UxKIYz4MuO+JRcvepWGdaHIi+vOFxK1Nxw==
+  appointment:zoom-client-id:
+    secure: AAABAJYEh9/f+XhfWKtYuksFpNdYZK+OWIvA5kfLUyriEesFm93T8z+XkSL+zFdrvHmr4WIC
+  appointment:zoom-auth-secret:
+    secure: AAABAJ4+G4jTJiLuETGZb/Oz7OLJftGqZh59OswhSCftIw5oZxB0VpbejAh1EpNOSvt1kXRCPzIQGCWdJJ7JBQ==
+  appointment:zoom-api-secret:
+    secure: AAABAHN4fEjjvghxDZB09Oy38wF2/8AVfCe0+X0ncjBDYoR5Q1I5Nr0SxKHv+2b1tnr1xr+2
+  appointment:fxa-client-id:
+    secure: AAABACmttH2jHJb0bc8Ijr8hsj9LJqGfdHdkDQY4/7/8CcEGEbwFOiMgVOWfOgyi
+  appointment:fxa-secret:
+    secure: AAABAN2zzOLvK59xZ3PJyZNXhm/x55hS3rVzRJOuToGUjwufdqv5Iq8bQc7l5RFH+b72yes4tPY+YNS636Nf+eQE0En50cEMTNvWr5pFTJYEtdmBvgT7gl0axO9nd2gj
+  appointment:fxa-openid-config:
+    secure: AAABALN/+NLIqD/AVK0ixneRqQKtEXMSMNTBtagbV7ZdZXiyL6O56yNrZHWqAXP39OLYxNqi9GtavAYIBZIrp61tPlFzLEWKCAqbvSdd8Ebnt8bm9PQB6RIrPFdtIyRQrCI=
+  appointment:fxa-allow-list:
+    secure: AAABAOXdjZdoi+9mhW5me3USch1AMiE9a46K1TcbXwXmFxNsbubJn1mbj7bjyJBHOXzccOxVAUKjgB/VOd7uRMgWMxufxg6OeTN+zpEJefkbNosbVyrALR/QCt3KKQ==
+  appointment:fxa-admin-list:
+    secure: AAABAFDGWcE0W4Dsjg2wBx92Rm7c+2EPad7/CcpVFeuD1BqHEoWz6sE3DeROU/8I
+  appointment:posthog-project-key:
+    secure: AAABAIgp63a9jq1Ltj8E4Tuk3elknijgAii8Cp/vrLDLxXM5RkHPw0UXoKtQ2WEcNnLg82+X4PlDkEBAfOX81T8yHYDi6Mm4E3Er2wShfQ==

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -89,18 +89,37 @@ resources:
       secret_names:
         - database-connection
         - database-encryption
+        - database-encryption-secret
         - database-host
         - database-name
         - database-password
         - database-user
+        - fxa-client-id
+        - fxa-secret
+        - fxa-openid-config
+        - fxa-allow-list
+        - fxa-admin-list
         - fxa-secrets
         - google-oauth
+        - google-auth-client-id
+        - google-auth-secret
+        - google-auth-project-id
+        - jwt-secret
         - neon-database-connection
         - oidc-client-id
         - oidc-client-secret
+        - posthog-project-key
+        - session-encryption-secret
+        - signed-url-secret
         - smtp-connection
+        - smtp-url
+        - smtp-username
+        - smtp-password
         - x-allow-secret
         - zoom-secrets
+        - zoom-client-id
+        - zoom-auth-secret
+        - zoom-api-secret
 
   tb:ec2:SshableInstance: {}
   # Fill out this template to build an SSH bastion
@@ -145,7 +164,7 @@ resources:
           - FARGATE
         container_definitions:
           backend:
-            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/appointment:b5cf7399061638c6b39d3aa8e3ec136caaa725b5
+            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/appointment:3ade29177ce2e361bdb3c2a8b7df1f80928bd8e3
             portMappings:
               - name: backend
                 containerPort: 5000
@@ -155,6 +174,7 @@ resources:
             linuxParameters:
               initProcessEnabled: True
             secrets:
+              # Database connection
               - name: DATABASE_HOST
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/database-host-cMwTdY
               - name: DATABASE_NAME
@@ -163,69 +183,128 @@ resources:
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/database-user-cfbYYI
               - name: DATABASE_PASSWORD
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/database-password-h8xPx9
-              - name: DB_ENC_SECRET
-                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/database-encryption-fY5K5W
+              
+              # Firefox auth
               - name: FXA_SECRETS
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/fxa-secrets-2i62be
-              - name: GOOGLE_OAUTH_SECRETS
-                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/google-oauth-8S9Vvx
+              - name: FXA_CLIENT_ID
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/fxa-client-id-YxqZfU
+              - name: FXA_SECRET
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/fxa-secret-w9FcXe
+              - name: FXA_OPEN_ID_CONFIG
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/fxa-openid-config-r1tYME
+              - name: FXA_ALLOW_LIST
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/fxa-allow-list-xrnkYm
+              - name: APP_ADMIN_ALLOW_LIST
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/fxa-admin-list-71QqCa
+              - name: POSTHOG_PROJECT_KEY
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/posthog-project-key-1h1LsO
+
+              # Google OAuth
+              - name: GOOGLE_AUTH_CLIENT_ID
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/google-auth-client-id-AVHrWq
+              - name: GOOGLE_AUTH_SECRET
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/google-auth-secret-CLWZFR
+              - name: GOOGLE_AUTH_PROJECT_ID
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/google-auth-project-id-fotn7G
+              
+              # OIDC
               - name: OIDC_CLIENT_ID
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/oidc-client-id-l0LS7y
               - name: OIDC_CLIENT_SECRET
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/oidc-client-secret-fMpKjV
-              - name: SMTP_SECRETS
-                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/smtp-connection-5FT5yU
+
+              # STMP via SocketLabs
+              - name: SMTP_URL
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/smtp-url-HAuJtZ
+              - name: SMTP_USER
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/smtp-username-fWTyya
+              - name: SMTP_PASS
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/smtp-password-A5vsVJ
+              
+              # Zoom auth
               - name: ZOOM_SECRETS
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/zoom-secrets-KdyrDH
+              - name: ZOOM_AUTH_CLIENT_ID
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/zoom-client-id-npOU9F
+              - name: ZOOM_AUTH_SECRET
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/zoom-auth-secret-eCUX9h
+              - name: ZOOM_API_SECRET
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/zoom-api-secret-Od9vn5
+
+              # Various encryption settings
+              - name: DB_SECRET
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/database-encryption-secret-R0j1vH
+              - name: SIGNED_SECRET
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/signed-url-secret-FMy5P5
+              - name: SESSION_SECRET
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/session-encryption-secret-6EYEm1
+              - name: JWT_SECRET
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/stage/jwt-secret-JKYzbA
+
             environment:
+              - name: APP_ENV
+                value: stage
+              - name: AUTH_SCHEME
+                value: "oidc"
               - name: DATABASE_ENGINE
                 value: postgresql
               - name: DATABASE_PORT
                 value: '5432'
-              - name: LOG_LEVEL
-                value: ERROR
               - name: FRONTEND_URL
                 value: https://appointment-stage.tb.pro
+              - name: FXA_CALLBACK
+                value: https://appointment-stage.tb.pro/fxa
+              - name: GOOGLE_AUTH_CALLBACK_URL
+                value: https://appointment-stage.tb.pro/api/v1/google/callback
+              - name: JWT_ALGO
+                value: "HS256"
+              - name: JWT_EXPIRE_IN_MINS
+                value: "10000"
+              - name: LOG_LEVEL
+                value: ERROR
+              - name: LOG_USE_STREAM
+                value: "True"
+              - name: OIDC_EXP_GRACE_PERIOD
+                value: "60"
+              - name: OIDC_TOKEN_INTROSPECTION_URL
+                value: "https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/token/introspect"
+              - name: POSTHOG_HOST
+                value: https://us.i.posthog.com
+              - name: REDIS_DB
+                value: "0"
+              - name: REDIS_PORT
+                value: "6379"
+              - name: REDIS_URL
+                value: cache.appointment-stage.tb.pro
+              - name: REDIS_USE_CLUSTER
+                value: "True"
+              - name: REDIS_USE_SSL
+                value: "True"
+              - name: SENTRY_DSN
+                value: https://5dddca3ecc964284bb8008bc2beef808@o4505428107853824.ingest.sentry.io/4505428124827648
+              - name: SERVICE_EMAIL
+                value: no-reply@appointment-stage.tb.pro
               - name: SHORT_BASE_URL
                 value: https://stage.apt.mt/
+              - name: SMTP_PORT
+                value: "587"
+              - name: SMTP_SECURITY
+                value: STARTTLS
+              - name: SUPPORT_EMAIL
+                value: appointment-support@thunderbird.net
               - name: TIER_BASIC_CALENDAR_LIMIT
                 value: "3"
               - name: TIER_PLUS_CALENDAR_LIMIT
                 value: "5"
               - name: TIER_PRO_CALENDAR_LIMIT
                 value: "10"
-              - name: LOG_USE_STREAM
-                value: "True"
-              - name: APP_ENV
-                value: stage
-              - name: SENTRY_DSN
-                value: https://5dddca3ecc964284bb8008bc2beef808@o4505428107853824.ingest.sentry.io/4505428124827648
               - name: ZOOM_API_ENABLED
                 value: "True"
+              - name: ZOOM_API_NEW_APP
+                value: "False"
               - name: ZOOM_AUTH_CALLBACK
                 value: https://appointment-stage.tb.pro/api/v1/zoom/callback
-              - name: SERVICE_EMAIL
-                value: no-reply@appointment-stage.tb.pro
-              - name: AUTH_SCHEME
-                value: "oidc"
-              - name: JWT_ALGO
-                value: "HS256"
-              - name: JWT_EXPIRE_IN_MINS
-                value: "10000"
-              - name: REDIS_URL
-                value: cache.appointment-stage.tb.pro
-              - name: REDIS_PORT
-                value: "6379"
-              - name: REDIS_DB
-                value: "0"
-              - name: REDIS_USE_SSL
-                value: "True"
-              - name: REDIS_USE_CLUSTER
-                value: "True"
-              - name: OIDC_TOKEN_INTROSPECTION_URL
-                value: "https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/token/introspect"
-              - name: OIDC_EXP_GRACE_PERIOD
-                value: "60"
 
   tb:autoscale:EcsServiceAutoscaler:
     backend:
@@ -259,6 +338,8 @@ resources:
 
   tb:ci:AwsAutomationUser:
     ci:
+      access_keys: {}
+      enable_legacy_access_key: True
       additional_policies:
         - arn:aws:iam::768512802988:policy/appointment-stage-frontend-cache-invalidation
       enable_ecr_image_push: True


### PR DESCRIPTION
## Description of the Change

There is a ton of detail in Issue #1110. In lieu of repeating all of that, I'll say this is sort of a "Phase One" of that ticket. This separates the JSONified values into separate config options in stage, moving some into new secrets and some into plaintext env-vars.

## Benefits

Better visibility into the running app config. Better granularity in our ability to make changes.

## Applicable Issues

#1110 
