### PR TITLE
Fix refresh button on model in Availability page

### DIFF
--- a/frontend/src/components/ConfirmationModal.vue
+++ b/frontend/src/components/ConfirmationModal.vue
@@ -57,7 +57,9 @@ const emit = defineEmits(['close', 'confirm', 'error']);
         :label="confirmLabel"
         @click="emit('confirm')"
         :title="t('label.confirm')"
-      />
+      >
+        {{ t('label.confirm') }}
+      </primary-button>
       <danger-button
         v-else
         class="btn-confirm"

--- a/frontend/src/views/SettingsView/components/ConnectedApplications.vue
+++ b/frontend/src/views/SettingsView/components/ConnectedApplications.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { IconDots } from '@tabler/icons-vue';
-import { PrimaryButton, PrimaryBadge, CheckboxInput } from '@thunderbirdops/services-ui';
+import { PrimaryButton, BaseBadge, CheckboxInput } from '@thunderbirdops/services-ui';
 import { storeToRefs } from 'pinia';
 import { CalendarProviders, ExternalConnectionProviders } from '@/definitions';
 import DropDown from '@/elements/DropDown.vue';
@@ -207,9 +207,9 @@ async function refreshData() {
             @change="(event) => onCalendarChecked(event, calendar.id)"
             :checked="currentState.changedCalendars?.[calendar.id] !== undefined ? currentState.changedCalendars[calendar.id] : calendar.connected"
           />
-          <primary-badge v-if="currentState.defaultCalendarId === calendar.id">
+          <base-badge v-if="currentState.defaultCalendarId === calendar.id">
             {{ t('label.default') }}
-          </primary-badge>
+          </base-badge>
           <p>{{ calendar.title }}</p>
         </div>
   


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
- As part of the recent updates in the `services-ui` regarding buttons, they now require the default slot to be filled for the label to show up. This PR fixes the refresh button by adding the button label in the default slot of the primary button.
- (Unrelated) Also fixing the `BaseBadge` component on the Settings page as a `PrimaryBadge` component no longer exists.

## Benefits

<!-- What benefits will be realized by the code change? -->
- Settings page loads correctly
- Availability page's refresh button has a label.

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/1266