### PR TITLE
Separate JSONified values into individual values in prod

### DIFF
--- a/pulumi/Pulumi.prod.yaml
+++ b/pulumi/Pulumi.prod.yaml
@@ -25,3 +25,41 @@ config:
     secure: AAABALqKhforwIPv0VrT26wjnZywcXOZyPesItCEp3Z2DDZwNcbe96gFMKtndZoD
   appointment:database-name:
     secure: AAABAEhOw/G08M7QWETxNEoRig52DtSd+pt9tnI1aoJgDdmH2Lle3vxeIw==
+  appointment:database-encryption-secret:
+    secure: AAABAGjFHukNdFgkBfY7igkACYigPzrI2M5hxd+82gRPw1kZp2KxjUuC7IogJK3uEdG8dV+IXJtEmWpS4duC9DDzzG0xV8SKMk5PdmSgY90TG8lamPKQiaXuRtk+mMsOxVs7WcCZKt92yf7eRq0UdsgL3wEaGVc95b6BmNs8ncb8JOQuqTN7Mkq4RQc+929MwdzWLCaTXwiuU5pjqf2FGg==
+  appointment:signed-url-secret:
+    secure: AAABAJFzSgCo8d5nKTXMPXFLsRqD5RPNgszvJwcXls2FY4ZLfZLW63ATjboHghmjDhCFkISYObEuejbPaw74E8Us2hJUuzQF5AKDq8H+oOkS6wWuUOXIMvwpJRRoMf+HuJwqcctwVdTclGVFcCPng7sJtELtPj9XDisxwsZS5weId4RDG3yfmVhWW5niQk+qW9GYBFbsUJgDxCf3S39Kdg==
+  appointment:session-encryption-secret:
+    secure: AAABAPDisxKhQHpBlPDqSGwt9BIYsjkbEVkdlOHYiTCyQVR7ib/GGZAde7hyZ22S/xZuksW42AchHZ7pSHkBbbb+3MsgwloyRRCEasRKZUIxc2wFrvk/icBOUyobylkMMavd9ugXFmRQQ8/PBJ3QKQpede4QbYIwV3Hg1SxL+MJMZaOBS+cfJntD8YGYrHk9UZb08PK6/+pJUBttgKHv4uFNb4GCN3/olTDJ6b4P5J02ABiyzRsS4k/nf+nJ8XqEy1+uU4MShtGxDQCWx6GKPOWKy+x0iwDaphzNlNtZ++534niIjRIJwFDPgzBK5nK5DMsuO61kqeI1aq5u84XaCjSp8AW6KS+QzMINQPe4XFUa/57UY70eFHH/IfDqWzwQ
+  appointment:jwt-secret:
+    secure: AAABAOk3b6llGm+wDOXk0Ltf7/BDSIkfLSmA2Q56hTJ2HA9m4bvpKOPl9c2UHucKWD49bMAFtKwjOowjI7kYxcsoayZ3ag1kP8zZ6Wt3Yp163XXmkrdHgdVM5h2mbsuEQDqlrk2N8X2nFP0jxhkWZNGaTDcADWi5e09SBbd/JVT3KKGdV1sj+FDM03MC3q308ZRKl6elsygMk6oS85Jr1DBcXq5IVC/b20DVf5HeGj7Nt+jd+RnSFwsrZuP9bBepKMIqwxUrjIvbtmLtJcsK2WA3RFZC0mhXYF/N3mS9QyqsmbRmR5kOzU3kIZ8uV7OvpqUUG8f7MtMTRZV2LAJ86MSFPFlg1YAwn2t3N2AQBhm1jO+/uAwg44KQeDFhuncl
+  appointment:smtp-url:
+    secure: AAABAIf1fkRe93kIpcX84pBwsxyOW7RCbSRHM26G5rXNI5Sv4j6dUX0cJepHr6b2Q189
+  appointment:smtp-username:
+    secure: AAABAH7xFvt5hYg7Apwp+4WsyaQJMdylQS82pEggbqIB1pqRXdAbJixF2A==
+  appointment:smtp-password:
+    secure: AAABADR2aPhMbwVyLUKpQCXVArrafvo57gjx4YHkg+OVkgTCIz2h1rAboLu/wUmCGQ==
+  appointment:google-auth-client-id:
+    secure: AAABADyDdiU79PHuM3S84LHy6xuPa12KPG5LYwAIo4Orp/SJUBq6qqVzUyfY4Yr+aQKKBy/dfcGgxrYb9WhpkAY/WKzgJ7cKoyaQ8U8BklMT1qAgnxye5v/ZZQL+FlSeU85EnOtNBoM=
+  appointment:google-auth-secret:
+    secure: AAABAC/JrP1PlvdOO/oVCTdQUFJ7gyEv4bq1TLlMu6wbrSKOfoPohFsVzb5WXthJWpiqhCOoB3O8FeuygVQaqxOwXg==
+  appointment:google-auth-project-id:
+    secure: AAABAI6ptzC1cQDJH9kXsDTq27ADpE22Z1RlrJuyzoaQaF2jfzm+8Nd0B5j5OpsaU3K6vfLcuA==
+  appointment:zoom-client-id:
+    secure: AAABAK9oY4CHJe8UvV1yNKlFCXDpBWqyK7P2CRNAaeSP1HSNeSsnrluVElpoYIZO4NijX3kX
+  appointment:zoom-auth-secret:
+    secure: AAABANKi3OmjMQbqjPKnUl0qyM4/ZJrlCxjs+GvQ7enUBm4IqL4QIgp7VFTPN7jspmnGTkr3ZpL6BxlMKfU/fg==
+  appointment:zoom-api-secret:
+    secure: AAABANVV56anW2LuPdU0E3hDgdRcisQwfi3h4tJda59pPiHG+zOEcLh8KVTmtKDYY4wqgxvN
+  appointment:fxa-client-id:
+    secure: AAABAOIYnd1M1pzV/Cybq8JoXa2nUFVpfUwXJvirnyVwpxoMy7YXs4lFPZVUHDsE
+  appointment:fxa-secret:
+    secure: AAABAPu74R3PjWcfOrhT1k/KWT1Vkj3AXE2Q5kwtcIvl/NupCGM1wpzHHYp3qJTpvTQjxUb/GrNHcxWxxp3muQ7WdsmIjQoRqJxfufmppibPNDBaGke3vrXhMY7cFjrI
+  appointment:fxa-openid-config:
+    secure: AAABALmuQpYbCrfqeW0tPFqcDkB/okqKoh1rXmy3X4XpGgTFBGQqV9MK+NOoM66qX/YQ11R1HgJgc5s7cRCeKHax7a9eD/We0X/0uTEm6mgOe+1i/lG5PH4L/wxM
+  appointment:fxa-allow-list:
+    secure: AAABAB27/gfn4Migu0c9XgH+XS3f/psD7b3EXiGc6P3DGU11a7P2ONWuwZUxE3M0Hn5Vkf18x9IsnREqeJAhPVDVVE/VhtZn20gnobXOvCGNatY6CVN5llX9uLsgBi++m+KUclAwlnLLRtfO35pm/w9gKVRLp2uIckn/O2siXVhbBM4gFYo8gHhcNzDn2dpv86WYMwicnYnjivj+HpYUth9t7ptEP/PVDfNlG9Ds+eP0FEJx3xrDAXsgsrphOoH54vhcgY3PS2wyFXjYtmQ2MIsz7NEQbrVCsNjz
+  appointment:fxa-admin-list:
+    secure: AAABAMcI1Svz3I0vBeP6tptaRA3MfWXmc1UDUj5MTRj+gAs32al5Uyx35p563AFQAHVjTQ9ry+g15wgXyQRArd5ECKxDRyn1PD8/V5sutyBow+/v2dbWMmdm+qquCdiO52/ApEyJdl2BhpC1Qm2JuOeyBbG7eT4kpN+U/5kJMMISnSafmMM26pc1Rg588ZpjeIw=
+  appointment:posthog-project-key:
+    secure: AAABAKRmpsbJZh+umkJvjdU/AzH/WDX2FtP0ui+cF6Z7hUF0kvEcLazxtArS57ZUqSW8sJtZLnLdFGJHZA4JBeyS04OvmzG5vAmj0OAV/g==

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -89,16 +89,34 @@ resources:
       secret_names:
         - database-connection
         - database-encryption
+        - database-encryption-secret
         - database-host
         - database-name
         - database-password
         - database-user
+        - fxa-admin-list
+        - fxa-allow-list
+        - fxa-client-id
+        - fxa-openid-config
+        - fxa-secret
         - fxa-secrets
+        - google-auth-client-id
+        - google-auth-secret
+        - google-auth-project-id
         - google-oauth
+        - jwt-secret
+        - posthog-project-key
+        - session-encryption-secret
+        - signed-url-secret
         - smtp-connection
+        - smtp-password
+        - smtp-url
+        - smtp-username
         - x-allow-secret
+        - zoom-api-secret
+        - zoom-auth-secret
+        - zoom-client-id
         - zoom-secrets
-        # - neon-database-connection
 
   tb:ec2:SshableInstance: {}
   # Fill out this template to build an SSH bastion
@@ -153,6 +171,7 @@ resources:
             linuxParameters:
               initProcessEnabled: True
             secrets:
+              # Databsase connection
               - name: DATABASE_HOST
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/database-host-jjBGiD
               - name: DATABASE_NAME
@@ -161,61 +180,126 @@ resources:
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/database-password-lrx1wH
               - name: DATABASE_USERNAME
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/database-user-F5eCXv
-              - name: DB_ENC_SECRET
-                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/database-encryption-uS7JBM
+
+              # Firefox auth
               - name: FXA_SECRETS
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/fxa-secrets-tbPt8s
+              - name: FXA_CLIENT_ID
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/fxa-client-id-Kw1MOD
+              - name: FXA_SECRET
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/fxa-secret-bVZQ1Q
+              - name: FXA_OPEN_ID_CONFIG
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/fxa-openid-config-FoRyD4
+              - name: FXA_ALLOW_LIST
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/fxa-allow-list-5BMjhF
+              - name: APP_ADMIN_ALLOW_LIST
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/fxa-admin-list-LGZ72H
+              - name: POSTHOG_PROJECT_KEY
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/posthog-project-key-wU9Dyi
+
+              # Google OAuth
+              - name: GOOGLE_AUTH_CLIENT_ID
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/google-auth-client-id-FFp5Se
+              - name: GOOGLE_AUTH_SECRET
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/google-auth-secret-HkUTMA
+              - name: GOOGLE_AUTH_PROJECT_ID
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/google-auth-project-id-1LsMyl
               - name: GOOGLE_OAUTH_SECRETS
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/google-oauth-aSrasg
+              
+              # OIDC ???
+
+              # STMP via SocketLabs
               - name: SMTP_SECRETS
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/smtp-connection-eW2HFf
+              - name: SMTP_URL
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/smtp-url-d48icD
+              - name: SMTP_USER
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/smtp-username-hx6dcp
+              - name: SMTP_PASS
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/smtp-password-ItpbDS
+              
+              # Zoom auth
               - name: ZOOM_SECRETS
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/zoom-secrets-btmho1
+              - name: ZOOM_AUTH_CLIENT_ID
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/zoom-client-id-BA59JX
+              - name: ZOOM_AUTH_SECRET
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/zoom-auth-secret-fJa1R1
+              - name: ZOOM_API_SECRET
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/zoom-api-secret-5JqmI2
+
+              # Various encryption secrets
+              - name: DB_ENC_SECRET
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/database-encryption-uS7JBM
+              - name: DB_SECRET
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/database-encryption-secret-Ozx7B2
+              - name: SIGNED_SECRET
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/signed-url-secret-P75Afi
+              - name: SESSION_SECRET
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/session-encryption-secret-z1Z9wK
+              - name: JWT_SECRET
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/jwt-secret-NrzNnW
+
             environment:
+              - name: APP_ENV
+                value: prod
+              - name: AUTH_SCHEME
+                value: "fxa"
               - name: DATABASE_ENGINE
                 value: postgresql
               - name: DATABASE_PORT
                 value: '5432'
-              - name: LOG_LEVEL
-                value: ERROR
+              - name: FXA_CALLBACK
+                value: https://appointment.day/fxa
               - name: FRONTEND_URL
                 value: https://appointment.tb.pro
+              - name: GOOGLE_AUTH_CALLBACK_URL
+                value: https://appointment.tb.pro/api/v1/google/callback
+              - name: JWT_ALGO
+                value: "HS256"
+              - name: JWT_EXPIRE_IN_MINS
+                value: "10000"
+              - name: LOG_LEVEL
+                value: ERROR
+              - name: LOG_USE_STREAM
+                value: "True"
+              - name: POSTHOG_HOST
+                value: https://us.i.posthog.com
+              - name: REDIS_DB
+                value: "0"
+              - name: REDIS_PORT
+                value: "6379"
+              - name: REDIS_URL
+                value: cache.appointment.tb.pro
+              - name: REDIS_USE_CLUSTER
+                value: "True"
+              - name: REDIS_USE_SSL
+                value: "True"
+              - name: SERVICE_EMAIL
+                value: no-reply@appointment.tb.pro
+              - name: SMTP_PORT
+                value: "587"
+              - name: SMTP_SECURITY
+                value: STARTTLS
+              - name: SENTRY_DSN
+                value: https://5dddca3ecc964284bb8008bc2beef808@o4505428107853824.ingest.sentry.io/4505428124827648
               - name: SHORT_BASE_URL
                 value: https://apt.mt/
+              - name: SUPPORT_EMAIL
+                value: appointment-support@thunderbird.net
               - name: TIER_BASIC_CALENDAR_LIMIT
                 value: "3"
               - name: TIER_PLUS_CALENDAR_LIMIT
                 value: "5"
               - name: TIER_PRO_CALENDAR_LIMIT
                 value: "10"
-              - name: LOG_USE_STREAM
-                value: "True"
-              - name: APP_ENV
-                value: prod
-              - name: SENTRY_DSN
-                value: https://5dddca3ecc964284bb8008bc2beef808@o4505428107853824.ingest.sentry.io/4505428124827648
               - name: ZOOM_API_ENABLED
                 value: "True"
               - name: ZOOM_AUTH_CALLBACK
                 value: https://appointment.tb.pro/api/v1/zoom/callback
-              - name: SERVICE_EMAIL
-                value: no-reply@appointment.tb.pro
-              - name: AUTH_SCHEME
-                value: "fxa"
-              - name: JWT_ALGO
-                value: "HS256"
-              - name: JWT_EXPIRE_IN_MINS
-                value: "10000"
-              - name: REDIS_URL
-                value: cache.appointment.tb.pro
-              - name: REDIS_PORT
-                value: "6379"
-              - name: REDIS_DB
-                value: "0"
-              - name: REDIS_USE_SSL
-                value: "True"
-              - name: REDIS_USE_CLUSTER
-                value: "True"
+              - name: ZOOM_API_NEW_APP
+                value: "False"
 
   tb:autoscale:EcsServiceAutoscaler:
     backend:
@@ -249,6 +333,8 @@ resources:
 
   tb:ci:AwsAutomationUser:
     ci:
+      access_keys: {}
+      enable_legacy_access_key: True
       additional_policies:
         - arn:aws:iam::768512802988:policy/appointment-prod-frontend-cache-invalidation
       enable_ecr_image_push: True

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -206,8 +206,6 @@ resources:
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/google-auth-project-id-1LsMyl
               - name: GOOGLE_OAUTH_SECRETS
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/google-oauth-aSrasg
-              
-              # OIDC ???
 
               # STMP via SocketLabs
               - name: SMTP_SECRETS


### PR DESCRIPTION
## Description of the Change

There is a ton of detail in Issue #1110. This change was previously made in stage with PR #1270. This separates the JSONified values into separate config options in PROD, moving some into new secrets and some into plaintext env-vars.

## Benefits

Better visibility into the running app config. Better granularity in our ability to make changes.

## Applicable Issues

#1110

The change in the task definition is shown by [this `pulumi preview` command](https://app.pulumi.com/mzla-services/appointment/prod/previews/01f5351d-2ac1-42b3-9eae-0d09904fc42a).
