### PR TITLE
Test ids for week calendar events

### DIFF
--- a/frontend/src/views/DashboardView/components/WeekCalendar.vue
+++ b/frontend/src/views/DashboardView/components/WeekCalendar.vue
@@ -8,7 +8,7 @@ import { useUserStore } from '@/stores/user-store';
 import EventPopup from '@/elements/EventPopup.vue';
 import { initialEventPopupData, showEventPopup, darkenColor, hexToRgba, hhmmToMinutes, minutesToHhmm } from '@/utils';
 import { Appointment, EventPopup as EventPopupType, RemoteEvent, Slot } from '@/models';
-import { BookingStatus, ColourSchemes } from '@/definitions';
+import { BookingStatus, ColourSchemes, DateFormatStrings } from '@/definitions';
 import { Dayjs } from 'dayjs';
 
 enum Weekday {
@@ -370,6 +370,7 @@ const filteredSelectableSlotsForGrid = computed(() => {
       class="time-slot-cell"
       :key="timeSlot.startTime"
       :style="{ gridRow: `${timeSlot.gridRowStart} / ${timeSlot.gridRowEnd}`, gridColumn: 1 }"
+      :data-testid="`time-${timeSlot.startTime}`"
     >
       {{ timeSlot.text }}
     </div>
@@ -387,6 +388,7 @@ const filteredSelectableSlotsForGrid = computed(() => {
       }"
       @mouseenter="(event) => onRemoteEventMouseEnter(event, remoteEvent)"
       @mouseleave="onRemoteEventMouseLeave"
+      :data-testid="`remote-event-${dj(remoteEvent.start).format(DateFormatStrings.Qalendar)}`"
     >
       {{ remoteEvent?.title }}
     </div>
@@ -405,6 +407,7 @@ const filteredSelectableSlotsForGrid = computed(() => {
       }"
       @mouseenter="(event) => onRemoteEventMouseEnter(event, pendingAppointment)"
       @mouseleave="onRemoteEventMouseLeave"
+      :data-testid="`pending-appointment-${dj(pendingAppointment.start).format(DateFormatStrings.Qalendar)}`"
     >
       {{ pendingAppointment?.title }}
     </div>
@@ -421,6 +424,7 @@ const filteredSelectableSlotsForGrid = computed(() => {
         backgroundColor: hexToRgba(slot?.calendar_color, 0.4),
       }"
       @click="emit('event-selected', slot.start)"
+      :data-testid="`event-${dj(slot.start).format(DateFormatStrings.Qalendar)}`"
     >
       {{ slot?.title }}
     </div>


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change adds test ids to the WeekCalendar component in the following format:

- `time-HH:mm` for the row header
    <img width="655" height="225" alt="image" src="https://github.com/user-attachments/assets/00278bb5-4612-41c4-895b-01f8acdab6b9" />
- `remote-event-YYYY-MM-DD HH:mm` for events coming from a remote calendar
    <img width="655" height="225" alt="image" src="https://github.com/user-attachments/assets/429ddeda-947b-4e64-a455-b769ff5a5f40" />
- `pending-appointment-YYYY-MM-DD HH:mm` for appointments that aren't confirmed yet
    <img width="655" height="225" alt="image" src="https://github.com/user-attachments/assets/429ddeda-947b-4e64-a455-b769ff5a5f40" />
- `event-YYYY-MM-DD HH:mm` for selectable time slots
    <img width="655" height="225" alt="image" src="https://github.com/user-attachments/assets/fc635881-d9b9-4ce6-af92-70592e2949cd" />


## Benefits

Enables e2e tests again.

## Applicable Issues

Fixes #1097 
