### PR TITLE
Remove old JSONified secrets from prod

### DIFF
--- a/backend/.env.test
+++ b/backend/.env.test
@@ -15,6 +15,7 @@ SHORT_BASE_URL=
 
 # -- DATABASE --
 DATABASE_URL=sqlite:///:memory:
+
 # Secret phrase for database encryption (e.g. create it by running `openssl rand -hex 32`)
 DB_SECRET=db-secret-pls-ignore
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,16 +9,6 @@ services:
       - ./backend/.env:/app/.env
       - ./backend/src/appointment:/app/appointment
     environment:
-      # The DATABASE_* variables are set in the example backend .env file, which overrides these
-      # DATABASE_ENGINE=postgresql
-      # DATABASE_HOST=postgresql
-      # DATABASE_NAME=appointment
-      # DATABASE_PASSWORD=abcd%efgh
-      # DATABASE_PORT=5432
-      # DATABASE_USERNAME=tba
-      
-      # The use of DATABASE_URL is problematic and deprecated
-      # - DATABASE_URL=postgresql+psycopg://tba:abcd%efgh@postgresql:5432/appointment
       - IS_LOCAL_DEV=yes
       - RELEASE_VERSION=localdev
 

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -87,8 +87,6 @@ resources:
     pulumi:
       recovery_window_in_days: 0
       secret_names:
-        - database-connection
-        - database-encryption
         - database-encryption-secret
         - database-host
         - database-name
@@ -99,16 +97,13 @@ resources:
         - fxa-client-id
         - fxa-openid-config
         - fxa-secret
-        - fxa-secrets
         - google-auth-client-id
         - google-auth-secret
         - google-auth-project-id
-        - google-oauth
         - jwt-secret
         - posthog-project-key
         - session-encryption-secret
         - signed-url-secret
-        - smtp-connection
         - smtp-password
         - smtp-url
         - smtp-username
@@ -116,7 +111,6 @@ resources:
         - zoom-api-secret
         - zoom-auth-secret
         - zoom-client-id
-        - zoom-secrets
 
   tb:ec2:SshableInstance: {}
   # Fill out this template to build an SSH bastion
@@ -182,8 +176,6 @@ resources:
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/database-user-F5eCXv
 
               # Firefox auth
-              - name: FXA_SECRETS
-                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/fxa-secrets-tbPt8s
               - name: FXA_CLIENT_ID
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/fxa-client-id-Kw1MOD
               - name: FXA_SECRET
@@ -204,12 +196,8 @@ resources:
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/google-auth-secret-HkUTMA
               - name: GOOGLE_AUTH_PROJECT_ID
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/google-auth-project-id-1LsMyl
-              - name: GOOGLE_OAUTH_SECRETS
-                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/google-oauth-aSrasg
 
               # STMP via SocketLabs
-              - name: SMTP_SECRETS
-                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/smtp-connection-eW2HFf
               - name: SMTP_URL
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/smtp-url-d48icD
               - name: SMTP_USER
@@ -218,8 +206,6 @@ resources:
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/smtp-password-ItpbDS
               
               # Zoom auth
-              - name: ZOOM_SECRETS
-                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/zoom-secrets-btmho1
               - name: ZOOM_AUTH_CLIENT_ID
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/zoom-client-id-BA59JX
               - name: ZOOM_AUTH_SECRET
@@ -228,8 +214,6 @@ resources:
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/zoom-api-secret-5JqmI2
 
               # Various encryption secrets
-              - name: DB_ENC_SECRET
-                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/database-encryption-uS7JBM
               - name: DB_SECRET
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:appointment/prod/database-encryption-secret-Ozx7B2
               - name: SIGNED_SECRET


### PR DESCRIPTION
## Description of the Change

This removes the last of the secrets from the prod environment. It also adjusts the code that generates database URLs because we use sqlite in our tests. I tried finding the right individual settings to support in-memory sqlite, but nothing worked easily. So we will continue to support `DATABASE_URL` for the sqlite use case.

[Here is the pulumi diff](https://app.pulumi.com/mzla-services/appointment/prod/previews/3258a7b2-798c-46c8-a471-b50156c72698) for the task definition.

## Benefits

Clean, tidy code with less configuration obscurity.

## Applicable Issues

#1110
