### PR TITLE
Change AUTH_SCHEME to OIDC

### DIFF
--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -227,7 +227,7 @@ resources:
               - name: APP_ENV
                 value: prod
               - name: AUTH_SCHEME
-                value: "fxa"
+                value: oidc
               - name: DATABASE_ENGINE
                 value: postgresql
               - name: DATABASE_PORT


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
For `prod` / `appointment.tb.pro`, I've created a Keycloak client id for Appointment Frontend but I can't actually login since the `AUTH_SCHEME` is set to `fxa` instead of `oidc`.

All the code to login through oidc seems to be in place as I can verify that pointing my local to the stage realm works well at the moment.

Can this be added only for the `appointment.tb.pro` and not to `appointment.day`?

## Benefits

<!-- What benefits will be realized by the code change? -->
- Hopefully be able to login in `appointment.tb.pro` using keycloak.

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/1275