### PR TITLE
Fix Google auth env var name

### DIFF
--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -244,7 +244,7 @@ resources:
                 value: https://appointment.day/fxa
               - name: FRONTEND_URL
                 value: https://appointment.tb.pro
-              - name: GOOGLE_AUTH_CALLBACK_URL
+              - name: GOOGLE_AUTH_CALLBACK
                 value: https://appointment.tb.pro/api/v1/google/callback
               - name: JWT_ALGO
                 value: "HS256"

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -245,7 +245,7 @@ resources:
                 value: https://appointment-stage.tb.pro
               - name: FXA_CALLBACK
                 value: https://appointment-stage.tb.pro/fxa
-              - name: GOOGLE_AUTH_CALLBACK_URL
+              - name: GOOGLE_AUTH_CALLBACK
                 value: https://appointment-stage.tb.pro/api/v1/google/callback
               - name: JWT_ALGO
                 value: "HS256"


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
We are expecting the google auth callback env var to be `GOOGLE_AUTH_CALLBACK` and not `GOOGLE_AUTH_CALLBACK_URL` per existing code: https://github.com/thunderbird/appointment/blob/main/backend/src/appointment/dependencies/google.py#L11

## Benefits

<!-- What benefits will be realized by the code change? -->
- Google Auth redirect URI should be passed on successfully for auth

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/1275