### PR TITLE
Export users to keycloak via Admin API

### DIFF
--- a/backend/src/appointment/commands/export_users_to_keycloak.py
+++ b/backend/src/appointment/commands/export_users_to_keycloak.py
@@ -1,0 +1,80 @@
+import logging
+import os
+import requests
+from ..database import models
+from ..dependencies.database import get_engine_and_session
+
+
+def export_users() -> None:
+    """Export all users to Keycloak via API"""
+
+    logging.info('Starting Keycloak user export via API...')
+
+    # Get required environment variables
+    tb_accounts_host = os.getenv('TB_ACCOUNTS_HOST')
+    realm = os.getenv('KEYCLOAK_REALM')
+
+    if not tb_accounts_host:
+        logging.error('TB_ACCOUNTS_HOST environment variable is not set')
+        raise ValueError('TB_ACCOUNTS_HOST environment variable is required')
+
+    if not realm:
+        logging.error('KEYCLOAK_REALM environment variable is not set')
+        raise ValueError('KEYCLOAK_REALM environment variable is required')
+
+    api_url = f'{tb_accounts_host}/admin/realms/{realm}/users'
+    logging.info(f'Target API URL: {api_url}')
+
+    _, session = get_engine_and_session()
+    db = session()
+
+    try:
+        # Get all subscribers (not paginated for export)
+        subscribers = db.query(models.Subscriber).all()
+        total_users = len(subscribers)
+        logging.info(f'Found {total_users} users to export')
+
+        success_count = 0
+        error_count = 0
+
+        for idx, subscriber in enumerate(subscribers, 1):
+            email = subscriber.email
+
+            try:
+                # Make POST request with only email field
+                response = requests.post(
+                    url=api_url,
+                    json={
+                        'email': email,
+                        'emailVerified': 'true',
+                        'username': subscriber.username
+                    },
+                    headers={'Content-Type': 'application/json'},
+                    timeout=30,
+                )
+
+                response.raise_for_status()
+                logging.info(f'[{idx}/{total_users}] Successfully exported user: {email}')
+                success_count += 1
+
+            except requests.HTTPError as e:
+                logging.error(
+                    f'[{idx}/{total_users}] Failed to export user {email}: '
+                    f'HTTP {e.response.status_code} - {e.response.text}'
+                )
+                error_count += 1
+            except requests.RequestException as e:
+                logging.error(f'[{idx}/{total_users}] Request failed for user {email}: {str(e)}')
+                error_count += 1
+
+        logging.info(
+            f'Export completed: {success_count} successful, {error_count} failed out of {total_users} total users'
+        )
+
+    finally:
+        db.close()
+
+
+def run():
+    """Main entry point for the command"""
+    export_users()

--- a/backend/src/appointment/routes/commands.py
+++ b/backend/src/appointment/routes/commands.py
@@ -4,7 +4,14 @@ from contextlib import contextmanager
 import os
 
 import typer
-from ..commands import update_db, download_legal, create_invite_codes, setup, generate_documentation_pages
+from ..commands import (
+    update_db,
+    download_legal,
+    create_invite_codes,
+    setup,
+    generate_documentation_pages,
+    export_users_to_keycloak,
+)
 
 router = typer.Typer()
 
@@ -44,6 +51,11 @@ def generate_docs():
 @router.command('create-invite-codes')
 def create_app_invite_codes(n: int):
     create_invite_codes.run(n)
+
+
+@router.command('export-users-to-keycloak')
+def export_users():
+    export_users_to_keycloak.run()
 
 
 @router.command('setup')


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
Example on how to use the [Keycloak Admin REST API](https://www.keycloak.org/docs-api/latest/rest-api/index.html#_users) to create users from our backend.

This assumes that it is possible to run a command inside of the backend container in the various environments.

```
run-command main export-users-to-keycloak
```

I am still unsure on how to create / update custom fields like `timezone`. We have this information already but the Keycloak Admin REST API doesn't seem to have a field for that.

## Benefits

<!-- What benefits will be realized by the code change? -->
Built-in way of importing users into Keycloak, no third party plugins needed for that.

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/1276