### PR TITLE
Fix VITE_SUPPORT_URL

### DIFF
--- a/frontend/.env.prod.example
+++ b/frontend/.env.prod.example
@@ -21,7 +21,7 @@ VITE_REPORT_BUG_URL=https://github.com/thunderbird/appointment/issues/new?assign
 # If the browser's hour setting is empty or missing fallback to this value
 VITE_DEFAULT_HOUR_FORMAT=12
 
-VITE_SUPPORT_URL=https://accounts.tb.pro/contact
+VITE_SUPPORT_URL=https://accounts.tb.pro/contact/
 
 VITE_OIDC_CLIENT_ID=thunderbird-appointment-frontend
 VITE_OIDC_ROOT_URL=https://auth.tb.pro/realms/tbpro/


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->

If we miss the final `/` in URLs, accounts will try to parse the path through the Vue router. Currently, the routing for the contact form is done through Django templates (with a Vue form) instead.

This PR adds the missing final `/`.

## Benefits

<!-- What benefits will be realized by the code change? -->
Redirects works successfully

## Applicable Issues

<!-- Enter any applicable issues here -->
Fixes #1317