### PR TITLE
Remove is_in_allow_list and use preferred_username (the thundermail address) instead of recovery email (Fixes #1329)

### DIFF
--- a/backend/test/integration/test_auth.py
+++ b/backend/test/integration/test_auth.py
@@ -923,7 +923,7 @@ class TestOIDCToken:
             mock_introspect.return_value = {
                 'sub': oidc_id,
                 'email': subscriber.email,
-                'username': subscriber.username,
+                'preferred_username': subscriber.email, # preferred_username is the thundermail address
                 'name': subscriber.name,
             }
 


### PR DESCRIPTION
Fixes #1329 

The user in the ticket has a thundermail address, but their recovery email is not on the allow list so the allow list check fails, and then they're just silently stuck on the frontend. 

So let's nuke the allow list code for oidc auth, and also fix it so we grab their thundermail address instead of recovery email. 