### PR TITLE
Remove VITE_LANDING_PAGE_URL env var and redirect to login if not logged in

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -3,7 +3,6 @@
 # -- Frontend --
 VITE_BASE_URL=localhost:8080
 VITE_SHORT_BASE_URL=http://localhost:8080/user
-VITE_LANDING_PAGE_URL=http://stage.tb.pro/appointment
 # Set true to activate polling for dev server
 VITE_SERVER_WATCH_POLLING=
 VITE_SERVER_WATCH_INTERVAL=

--- a/frontend/.env.prod.example
+++ b/frontend/.env.prod.example
@@ -3,7 +3,6 @@ VITE_API_URL=appointment.tb.pro/api/v1/
 VITE_BASE_URL=appointment.tb.pro
 VITE_API_SECURE=true
 VITE_SHORT_BASE_URL=apt.mt
-VITE_LANDING_PAGE_URL=http://tb.pro/appointment
 
 # -- Sentry --
 VITE_SENTRY_DSN=https://66f57328baac4929be7d62b77f41b510@o4505428107853824.ingest.sentry.io/4505428280279040

--- a/frontend/.env.stage.example
+++ b/frontend/.env.stage.example
@@ -3,7 +3,6 @@ VITE_API_URL=appointment-stage.tb.pro/api/v1/
 VITE_BASE_URL=appointment-stage.tb.pro
 VITE_API_SECURE=true
 VITE_SHORT_BASE_URL=stage.apt.mt
-VITE_LANDING_PAGE_URL=http://stage.tb.pro/appointment
 
 # -- Sentry --
 VITE_SENTRY_DSN=https://66f57328baac4929be7d62b77f41b510@o4505428107853824.ingest.sentry.io/4505428280279040

--- a/frontend/.env.test
+++ b/frontend/.env.test
@@ -3,7 +3,6 @@
 # -- Frontend --
 VITE_BASE_URL=localhost:8080
 VITE_SHORT_BASE_URL=localhost:8080/user
-VITE_LANDING_PAGE_URL=http://stage.tb.pro/appointment
 
 # -- Backend API --
 VITE_API_URL=localhost

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -10,7 +10,7 @@ onMounted(() => {
   if (user.authenticated) {
     router.push('/dashboard');
   } else {
-    window.location.href = import.meta.env.VITE_LANDING_PAGE_URL;
+    router.push('/login');
   }
 });
 </script>


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

Before, if the user is not logged in and they navigate to `appointment.tb.pro`, we would redirect the user to the marketing page at tb.pro/appointment. This caused some confusion so now we are simply redirecting to the login page instead.

- Removes `VITE_LANDING_PAGE_URL` env var since we were only using it for the redirect.
- In the `HomeView`, if not authenticated, redirect to login.

## Benefits

<!-- What benefits will be realized by the code change? -->
- Potentially less confusion as we are not redirecting to a different domain.

## How to test

- When not logged in, navigate to http://localhost:8080 and check if you are redirected to the login instead of the link in `VITE_LANDING_PAGE_URL` env var.

## Applicable Issues

<!-- Enter any applicable issues here -->
https://github.com/thunderbird/appointment/issues/1326