### PR TITLE
Fix schedule public availability test

### DIFF
--- a/backend/test/integration/test_schedule.py
+++ b/backend/test/integration/test_schedule.py
@@ -533,28 +533,30 @@ class TestSchedule:
         monkeypatch.setattr(CalDavConnector, 'get_busy_time', MockCaldavConnector.get_busy_time)
 
         start_date = date(2024, 3, 1)
-        start_time = time(16, tzinfo=UTC)
+        start_time = time(17, tzinfo=UTC)
         # Next day
-        end_time = time(0, tzinfo=UTC)
+        end_time = time(1, tzinfo=UTC)
 
         subscriber = make_pro_subscriber()
         generated_calendar = make_caldav_calendar(subscriber.id, connected=True)
-        make_schedule(
-            calendar_id=generated_calendar.id,
-            active=True,
-            start_date=start_date,
-            start_time=start_time,
-            end_time=end_time,
-            end_date=None,
-            earliest_booking=1440,
-            farthest_booking=20160,
-            slot_duration=30,
-        )
-
         signed_url = signed_url_by_subscriber(subscriber)
 
         # Check availability at the start of the schedule
         with freeze_time(start_date):
+            # We create the schedule inside the freeze_time block to ensure the time_updated
+            # is set to a known date (PST) so start_time_local calculation is deterministic.
+            make_schedule(
+                calendar_id=generated_calendar.id,
+                active=True,
+                start_date=start_date,
+                start_time=start_time,
+                end_time=end_time,
+                end_date=None,
+                earliest_booking=1440,
+                farthest_booking=20160,
+                slot_duration=30,
+            )
+
             response = with_client.post(
                 '/schedule/public/availability',
                 json={'url': signed_url},


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
- The `make_schedule` sets `time_updated` to `func.now()` which creates the time inconsistency if it is not under the `freeze_time`.

In the original test:
- `start_time` was set to 16:00 UTC
- `make_schedule` sets `time_updated` to `func.now()`
- We calculate the local start time by combining `time_updated` with `start_time` and the converting the timezone to `America/Vancouver`
- If the test is ran in PDT
  - 16:00 UTC is 09:00 PDT
  - `start_time_local` becomes 09:00, all good, tests pass, hooray!
- If the test is ran in PST
  - 16:00 UTC is 08:00 PST
  - `start_time_local` becomes 08:00, no good, test fail, boo!

## Benefits

<!-- What benefits will be realized by the code change? -->
- Backend tests should now pass and not flake depending on the time of the year it is being ran.

## Applicable Issues

<!-- Enter any applicable issues here -->
Solves https://github.com/thunderbird/appointment/issues/1340