### PR TITLE
Remove email as login_hint from GoogleOAuth

### DIFF
--- a/backend/src/appointment/controller/apis/google_client.py
+++ b/backend/src/appointment/controller/apis/google_client.py
@@ -48,15 +48,13 @@ class GoogleClient:
         """Actually create the client, this is separate, so we can catch any errors without breaking everything"""
         self.client = Flow.from_client_config(self.config, self.SCOPES, redirect_uri=self.callback_url)
 
-    def get_redirect_url(self, email):
+    def get_redirect_url(self):
         """Returns the redirect url for the google oauth flow"""
         if self.client is None:
             return None
 
         # (Url, State ID)
-        return self.client.authorization_url(
-            access_type='offline', prompt='consent', login_hint=email if email else None
-        )
+        return self.client.authorization_url(access_type='offline', prompt='consent')
 
     def get_credentials(self, code: str):
         if self.client is None:

--- a/backend/src/appointment/routes/google.py
+++ b/backend/src/appointment/routes/google.py
@@ -38,15 +38,12 @@ def google_auth_status(request: Request, subscriber: Subscriber = Depends(get_su
 @router.get('/auth')
 def google_auth(
     request: Request,
-    email: str | None = None,
     google_client: GoogleClient = Depends(get_google_client),
     db: Session = Depends(get_db),
     subscriber: Subscriber = Depends(get_subscriber),
 ):
     """Starts the google oauth process"""
-    if email:
-        email = email.lower()
-    url, state = google_client.get_redirect_url(email)
+    url, state = google_client.get_redirect_url()
 
     request.session[SESSION_OAUTH_STATE] = state
     request.session[SESSION_OAUTH_SUBSCRIBER_ID] = subscriber.id

--- a/frontend/src/components/FTUE/GoogleOauthProvider.vue
+++ b/frontend/src/components/FTUE/GoogleOauthProvider.vue
@@ -6,7 +6,6 @@ import { useRoute, useRouter } from 'vue-router';
 import { PrimaryButton } from '@thunderbirdops/services-ui';
 import { useFTUEStore } from '@/stores/ftue-store';
 import { createCalendarStore } from '@/stores/calendar-store';
-import { useUserStore } from '@/stores/user-store';
 import { createExternalConnectionsStore } from '@/stores/external-connections-store';
 import { callKey } from '@/keys';
 import { ExternalConnectionProviders } from '@/definitions';
@@ -84,13 +83,11 @@ onMounted(async () => {
 });
 
 const onSubmit = async () => {
-  const user = useUserStore();
-
   isLoading.value = true;
 
   // Create key so we can move to the next page after we come back
   localStorage?.setItem(initFlowKey, 'true');
-  await calendarStore.connectGoogleCalendar(user.data.email);
+  await calendarStore.connectGoogleCalendar();
 };
 
 </script>

--- a/frontend/src/stores/calendar-store.ts
+++ b/frontend/src/stores/calendar-store.ts
@@ -33,9 +33,8 @@ export const useCalendarStore = defineStore('calendars', () => {
     call.value = fetch;
   }
 
-  const connectGoogleCalendar = async (email: string) => {
-    const urlFriendlyEmail = encodeURIComponent(email);
-    const googleUrl = await call.value(`google/auth?email=${urlFriendlyEmail}`).get();
+  const connectGoogleCalendar = async () => {
+    const googleUrl = await call.value('google/auth').get();
     window.location.href = googleUrl.data.value.slice(1, -1);
   };
 

--- a/frontend/src/views/SettingsView/components/ConnectedApplications.vue
+++ b/frontend/src/views/SettingsView/components/ConnectedApplications.vue
@@ -69,7 +69,7 @@ const initialCalendars = computed(() => {
 });
 
 async function connectGoogleCalendar() {
-  await calendarStore.connectGoogleCalendar(userStore.data.email);
+  await calendarStore.connectGoogleCalendar();
 }
 
 async function afterCalDavConnect() {


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
By sending in a `login_hint` in the Google OAuth call, we were accidentally triggering Mozilla's SSO which would prevent any non-work computer to add a Google Account to Appointment.

I assume that this was done like this in the hopes of pre-filling the email address in Google's sign in screen. However, we were forcibly sending the logged in user's email as a `login_hint` which is very likely not the account that you want to connect anyways since it would be theoretically already configured... and during my testing it was not pre-filling their email input either.

Passing the `login_hint` is more harm than good IMHO as we could see from the issue that this PR solves so we shouldn't be sending that anymore.

## How to test

- Either in FTUE or in `/settings`, connecting a Google account should still work as usual.

## Benefits

<!-- What benefits will be realized by the code change? -->
- More freedom to user to select any Google account instead of potentially triggering SSOs.

## Applicable Issues

<!-- Enter any applicable issues here -->
Fixes https://github.com/thunderbird/appointment/issues/1354