### PR TITLE
Override Tailwind's Input pre-applied styles

### DIFF
--- a/frontend/src/assets/styles/main.css
+++ b/frontend/src/assets/styles/main.css
@@ -10,18 +10,15 @@
 @layer base {
 
   /* Yep this is needed to "properly" override tailwind form... */
-  [type='text'],
   input:where(:not([type])),
   [type='email'],
   [type='url'],
-  [type='password'],
   [type='number'],
   [type='date'],
   [type='datetime-local'],
   [type='month'],
   [type='search'],
   [type='tel'],
-  [type='time'],
   [type='week'],
   [multiple],
   textarea,
@@ -31,6 +28,17 @@
   select:is(.dark *),
   textarea:is(.dark *) {
     @apply transition-all dark:text-white bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-500;
+  }
+
+  [type='time'],
+  [type='time']:is(.dark *),
+  [type='password'],
+  [type='password']:is(.dark *),
+  [type='text'],
+  [type='text']:is(.dark *) {
+    border: none;
+    background: none;
+    padding: 0;
   }
 
   select {


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
Upstream changes were made that is now affecting our components coming from `services-ui` when being used in a Tailwind context. There is a combination of background, border and padding that is being applied that makes some of the input types to mismatch our current UI mockups.

It would be great if we could spare some time [to completely remove Tailwind as this issue suggests](https://github.com/thunderbird/appointment/issues/495) but there are quite a few references in the code base to Tailwind classes that would require care.

The problem can currently be seen in `stage` in screens like the Availability page, for example: https://appointment-stage.tb.pro/availability. This does not happen in production yet as production is a bit behind.

For now, this PR only touches the affected input types to remove Tailwind's styles.

## Screenshots

Before / Login modal (AUTH_SCHEME=password)
<img width="1505" height="961" alt="image" src="https://github.com/user-attachments/assets/742f51cf-d31e-43c5-943a-9238d32b16f8" />

After / Login modal (AUTH_SCHEME=password)
<img width="1504" height="963" alt="image" src="https://github.com/user-attachments/assets/4f6bcf92-b686-4b9f-a4f6-15705a3f8a48" />


Before / Availability Page
<img width="2988" height="4802" alt="image" src="https://github.com/user-attachments/assets/36791782-ae46-4c81-b963-db937164e9ce" />

After / Availability Page
<img width="3712" height="4570" alt="image" src="https://github.com/user-attachments/assets/1d91364f-0fd7-4bfa-b2d3-cb9f64ebfca1" />


## Benefits

<!-- What benefits will be realized by the code change? -->
Back to cohesive styles for inputs!

## How to test

- When the `AUTH_SCHEME` in the `frontend/.env` file is `password`, check that the password input matches the username input.
- When the `AUTH_SCHEME` in the `frontend/.env` file is `oidc`, check that the FTUE doesn't show any mismatching styles, specially around the Availability step (the time inputs had mismatching UI)
- After creating an account / login in, check the `Availability` page for any mismatching UI input.
- Navigate around for sanity check purposes to see if there's any mismatching inputs.

## Applicable Issues

<!-- Enter any applicable issues here -->
Fixes #1396