### PR TITLE
Fix VITE_SUPPORT_URL contact link

### DIFF
--- a/frontend/.env.prod.example
+++ b/frontend/.env.prod.example
@@ -21,7 +21,7 @@ VITE_REPORT_BUG_URL=https://github.com/thunderbird/appointment/issues/new?assign
 # If the browser's hour setting is empty or missing fallback to this value
 VITE_DEFAULT_HOUR_FORMAT=12
 
-VITE_SUPPORT_URL=https://accounts.tb.pro/contact/
+VITE_SUPPORT_URL=https://accounts.tb.pro/contact
 
 VITE_OIDC_CLIENT_ID=thunderbird-appointment-frontend
 VITE_OIDC_ROOT_URL=https://auth.tb.pro/realms/tbpro/

--- a/frontend/.env.stage.example
+++ b/frontend/.env.stage.example
@@ -21,7 +21,7 @@ VITE_REPORT_BUG_URL=https://github.com/thunderbird/appointment/issues/new?assign
 # If the browser's hour setting is empty or missing fallback to this value
 VITE_DEFAULT_HOUR_FORMAT=12
 
-VITE_SUPPORT_URL=https://accounts-stage.tb.pro/contact/
+VITE_SUPPORT_URL=https://accounts-stage.tb.pro/contact
 
 VITE_OIDC_CLIENT_ID=thunderbird-appointment-frontend
 VITE_OIDC_ROOT_URL=https://auth-stage.tb.pro/realms/tbpro/


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
In Accounts, [after we moved the contact support form](https://github.com/thunderbird/thunderbird-accounts/issues/383) from the Django route rendering a Vue form only -> the route in the Vue SPA, the URL actually changed from `/contact/` to `/contact`.

The trailing `/` causes Accounts to resolve the URL through the Django router (and prompts a login) instead of the being caught by the Vue SPA and handled by its Vue Router.

## Benefits

<!-- What benefits will be realized by the code change? -->
Contact support link won't prompt a re-login

## How to test
0. Ensure that you have the following .env vars in your `frontend/.env` file:

```
VITE_AUTH_SCHEME=oidc
VITE_SUPPORT_URL=https://accounts.tb.pro/contact
```

1. On an incognito window / without being logged in, navigate to `localhost:8080`
2. On Keycloak's login page, click the `Contact support` link
3. See that you are redirected to https://accounts.tb.pro/contact without being prompted to login

## Applicable Issues

<!-- Enter any applicable issues here -->
Fixes https://github.com/thunderbird/appointment/issues/1384