### PR TITLE
Update alert threshold

### DIFF
--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -157,7 +157,7 @@ resources:
           - FARGATE
         container_definitions:
           backend:
-            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/appointment:ddd147e76509ede8927a0760572ef3b4a838e738
+            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/appointment:5b88df955e78edca86b9de0a277ac0bd4bd8ed7d
             portMappings:
               - name: backend
                 containerPort: 5000
@@ -327,7 +327,10 @@ resources:
       notify_emails:
         - thunderbird-services-monitoring@thunderbird.net
       config:
-        alarms: {}
+        alarms:
+          appointment-prod-fargate-backend-fargateservicealb-alb-backend:
+            response_time:
+              threshold: 2
 
   tb:ci:AwsAutomationUser:
     ci:

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -158,7 +158,7 @@ resources:
           - FARGATE
         container_definitions:
           backend:
-            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/appointment:24146d74c0876ced7fbfbffc1f72fcfd9d6e49de
+            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/appointment:14b27ace3ad4bd02d3858e67b4e5c39f835ec452
             portMappings:
               - name: backend
                 containerPort: 5000


### PR DESCRIPTION
## Description of the Change

The production alert for backend response time is known to sometimes run a little long. This extends the alert threshold to 2 seconds to avoid false positives.

## Benefits

Less alert fatigue.