### PR TITLE
Add descriptive text help for URL Username in FTUE

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -49,6 +49,7 @@
     "createYourProfile": "Dein Profil erstellen",
     "fullName": "Vollständiger Name",
     "urlUsername": "URL Benutzername",
+    "urlUsernameHelp": "Wähle einen eindeutigen Namen. Dies wird dein Buchungslink sein.",
     "createAccount": "Konto erstellen",
     "connectYourCalendar": "Kalender verbinden",
     "connectYourCalendarInfo": "Thunderbird Appointment benötigt Zugriff auf einen Kalender, um deine Verfügbarkeit zu prüfen. Du kannst jederzeit weitere Kalender aus den Einstellungen verbinden.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -49,6 +49,7 @@
     "createYourProfile": "Create your profile",
     "fullName": "Full Name",
     "urlUsername": "URL Username",
+    "urlUsernameHelp": "Choose a unique name. This will be your booking link.",
     "createAccount": "Create account",
     "connectYourCalendar": "Connect your calendar",
     "connectYourCalendarInfo": "Thunderbird Appointment needs access to a calendar to check your availability. You can always connect more from Settings later.",

--- a/frontend/src/views/FTUEView/steps/CreateYourProfileStep.vue
+++ b/frontend/src/views/FTUEView/steps/CreateYourProfileStep.vue
@@ -109,6 +109,7 @@ const onSubmit = async () => {
       :outer-prefix="quickLink"
       v-model="username"
       :error="usernameError"
+      :help="t('ftue.urlUsernameHelp')"
     >
       {{ t('ftue.urlUsername') }}
     </text-input>


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
Following the changes on the [Appointment FTUE design in Zeplin](https://app.zeplin.io/project/66dd0f2b2fe8f1b63cda36f1/screen/68e84c8f8b0327368e72b1fd), we now have a help text for the URL Username input.

<img width="1301" height="854" alt="image" src="https://github.com/user-attachments/assets/353f31de-a596-4311-9071-bcb7cafdb17a" />


## Benefits

<!-- What benefits will be realized by the code change? -->
Better UX during FTUE

## Applicable Issues

<!-- Enter any applicable issues here -->
Fixes https://github.com/thunderbird/appointment/issues/1379