### PR TITLE
Fix Availability Page and Settings Page NoticeBar styles

### DIFF
--- a/frontend/src/views/AvailabilityView/index.vue
+++ b/frontend/src/views/AvailabilityView/index.vue
@@ -110,10 +110,13 @@ async function onSaveChanges() {
   })
 }
 
-function onRevertChanges() {
+function clearNotices() {
   validationError.value = null;
   saveSuccess.value = null;
+}
 
+function onRevertChanges() {
+  clearNotices();
   availabilityStore.revertChanges();
 }
 </script>
@@ -166,7 +169,7 @@ export default {
 
       <template #cta>
         <icon-button
-          @click="validationError = null"
+          @click="clearNotices"
           :title="t('label.close')"
           class="btn-close"
         >
@@ -184,7 +187,7 @@ export default {
 
       <template #cta>
         <icon-button
-          @click="saveSuccess = null"
+          @click="clearNotices"
           :title="t('label.close')"
           class="btn-close"
         >

--- a/frontend/src/views/SettingsView/index.vue
+++ b/frontend/src/views/SettingsView/index.vue
@@ -5,17 +5,16 @@ import {
 import { useRoute, useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { storeToRefs } from 'pinia';
-import { PrimaryButton, LinkButton } from '@thunderbirdops/services-ui';
+import { PrimaryButton, LinkButton, NoticeBar, NoticeBarTypes, IconButton } from '@thunderbirdops/services-ui';
 import { enumToObject } from '@/utils';
 import { callKey } from '@/keys';
-import { SettingsSections, AlertSchemes, ColourSchemes } from '@/definitions';
+import { SettingsSections, ColourSchemes } from '@/definitions';
 import { Alert, SubscriberResponse } from '@/models';
-import AlertBox from '@/elements/AlertBox.vue';
 import { useUserStore } from '@/stores/user-store';
 import { useCalendarStore } from '@/stores/calendar-store';
 import { useScheduleStore } from '@/stores/schedule-store';
 import { createSettingsStore } from '@/stores/settings-store';
-import { PhCaretRight } from '@phosphor-icons/vue';
+import { PhCaretRight, PhX } from '@phosphor-icons/vue';
 
 // Page sections
 import AccountSettings from './components/AccountSettings.vue';
@@ -196,7 +195,14 @@ async function onSaveChanges() {
   }
 }
 
+function clearNotices() {
+  validationError.value = null;
+  saveSuccess.value = null;
+}
+
 function onRevertChanges() {
+  clearNotices();
+
   settingsStore.revertChanges();
 }
 
@@ -227,20 +233,39 @@ export default {
     <h2>{{ t('label.settings') }}</h2>
   </header>
 
-  <alert-box
-    class="alert-box"
+  <notice-bar
+    class="notice-bar"
     v-if="validationError"
-    :alert="validationError"
-    @close="validationError = null"
-  />
+    :type="NoticeBarTypes.Critical"
+  >
+    {{ validationError.title }}
 
-  <alert-box
-    class="alert-box"
+    <template #cta>
+      <icon-button
+        @click="clearNotices"
+        :title="t('label.close')"
+      >
+        <ph-x />
+      </icon-button>
+    </template>
+  </notice-bar>
+
+  <notice-bar
+    class="notice-bar"
     v-else-if="saveSuccess"
-    :alert="saveSuccess"
-    :scheme="AlertSchemes.Success"
-    @close="saveSuccess = null"
-  />
+    :type="NoticeBarTypes.Success"
+  >
+    {{ saveSuccess.title }}
+
+    <template #cta>
+      <icon-button
+        @click="clearNotices"
+        :title="t('label.close')"
+      >
+        <ph-x />
+      </icon-button>
+    </template>
+  </notice-bar>
 
   <div class="main-container">
     <!-- sidebar navigation -->
@@ -310,7 +335,7 @@ section {
   margin-block-end: 2rem;
 }
 
-.alert-box {
+.notice-bar {
   margin-block-end: 2rem;
 }
 


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
- We were using the `AlertBox` component (present only in Appointment, not in `services-ui`) for the success / failures of the Availability page and Settings page. However, the `AlertBox` is a wrapper for `NoticeBar` changing some of its styles, hence the visual difference between the warning state and the success state font-sizes.
- This PR normalizes the component used to be `NoticeBar`s instead, also making it sticky and making sure that only one NoticeBar is present at a time.

## Screenshots

Before / Availability

<img width="1015" height="265" alt="image" src="https://github.com/user-attachments/assets/63f4731c-bfbc-41bc-a50f-f7b59a395c98" />


After / Availability

<img width="997" height="267" alt="image" src="https://github.com/user-attachments/assets/f0b16e63-46fb-4178-8ef5-df1a33018807" />

--

Before / Settings
<img width="1795" height="252" alt="image" src="https://github.com/user-attachments/assets/cf963f0b-045e-493e-ac26-ebf5aaf627c9" />


After / Settings
<img width="1462" height="261" alt="image" src="https://github.com/user-attachments/assets/718fbb86-5583-4b4e-a1f1-faef3e8cf893" />



## Benefits

<!-- What benefits will be realized by the code change? -->
- No more overlapping of NoticeBar / AlertBox
- Better hitbox for the close button
- Consistent font-size across NoticeBars

## Applicable Issues

<!-- Enter any applicable issues here -->
Fixes https://github.com/thunderbird/appointment/issues/1389