### PR TITLE
Remove prompt: login on signinRedirect calls. (Fixes #1420)

### DIFF
--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -240,9 +240,7 @@ router.beforeEach(async (to, _from) => {
 
   // If the route is not public and the user is not authenticated, redirect to the OIDC login
   if (!toMeta?.isPublic && !user.authenticated && isOidcAuth) {
-    await userManager.signinRedirect({
-      prompt: 'login',
-    });
+    await userManager.signinRedirect({});
 
     return false;
   }

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -65,9 +65,7 @@ onMounted(async () => {
     if (user.authenticated) {
       await router.push({ name: 'dashboard' });
     } else {
-      await userManager.signinRedirect({
-        prompt: 'login',
-      });
+      await userManager.signinRedirect({});
     }
   }
 });
@@ -149,7 +147,6 @@ const login = async () => {
       window.sessionStorage?.setItem(INVITE_CODE_KEY, inviteCode.value.trim());
     }
     await userManager.signinRedirect({
-      prompt: 'login',
       login_hint: email.value,
     });
   } else if (isFxaAuth) {


### PR DESCRIPTION
Fixes #1420 

Setting the prompt to login seems to force a login in cases where it doesn't need to be shown. (like if you're logged into accounts already.)

Keycloak only has one session per user so removing this allows it to be reused. 