### PR TITLE
WIP: Port the book appointment E2E test to mobile

### DIFF
--- a/test/e2e/const/constants.ts
+++ b/test/e2e/const/constants.ts
@@ -41,7 +41,7 @@ export const APPT_THEME_SETTING_LIGHT = 'Light';
 export const APPT_THEME_SETTING_DARK = 'Dark';
 // set the Appointment time zone setting to the local timezone is where the test is running
 export const APPT_TIMEZONE_SETTING_PRIMARY = 'Europe/Dublin'; // BrowserStack runs in GMT
-console.log(`appt settings timezone: ${APPT_TIMEZONE_SETTING_PRIMARY}`)
+console.log(`appt settings timezone: ${APPT_TIMEZONE_SETTING_PRIMARY}`);
 export const APPT_TIMEZONE_SETTING_HALIFAX = 'America/Halifax'; // settings test changes to this tz temporarily
 export const APPT_START_OF_WEEK_SUN = 'SUN';
 export const APPT_START_OF_WEEK_MON = 'MON';

--- a/test/e2e/pages/availability-page.ts
+++ b/test/e2e/pages/availability-page.ts
@@ -20,6 +20,7 @@ export class AvailabilityPage {
   readonly timeZoneSelect: Locator;
   readonly calendarSelect: Locator;
   readonly autoConfirmBookingsCheckBox: Locator;
+  readonly autoConfirmBookingsCheckBoxContainer: Locator;
   readonly customizePerDayCheckBox: Locator;
   readonly customizePerDayCheckBoxContainer: Locator;
   readonly allStartTimeInput: Locator;
@@ -57,6 +58,8 @@ export class AvailabilityPage {
     this.timeZoneSelect = this.page.locator('select[name="timezone"]');
     this.calendarSelect = this.page.locator('select[name="calendar"]');
     this.autoConfirmBookingsCheckBox = this.page.getByTestId('availability-automatically-confirm-checkbox');
+    this.autoConfirmBookingsCheckBoxContainer = this.page.locator('label').filter({ hasText: 'Automatically confirm bookings' }).locator('span').first();
+
     this.customizePerDayCheckBox = this.page.getByRole('checkbox', { name: 'Set custom times for each day'});
     this.customizePerDayCheckBoxContainer = this.page.locator('label').filter({ hasText: 'Set custom times for each day' }).locator('span').first();
 

--- a/test/e2e/pages/booking-page.ts
+++ b/test/e2e/pages/booking-page.ts
@@ -1,9 +1,11 @@
 import { expect } from '@playwright/test';
 import { type Page, type Locator } from '@playwright/test';
 import { APPT_MY_SHARE_LINK, APPT_SHORT_SHARE_LINK_PREFIX, APPT_LONG_SHARE_LINK_PREFIX, TIMEOUT_30_SECONDS, APPT_TIMEZONE_SETTING_PRIMARY } from '../const/constants';
+import { NONAME } from 'dns';
 
 export class BookingPage {
   readonly page: Page;
+  readonly testPlatform: String;
   readonly titleText: Locator;
   readonly bookingPageTimeZoneFooter: Locator;
   readonly bookATimeToMeetText: Locator;
@@ -30,10 +32,11 @@ export class BookingPage {
   readonly bookApptPage630PMSlot: Locator;
   readonly bookApptPage15MinSlot: Locator;
 
-  constructor(page: Page) {
+  constructor(page: Page, testPlatform: string = 'desktop') {
     this.page = page;
+    this.testPlatform = testPlatform;
     this.titleText = this.page.getByTestId('booking-view-title-text');
-    this.bookingPageTimeZoneFooter = this.page.locator('div').filter({ hasText: /^Timezone:/ });
+    this.bookingPageTimeZoneFooter = this.page.locator('.calendar-footer');
     this.bookATimeToMeetText = this.page.getByTestId('booking-view-book-a-time-to-meet-with-text');
     this.selectTimeSlotText = this.page.getByText('Select an open time slot from the calendar');
     this.bookingCalendarHdrSun = this.page.getByText('SUN', { exact: true });
@@ -49,7 +52,7 @@ export class BookingPage {
     this.bookSelectionNameInput = this.page.locator('[name="booker-view-user-name"]');
     this.bookSelectionEmailInput = this.page.locator('[name="booker-view-user-email"]');
     this.bookApptBtn = this.page.getByTestId('booking-view-confirm-selection-button');
-    this.bookingConfirmedTitleText = this.page.getByText('Booking Request Sent');
+    this.bookingConfirmedTitleText = this.page.getByText('Booking confirmed');
     this.requestSentAvailabilityText = this.page.getByText("'s Availability");
     this.requestSentCloseBtn = this.page.getByRole('button', { name: 'Close' });
     this.eventBookedTitleText = this.page.getByText('Event booked!');
@@ -89,6 +92,15 @@ export class BookingPage {
   }
 
   /**
+   * Scroll the given element into view. The reason why we do this here is because playright doesn't yet supported this on ios.
+   */
+  async scrollIntoView(targetElement: Locator, timeout: number = 10000) {
+    if (!this.testPlatform.includes('ios')) {
+      await targetElement.scrollIntoViewIfNeeded({ timeout: timeout });
+    }
+  }
+
+  /**
    * With the booking page week view already displayed, go forward to the next week.
    */
   async goForwardOneWeek() {
@@ -107,28 +119,26 @@ export class BookingPage {
    */
   async selectAvailableBookingSlot(userDisplayName: string): Promise<string> {
     // let's check if a non-busy appointment slot exists in the current week view
-    const slotCount: number = await this.availableBookingSlot.count();
-    console.log(`available slot count: ${slotCount}`);
+    // playwrignt doesn't yet support 'count' or 'all' or 'elementHandles' on ios
+    var availableSlot: Locator = this.availableBookingSlot.first();
 
     // if no slots are available in current week view then fast forward to next week
-    if (slotCount === 0) {
+    if (!availableSlot) {
       console.log('no slots available in current week, skipping ahead to the next week');
       await this.goForwardOneWeek();
       // now check again for available slots; if none then fail out the test (safety catch but shouldn't happen)
-      const newSlotCount: number = await this.availableBookingSlot.count();
-      console.log(`available slot count: ${newSlotCount}`);
-      expect(newSlotCount, `no booking slots available, please check availability settings for ${userDisplayName}`).toBeGreaterThan(0);
+      availableSlot = this.availableBookingSlot.first();
+      expect(availableSlot, `no booking slots available, please check availability settings for ${userDisplayName}`).toBeTruthy();
     }
 
-    // slots are available in current week view so get the first one
-    const firstSlot: Locator = this.availableBookingSlot.first();
-    let slotRef = await firstSlot.getAttribute('data-testid'); // ie. 'event-2025-01-08 09:30'
+    // get our slot info for the available slot that we are going to request
+    let slotRef = await availableSlot.getAttribute('data-testid'); // ie. 'event-2025-01-08 09:30'
     if (!slotRef)
       slotRef = 'none';
     expect(slotRef).toContain('event-');
 
     // now that we've found an availalbe slot select it and confirm
-    await firstSlot.click();
+    await availableSlot.click();
     return slotRef;
   }
 
@@ -143,7 +153,29 @@ export class BookingPage {
   async finishBooking(bookerName: string, bookerEmail: string) {
     await this.bookSelectionNameInput.fill(bookerName);
     await this.bookSelectionEmailInput.fill(bookerEmail);
-    await this.bookApptBtn.click();
+    // when clicking the book appt button for some reason on android it won't click it unless we force it; but
+    // force doesn't work on ios
+    if (this.testPlatform.includes('android')) { 
+      await this.bookApptBtn.click({ force: true });
+    } else {
+      await this.bookApptBtn.click();
+    }
+  }
+
+  /**
+   * Verify the given appointment time slot text is displayed in the appointment confirmed dialog
+   * @param expSlotDateStr Expected slot date string formatted as 'Friday, January 10, 2025'
+   * @param expSlotTimeStr Expected time slot time string formatted as '14:30 PM'
+   * @param expSlotTimeZoneStr Expected time zone that the time slot was booked in
+   */
+  async verifyRequestedSlotTextDisplayed(expSlotDateStr: string, expSlotTimeStr: string, expSlotTimeZoneStr: string) {
+    console.log(`selected time slot that is expected to appear on the appointment confirmation dialog: ${expSlotDateStr} ${expSlotTimeStr} ${expSlotTimeZoneStr}`);
+    const slotDateDisplayText: Locator = this.page.getByText(expSlotDateStr);
+    await expect(slotDateDisplayText).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+    const slotTimeDisplayText: Locator = this.page.getByText(`${expSlotTimeStr}`);
+    await expect(slotTimeDisplayText).toBeVisible();
+    const slotTimeZoneDisplayText: Locator = this.page.getByText(`${expSlotTimeZoneStr}`);
+    await expect(slotTimeZoneDisplayText).toBeVisible();
   }
 
   /**

--- a/test/e2e/tests/mobile/book-appointment.spec.ts
+++ b/test/e2e/tests/mobile/book-appointment.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+import { BookingPage } from '../../pages/booking-page';
+import { DashboardPage } from '../../pages/dashboard-page';
+import { mobileSignInAndSetup } from '../../utils/utils';
+
+import {
+  APPT_DISPLAY_NAME,
+  PLAYWRIGHT_TAG_PROD_MOBILE_NIGHTLY,
+  PLAYWRIGHT_TAG_E2E_SUITE_MOBILE,
+  APPT_BOOKEE_NAME,
+  APPT_BOOKEE_EMAIL,  
+  TIMEOUT_3_SECONDS,
+  TIMEOUT_10_SECONDS,
+  TIMEOUT_30_SECONDS,
+  TIMEOUT_60_SECONDS,
+  TIMEOUT_2_SECONDS,
+} from '../../const/constants';
+
+var bookingPage: BookingPage;
+var dashboardPage: DashboardPage;
+var testProjectName: string;
+
+
+/**
+ * The test must be able to run from different timezones because people may run this on their local machine, and also
+ * when the test runs in CI on BrowserStack it is in a different timezone, and when run on BrowserStack real mobile devices
+ * the device can be set in yet another different timezone. In order to get around that we ensure that the Appointment
+ * application timezone setting matches the timezone where the booking page is displayed, as follows.
+ * When the booking page is loaded (to select a time slot) the test grabs the timezone displayed at the bottom of the page.
+ * After a time slot is selected the test verifies that same timezone is displayed in the confirmed appointment dialog.
+ * Then when confirming the corresponding event is created in Appointment, the test signs into Appointment and then sets
+ * the Appointment timezone setting to match the time zone of the booking page; then when searching for a confirmed booking
+ * that matches the selected time slot, the list of bookings matches the timezone that was used when the slot was selected.
+ */
+test.describe('book an appointment on mobile browser', () => {
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    bookingPage = new BookingPage(page, testInfo.project.name); // i.e. 'ios-safari'
+    dashboardPage = new DashboardPage(page);
+    testProjectName = testInfo.project.name;
+  });
+
+  test('able to request a booking on mobile browser', {
+    tag: [PLAYWRIGHT_TAG_E2E_SUITE_MOBILE, PLAYWRIGHT_TAG_PROD_MOBILE_NIGHTLY],
+  }, async ({ page }) => {
+    // in order to ensure we find an available slot we can click on, first switch to week view URL
+    await bookingPage.gotoBookingPageWeekView();
+    await expect(bookingPage.titleText).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+
+    // record the timezone that the booking page is using (will be the timezone of selected time slot)
+    // issue 1035 causes the timezone to be read by the Appointment booking page on android as "+00:00"; check
+    // if that is the retrieved timezone value from the booking page and if so use "UTC" instead
+    var selectedSlotTimeZone = (await bookingPage.bookingPageTimeZoneFooter.innerText()).split(': ')[1].trim();
+    if (selectedSlotTimeZone == '+00:00')
+      selectedSlotTimeZone = 'UTC';
+    console.log(`booking page is using time zone: ${selectedSlotTimeZone}`);
+
+    // now select an available booking time slot  
+    const selectedSlot: string|null = await bookingPage.selectAvailableBookingSlot(APPT_DISPLAY_NAME);
+    console.log(`selected appointment time slot: ${selectedSlot}`);
+
+    // now provide the bookee details for our selected time slot; when signed into Appointment this
+    // info is provided automatically however for this test we are selecting a time slot without being
+    // signed in / without being an Appointment user; so we must specify the bookee name and email
+    // also after entering bookee details, this clicks the 'book appointment' button to request the slot
+    await bookingPage.finishBooking(APPT_BOOKEE_NAME, APPT_BOOKEE_EMAIL);
+
+    // verify booking request sent pop-up
+    // on iOS we currently have to scroll to top of page first to see the confirmation
+    // we can remove the scrolling to top once issue #1423 is resolved
+    page.evaluate("window.scrollTo(0, 0)")
+    page.waitForTimeout(TIMEOUT_2_SECONDS);
+    await expect(bookingPage.bookingConfirmedTitleText.first()).toBeVisible({ timeout: TIMEOUT_60_SECONDS });
+    await bookingPage.scrollIntoView(bookingPage.bookingConfirmedTitleText);
+
+    // booking request sent dialog should display the correct time slot that was requested
+    // our requested time slot is stored in this format, as example: 'event-2025-01-14 14:30'
+    // the dialog reports the slot in this format, as example: 'January 14, 2025' with start time
+    // on next line; convert our selected slot value to same format as displayed so we can verify
+    const expDateStr = await bookingPage.getDateFromSlotString(selectedSlot);
+    const expTimeStr = await bookingPage.getTimeFromSlotString(selectedSlot);
+
+    // now verify the correct date/time is dispalyed on the booking confirmed dialog
+    await bookingPage.verifyRequestedSlotTextDisplayed(expDateStr, expTimeStr, selectedSlotTimeZone);
+
+    // give some initial time for the new confirmed appointment to make it to the Appointment dashboard sometimes the
+    // test is so fast when it switches back to the dashboard the new appointment hasn't been added/displayed yet
+    await page.waitForTimeout(TIMEOUT_10_SECONDS);
+
+    // now verify a corresponding booking was created on the host account's list of bookings; on mobile we aren't signed
+    // into Apppointment yet, so sign in to the main dashboard first; mobileSignInAndSetup will then set the Appointment
+    // settings timezone to match the timezone that was used by the booking page; so that we can easily find the selected
+    // time slot in the list of confirmed Appointment bookings
+    await mobileSignInAndSetup(page, testProjectName, selectedSlotTimeZone);
+    await dashboardPage.verifyEventCreated(expDateStr, expTimeStr);
+
+    // also go back to main dashboard and check that pending requests link now appears
+    await dashboardPage.gotoToDashboardMonthView();
+    await expect(dashboardPage.pendingBookingRequestsLink).toBeVisible();
+  });
+});

--- a/test/e2e/tests/mobile/settings-account.spec.ts
+++ b/test/e2e/tests/mobile/settings-account.spec.ts
@@ -28,7 +28,7 @@ test.describe('account settings on mobile browser', {
     settingsPage = new SettingsPage(page, testInfo.project.name); // i.e. 'ios-safari'
     dashboardPage = new DashboardPage(page);
     availabilityPage = new AvailabilityPage(page);
-    bookApptPage = new BookingPage(page);
+    bookApptPage = new BookingPage(page, testInfo.project.name); // i.e. 'ios-safari'
 
     // mobile browsers don't support saving auth storage state so must sign in before each test
     // send in the playright test project name i.e. safari-ios because some mobile platforms differ

--- a/test/e2e/utils/utils.ts
+++ b/test/e2e/utils/utils.ts
@@ -116,9 +116,12 @@ export const setDefaultUserSettingsLocalStore = async (page: Page, setTimeZone: 
 }
 
 /**
- * Sign into Appointment on mobile browser and set default settings required by tests
+ * Sign into Appointment on mobile browser and set default settings required by tests; if setTimeZone is provided
+ * set the Appointment app default timezone setting to that value, otherwise use APPT_TIMEZONE_SETTING_PRIMARY. This
+ * allows the book an appoitment test to set the timezone in Appointment to the timezone that was used by the
+ * booking page, when a timeslot was selected.
  */
-export const mobileSignInAndSetup = async (page: Page, testProjectName: string) => {
+export const mobileSignInAndSetup = async (page: Page, testProjectName: string, setTimeZone: string = APPT_TIMEZONE_SETTING_PRIMARY) => {
   // playwright for mobile browsers doesn't support saving auth storage state, so unfortunately
   // we must sign into Appointment at the start of every test
   await navigateToAppointmentAndSignIn(page, testProjectName);
@@ -127,7 +130,7 @@ export const mobileSignInAndSetup = async (page: Page, testProjectName: string) 
   await page.goto(APPT_SETTINGS_PAGE);
   await page.waitForTimeout(TIMEOUT_5_SECONDS);
   await page.waitForURL(APPT_SETTINGS_PAGE);
-  await setDefaultUserSettingsLocalStore(page);
+  await setDefaultUserSettingsLocalStore(page, setTimeZone);
   await page.waitForTimeout(TIMEOUT_2_SECONDS);
 }
 


### PR DESCRIPTION
Currently the `Book an Appointment` E2E test is running on desktop browsers only; port it over so it will also run on real mobile devices in BrowserStack (Safari on iOS and Chrome on Android). Fixes #1258.
