### PR TITLE
Skip mobile E2E calendar connection tests for now

### DIFF
--- a/test/e2e/tests/mobile/settings-connected-apps.spec.ts
+++ b/test/e2e/tests/mobile/settings-connected-apps.spec.ts
@@ -63,7 +63,11 @@ test.describe('settings - connected applications on mobile browser', {
     await expect(settingsPage.googleSignInHdr).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
   });
 
-  test('verify calendar dropdown only shows for calendars with different external connection than default', async ({ page }) => {
+  // TODO: This test passes on desktop but fails on mobile. Need further investion on why that is
+  // and the differences between iOS and Android capabilities in Playwright
+  //
+  // Ref: https://github.com/thunderbird/appointment/issues/1446
+  test.skip('verify calendar dropdown only shows for calendars with different external connection than default', async ({ page }) => {
     // verify section header and default badge
     await expect(settingsPage.connectedAppsHdr).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
     await expect(settingsPage.defaultCalendarBadge).toBeVisible();
@@ -96,7 +100,11 @@ test.describe('settings - connected applications on mobile browser', {
     }
   });
 
-  test('verify calendar checkbox change shows notice bar and revert restores previous state', async ({ page }) => {
+  // TODO: This test passes on desktop but fails on mobile. Need further investion on why that is
+  // and the differences between iOS and Android capabilities in Playwright
+  //
+  // Ref: https://github.com/thunderbird/appointment/issues/1446
+  test.skip('verify calendar checkbox change shows notice bar and revert restores previous state', async ({ page }) => {
     // verify section header
     await expect(settingsPage.connectedAppsHdr).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
 


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
- Mobile E2E tests for calendar are not passing at the moment and need further investigation on how to adjust them / make them work.

## Benefits

<!-- What benefits will be realized by the code change? -->
- CI won't be problem anymore on mobile tests!

## Applicable Issues

<!-- Enter any applicable issues here -->
Related with https://github.com/thunderbird/appointment/issues/1446