### PR TITLE
Remove extra slash in VITE_API_URL env var

### DIFF
--- a/frontend/.env.prod.example
+++ b/frontend/.env.prod.example
@@ -1,5 +1,5 @@
 # Production env config, do not put secrets in here !!
-VITE_API_URL=appointment.tb.pro/api/v1/
+VITE_API_URL=appointment.tb.pro/api/v1
 VITE_BASE_URL=appointment.tb.pro
 VITE_API_SECURE=true
 VITE_SHORT_BASE_URL=apt.mt

--- a/frontend/.env.stage.example
+++ b/frontend/.env.stage.example
@@ -1,5 +1,5 @@
 # Production env config, do not put secrets in here !!
-VITE_API_URL=appointment-stage.tb.pro/api/v1/
+VITE_API_URL=appointment-stage.tb.pro/api/v1
 VITE_BASE_URL=appointment-stage.tb.pro
 VITE_API_SECURE=true
 VITE_SHORT_BASE_URL=stage.apt.mt


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
- The symptom of this issue was that the download ICS button was not working in stage / prod due to an extra slash at the end but it was working locally since it is just `localhost`. This PR removes the extra `/` at the end.
- I believe that the env var itself should be changed since it was originally composed of a `port` as well and having it as `https://appointment.tb.pro/api/v1/:5000` would be incorrect as well.

## Benefits

<!-- What benefits will be realized by the code change? -->
- Links that rely on the VITE_API_URL env var should work again in stage / prod (e.g. download ICS)

## Applicable Issues

<!-- Enter any applicable issues here -->
Closes https://github.com/thunderbird/appointment/issues/1466