### PR TITLE
Fix date format in booking successful page

### DIFF
--- a/frontend/src/views/BookerView/components/BookingViewSuccess.vue
+++ b/frontend/src/views/BookerView/components/BookingViewSuccess.vue
@@ -34,7 +34,7 @@ const description = props.requested
   : t('text.timeHasBeenConfirmed', {'email': props.attendee.email});
 
 const date = dj(props.selectedEvent.start).format('ddd') + ', '
-  + dj(props.selectedEvent.start).format('MMM DD') + ' from '
+  + dj(props.selectedEvent.start).format('MMM D') + ' from '
   + dj(props.selectedEvent.start).format(timeFormat()) + ' – '
   + dj(props.selectedEvent.start).add(props.selectedEvent.duration, 'minutes').format(timeFormat())
   + ' (' + dj.tz.guess() + ')';


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
- Changed the date format in the booking successful page to 1 digit (if possible) instead of always 2 for the day. 

## Screenshots

<img width="2774" height="1932" alt="image" src="https://github.com/user-attachments/assets/75158410-4d6e-4a99-b299-0e20e2b6f9d8" />



## Benefits

<!-- What benefits will be realized by the code change? -->
- E2E tests passes again and there's more consistency between the booking slot selection and the booking confirmation formatting.

## Applicable Issues

<!-- Enter any applicable issues here -->
Fixes https://github.com/thunderbird/appointment/issues/1490