### PR TITLE
Fix "share your link" input editable in Availability page

### DIFF
--- a/frontend/src/views/AvailabilityView/components/BookingPageLink/index.vue
+++ b/frontend/src/views/AvailabilityView/components/BookingPageLink/index.vue
@@ -94,6 +94,7 @@ export default {
     name="bookingPageLinkInput"
     class="share-link-input"
     :model-value="userStore.myLink"
+    readonly
   >
     {{ t('label.shareYourLink') }}:
     <link-button @click="copyLink">


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
- Adds a `readonly` attribute to the "Share your link" input in the Availability page

## Benefits

<!-- What benefits will be realized by the code change? -->
- Better UX as it reduces confusion on having a read-only editable input 

## Applicable Issues

<!-- Enter any applicable issues here -->
Fixes https://github.com/thunderbird/appointment/issues/1496