### PR TITLE
Fix logout button in UserMenu relative route path

### DIFF
--- a/frontend/src/components/UserMenu.vue
+++ b/frontend/src/components/UserMenu.vue
@@ -46,7 +46,7 @@ onBeforeUnmount(() => {
       <a :href="supportUrl">
         {{ t('label.support') }}
       </a>
-      <router-link to="logout">
+      <router-link :to="{ name: 'logout' }">
         {{ t('label.logOut') }}
       </router-link>
     </div>


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->

When we use the `to` prop in [vue-router](https://router.vuejs.org/guide/), we either need to put an absolute path OR we can leverage the named routes and reference it by name. Before, the code was using a relative path (without `/`), so the logout path was being appended to whatever else was in the URL.

It worked for any other path since we only had one level of routes in other parts of the app where the booking link has more segments.

Now, I've changed it to leverage the named routes by matching the `name` attribute in the `router.ts`.

## Benefits

<!-- What benefits will be realized by the code change? -->
Logged in users are able to logout from any booking page url (or any other non-root relative urls).

## Known issues / Things to improve

We have a different issue to prompt Keycloak / OIDC logout (https://github.com/thunderbird/appointment/issues/1456). Using the `userManager.signoutRedirect`, even though it prompts Keycloak, doesn't seem to logout from Appointment somehow so it requires more investigation.

## Applicable Issues

<!-- Enter any applicable issues here -->
Fixes https://github.com/thunderbird/appointment/issues/1497