### PR TITLE
Update book appt E2E test to have auto-confirm bookings off

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -29,7 +29,7 @@ The E2E tests require an existing TB Pro account and other settings that are rea
 The tests expect the following Appointment application settings:
 - The user scheduling availability hasn't been changed from the default settings;
 - In the dashboard the default calendar view is the current month view; this is important so that the tests can find an available booking slot, etc.
-- In `Booking Settings`, the `Automatically confirm bookings if time is available` option is checked / turned on
+- In `Booking Settings`, the `Automatically confirm bookings if time is available` option is UNchecked / turned off (which is default)
 
 ## Running the E2E tests against your local dev environment
 

--- a/test/e2e/pages/booking-page.ts
+++ b/test/e2e/pages/booking-page.ts
@@ -47,7 +47,7 @@ export class BookingPage {
     this.availableBookingSlot = this.page.locator('.selectable-slot', { hasNotText: 'Busy'});
     this.bookSelectionNameInput = this.page.getByPlaceholder('First and last name');
     this.bookSelectionEmailInput = this.page.getByPlaceholder('john.doe@example.com');
-    this.bookingConfirmedTitleText = this.page.getByText('Booking confirmed');
+    this.bookingConfirmedTitleText = this.page.getByText('Booking Request Sent');
     this.requestSentAvailabilityText = this.page.getByText("'s Availability");
     this.requestSentCloseBtn = this.page.getByRole('button', { name: 'Close' });
     this.eventBookedTitleText = this.page.getByText('Event booked!');

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -17,8 +17,8 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* No retries locally or in CI, just makes failing jobs longer */
-  retries: 0,
+  /* 1 failed test retry in CI */
+  retries: process.env.CI ? 1 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : 1, // actualy don't run in parallel locally either, for now
   // Global timeout: Playwright will timeout if the entire session (includes all test runs) exceeds this.

--- a/test/e2e/tests/desktop/availability-set.spec.ts
+++ b/test/e2e/tests/desktop/availability-set.spec.ts
@@ -46,7 +46,7 @@ test.describe('set availability on desktop browser', {
 
     // automatically confirm bookings checkbox is on
     await availabilityPage.autoConfirmBookingsCheckBox.scrollIntoViewIfNeeded();
-    expect(await availabilityPage.autoConfirmBookingsCheckBox.isChecked()).toBeTruthy();
+    expect(await availabilityPage.autoConfirmBookingsCheckBox.isChecked()).toBeFalsy();
 
     // customize per day checkbox
     await availabilityPage.customizePerDayCheckBox.scrollIntoViewIfNeeded();


### PR DESCRIPTION
Fixes #1504. Have the E2E tests run with the `auto confirm bookings` option turned off, so that after a booking request is sent, new pending bookings will exist and therefore the pending bookings notification/link will appear on the dashboard. Also turning on 1 test retry when tests run in CI (this may help in case a test fails because of slow running in BrowserStack).

BrowserStack link running all E2E tests on [Firefox desktop](https://automate.browserstack.com/dashboard/v2/builds/056afcf75227ec868754425424c9ef8f015c8c68) with this update (all tests pass).