### PR TITLE
Build email before connecting to SMTP server

### DIFF
--- a/backend/src/appointment/controller/mailer.py
+++ b/backend/src/appointment/controller/mailer.py
@@ -147,6 +147,7 @@ class Mailer:
             # url is not valid
             logging.error('[mailer.send] No valid SMTP url configured: ' + url)
 
+        message = self.build()
         server = None
         try:
             # if configured, create a secure SSL context
@@ -161,7 +162,7 @@ class Mailer:
             else:
                 server = smtplib.SMTP(SMTP_URL, SMTP_PORT)
             # now send email
-            server.send_message(self.build(), to_addrs=self.to)
+            server.send_message(message, to_addrs=self.to)
         except Exception as e:
             # sending email was not possible
             logging.error('[mailer.send] An error occurred on sending email: ' + str(e))

--- a/backend/test/unit/test_mailer.py
+++ b/backend/test/unit/test_mailer.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest.mock import MagicMock
 
 from starlette_context import request_cycle_context
 
@@ -123,6 +124,44 @@ class TestMailer:
         for idx, content in enumerate([mailer.text(), mailer.html()]):
             fault = 'text' if idx == 0 else 'html'
             assert fake_title in content, fault
+
+    def test_send_builds_message_before_smtp_connection(self, with_l10n, monkeypatch):
+        """Message must be fully built before the SMTP connection is opened,
+        otherwise slow template rendering / file I/O can cause the server to
+        timeout waiting for the MAIL FROM command (451 4.4.2)."""
+        call_order = []
+
+        mailer = InvitationMail(
+            to='to@example.org',
+            name='fake',
+            email='fake@example.org',
+            date=datetime.datetime.now(),
+            duration=30,
+            attachments=[Attachment(mime=('text', 'calendar'), filename='test.ics', data=b'')],
+        )
+
+        original_build = mailer.build
+
+        def tracked_build():
+            call_order.append('build')
+            return original_build()
+
+        mailer.build = tracked_build
+
+        mock_smtp_instance = MagicMock()
+
+        def tracked_smtp(*args, **kwargs):
+            call_order.append('smtp_connect')
+            return mock_smtp_instance
+
+        monkeypatch.setenv('SMTP_SECURITY', 'NONE')
+        monkeypatch.setenv('SMTP_URL', 'localhost')
+        monkeypatch.setenv('SMTP_PORT', '25')
+        monkeypatch.setattr('smtplib.SMTP', tracked_smtp)
+
+        mailer.send()
+
+        assert call_order.index('build') < call_order.index('smtp_connect')
 
     def test_booking_emails_use_correct_language(self, faker):
         """Bookee's invite email should be in German (bookee's language from context),


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
There were instances were we failed to build the email templates / message in time to actually send the email and while we are attempting to build it, the connection remains open and does a timeout.

In this PR, we are now building the email templates / message _before_ we connect to the server so that (hopefully) we don't run into timeouts anymore.

Sentry error for reference:
https://thunderbird.sentry.io/issues/7255683634/events/295bf53720a9457d910d7226f90d73bd/?project=4505428124827648

## Benefits

<!-- What benefits will be realized by the code change? -->
- One less reason for failing email delivery!

## Applicable Issues

<!-- Enter any applicable issues here -->
Fixes https://github.com/thunderbird/appointment/issues/1533