### PR TITLE
Add extra_hosts to use a CalDAV running in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     environment:
       - IS_LOCAL_DEV=yes
       - RELEASE_VERSION=localdev
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
     depends_on:
       postgresql:


### PR DESCRIPTION
## Description of the Change

The initial setup requests to connect a CalDAV Calendar, one alternative is to run Radicale in docker but the URL cannot be http://localhost:5232/ because appointment is also running in docker. The solution is to use the IP address or http://host.docker.internal:5232/ with this PR.

<img width="1263" height="839" alt="image" src="https://github.com/user-attachments/assets/9ddbae53-b2d9-4231-8ae7-ef2c34170022" />

## Benefits

Facilitate the initial setup of appointment.

## Applicable Issues

Closes https://github.com/thunderbird/appointment/issues/1557

<img width="642" height="592" alt="image" src="https://github.com/user-attachments/assets/795d30ef-7f56-4af2-9ddd-6a35fc787191" />
