### PR TITLE
Remove reply-to from emails to mitigate spam score

### DIFF
--- a/backend/src/appointment/controller/mailer.py
+++ b/backend/src/appointment/controller/mailer.py
@@ -230,7 +230,6 @@ class InvitationMail(BaseBookingMail):
     def __init__(self, *args, **kwargs):
         """Init Mailer with invitation/booking-accepted specific defaults
         To: Bookee
-        Reply-To: Event owner
         """
         lang = kwargs.get('lang')
         default_kwargs = {
@@ -238,7 +237,6 @@ class InvitationMail(BaseBookingMail):
             'plain': l10n('invite-mail-plain', lang=lang),
         }
         super().__init__(*args, **default_kwargs, **kwargs)
-        self.reply_to = self.email
 
     def html(self):
         return get_template('invite.jinja2').render(
@@ -458,14 +456,12 @@ class NewBookingMail(BaseBookingMail):
     def __init__(self, name, email, date, duration, schedule_name, *args, **kwargs):
         """Init Mailer with new-booking specific defaults
         To: Event owner
-        Reply-To: Bookee
         """
         self.schedule_name = schedule_name
         default_kwargs = {'subject': l10n('new-booking-subject', {'name': name}, lang=kwargs.get('lang'))}
         super(NewBookingMail, self).__init__(
             name=name, email=email, date=date, duration=duration, *args, **default_kwargs, **kwargs
         )
-        self.reply_to = email
 
     def text(self):
         return l10n(

--- a/backend/src/appointment/l10n/de/email.ftl
+++ b/backend/src/appointment/l10n/de/email.ftl
@@ -14,7 +14,6 @@
 mail-brand-contact-form = Kontaktformular
 mail-brand-support-hint = Du hast Fragen? Wir helfen gern! Antworte einfach auf diese E-Mail für Support.
 mail-brand-reply-hint = Du hast Fragen? Wir helfen gern! Du erreichst uns über unser { $contact_form_link }.
-mail-brand-reply-hint-attendee-info = Du möchtest { $name } kontaktieren? Antworte einfach auf diese E-Mail.
 
 mail-brand-footer = Du erhälst diese E-Mail, weil Du dich auf unserer Website für Thunderbird Appointment Beta angemeldet hast.
 

--- a/backend/src/appointment/l10n/en/email.ftl
+++ b/backend/src/appointment/l10n/en/email.ftl
@@ -14,7 +14,6 @@
 mail-brand-contact-form = contact form
 mail-brand-support-hint = Got questions? We're here to help! Simply reply to this email for support.
 mail-brand-reply-hint = Got questions? We're here to help! Reach out to us via our { $contact_form_link }.
-mail-brand-reply-hint-attendee-info = Need to get in touch with { $name }? Simply reply to this email.
 
 mail-brand-footer = You are receiving this email because you signed up on our website for the Thunderbird Appointment Beta.
 

--- a/backend/src/appointment/templates/email/includes/base.jinja2
+++ b/backend/src/appointment/templates/email/includes/base.jinja2
@@ -50,10 +50,6 @@
 </div>
 {% endif %}
 <div style="text-align: center; margin-left: auto; margin-right: auto; margin-bottom: 24px; padding: 12px; max-width: 310px;">
-{% if show_contact_form_reply_hint %}
-  {{ l10n('mail-brand-reply-hint-attendee-info', { 'name': name }, lang if lang else None)|safe }}
-  <br/><br/>
-{% endif %}
 {# Negative because it's on every email except for one. #}
 {% if not hide_contact_form_url_hint %}
 {% set link = '<a href="%(url)s">%(label)s</a>'|format(url=homepage_url + '/contact', label=l10n('mail-brand-contact-form', lang=lang if lang else None)) %}

--- a/backend/src/appointment/templates/email/invite.jinja2
+++ b/backend/src/appointment/templates/email/invite.jinja2
@@ -3,7 +3,6 @@
 {% set clock_image_small = '<img style="width: 11px; height: 11px; position: relative; top: 2px;" alt="" src="cid:%(cid)s" />'|format(cid=clock_icon_cid) %}
 {% set clock_image = '<img style="width: 15px; height: 15px; position: relative; top: 2px;" alt="" src="cid:%(cid)s" />'|format(cid=clock_icon_cid) %}
 {% set calendar_image = '<img style="width: 14px; height: 14px; position: relative; top: 2px;" alt="" src="cid:%(cid)s" />'|format(cid=calendar_icon_cid) %}
-{% set show_contact_form_reply_hint = True %}
 {# Code begins! #}
 {% block introduction %}
   <div style="color: {{ colour_text_base }}; text-align: center; line-height: 16px;">

--- a/backend/src/appointment/templates/email/new_booking.jinja2
+++ b/backend/src/appointment/templates/email/new_booking.jinja2
@@ -3,7 +3,6 @@
 {% set clock_image_small = '<img style="width: 11px; height: 11px; position: relative; top: 2px;" alt="" src="cid:%(cid)s" />'|format(cid=clock_icon_cid) %}
 {% set clock_image = '<img style="width: 15px; height: 15px; position: relative; top: 2px;" alt="" src="cid:%(cid)s" />'|format(cid=clock_icon_cid) %}
 {% set calendar_image = '<img style="width: 14px; height: 14px; position: relative; top: 2px;" alt="" src="cid:%(cid)s" />'|format(cid=calendar_icon_cid) %}
-{% set show_contact_form_reply_hint = True %}
 {# Code begins! #}
 {% block introduction %}
   <div style="color: {{ colour_text_base }}; text-align: center; line-height: 16px;">


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
- Removed the `reply_to` fields in the booking invitation and confirmation emails to the bookee + the mentions to it in the body of the email.

## Benefits

<!-- What benefits will be realized by the code change? -->
Lower spam score!

## Screenshots

#### Booking auto-confirmed

Before
<img width="1395" height="769" alt="Screenshot 2026-03-17 at 3 40 02 PM" src="https://github.com/user-attachments/assets/2dd5946a-1c07-401b-9e33-91ed9081ce33" />

After
<img width="1390" height="701" alt="Screenshot 2026-03-17 at 3 40 48 PM" src="https://github.com/user-attachments/assets/52a64085-1db0-45cd-96be-3c98e975578c" />



#### Booking accepted

Before
<img width="1393" height="850" alt="Screenshot 2026-03-17 at 3 35 41 PM" src="https://github.com/user-attachments/assets/03165f0a-32da-45ff-a475-f4549fdb25cc" />

After
<img width="1394" height="796" alt="Screenshot 2026-03-17 at 3 36 21 PM" src="https://github.com/user-attachments/assets/5cd81fb4-01f6-42e8-a6ca-c747e3c1079b" />



## Known issues / things to improve

<!-- What things are intentionally left as is? -->
Even though this may reduce our spam score by ~6 points, it still not guaranteed that it may solve our spam issue entirely. If it doesn't we can open follow up tickets for it. Also, we are removing the niceness of being able to reply to the email to reach to the Subscriber and there might be better ways to accomplish both (like a relay email).

## Related tickets

<!-- Enter any applicable issues here -->
Fixes https://github.com/thunderbird/appointment/issues/1551