### PR TITLE
Nightly E2E test workflows: separate platforms and set deployment false

### DIFF
--- a/.github/workflows/nightly-tests-desktop-chromium.yml
+++ b/.github/workflows/nightly-tests-desktop-chromium.yml
@@ -1,13 +1,13 @@
-name: nightly-tests-mobile
+name: nightly-tests-desktop-chromium
 
 concurrency:
-  group: nightly-tests-mobile
+  group: nightly-tests-desktop-chromium
   cancel-in-progress: true
 
 on:
   schedule:
-    # run every day at 3am UTC (10PM EST)
-    - cron:  '0 3 * * *'
+    # run every day at 1:10am UTC
+    - cron:  '10 1 * * *'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -15,16 +15,17 @@ permissions:
   contents: read    # This is required for actions/checkout
 
 jobs:
-  nightly-prod-mobile-e2e:
-    name: nightly-prod-mobile-e2e
+  nightly-prod-desktop-e2e:
+    name: nightly-prod-desktop-e2e-chromium
     runs-on: ubuntu-latest
-    environment: production
+    environment:
+      name: production
+      deployment: false
     env:
       TB_ACCTS_EMAIL: ${{ secrets.E2E_APPT_PROD_TB_ACCTS_EMAIL }}
       TB_ACCTS_PWORD: ${{ secrets.E2E_APPT_PROD_TB_ACCTS_PWORD }}
       APPT_DISPLAY_NAME: ${{ secrets.E2E_APPT_PROD_DISPLAY_NAME }}
       APPT_MY_SHARE_LINK: ${{ secrets.E2E_APPT_PROD_MY_SHARE_LINK }}
-      APPT_BOOKEE_NAME: ${{ secrets.E2E_APPT_PROD_BOOKEE_NAME }}
       APPT_BOOKEE_EMAIL: ${{ secrets.E2E_APPT_PROD_BOOKEE_EMAIL }}
     steps:
       - uses: actions/checkout@v4
@@ -46,20 +47,12 @@ jobs:
           username:  ${{ secrets.BROWSERSTACK_USERNAME }}
           access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           project-name: 'Thunderbird Appointment'
-          build-name: 'TB Appointment Nightly Tests (Mobile): BUILD_INFO'
+          build-name: 'TB Appointment Nightly Tests (Desktop): BUILD_INFO'
 
-      - name: Prod E2E Tests on Android Chrome
+      - name: Prod E2E Tests on Desktop Chromium
         # don't send GHA failure email if any of the E2E tests fail, can be annoying (I check the jobs each day in BrowserStack)
         continue-on-error: true
         run: |
           cd ./test/e2e
           cp .env.prod.example .env
-          npm run prod-nightly-tests-mobile-browserstack-android-chrome
-
-      - name: Prod E2E Tests on iOS Safari
-        # don't send GHA failure email if any of the E2E tests fail, can be annoying (I check the jobs each day in BrowserStack)
-        continue-on-error: true
-        run: |
-          cd ./test/e2e
-          cp .env.prod.example .env
-          npm run prod-nightly-tests-mobile-browserstack-ios-safari
+          npm run prod-nightly-tests-browserstack-chromium

--- a/.github/workflows/nightly-tests-desktop-firefox.yml
+++ b/.github/workflows/nightly-tests-desktop-firefox.yml
@@ -1,0 +1,58 @@
+name: nightly-tests-desktop-firefox
+
+concurrency:
+  group: nightly-tests-desktop-firefox
+  cancel-in-progress: true
+
+on:
+  schedule:
+    # run every day at 1am UTC
+    - cron:  '0 1 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read    # This is required for actions/checkout
+
+jobs:
+  nightly-prod-desktop-e2e:
+    name: nightly-prod-desktop-e2e-firefox
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      deployment: false
+    env:
+      TB_ACCTS_EMAIL: ${{ secrets.E2E_APPT_PROD_TB_ACCTS_EMAIL }}
+      TB_ACCTS_PWORD: ${{ secrets.E2E_APPT_PROD_TB_ACCTS_PWORD }}
+      APPT_DISPLAY_NAME: ${{ secrets.E2E_APPT_PROD_DISPLAY_NAME }}
+      APPT_MY_SHARE_LINK: ${{ secrets.E2E_APPT_PROD_MY_SHARE_LINK }}
+      APPT_BOOKEE_EMAIL: ${{ secrets.E2E_APPT_PROD_BOOKEE_EMAIL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'test/e2e/package-lock.json'
+
+      - name: Install dependencies
+        run: |
+          cd ./test/e2e
+          npm install
+
+      - name: BrowserStack Env Setup
+        uses: browserstack/github-actions/setup-env@master
+        with:
+          username:  ${{ secrets.BROWSERSTACK_USERNAME }}
+          access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          project-name: 'Thunderbird Appointment'
+          build-name: 'TB Appointment Nightly Tests (Desktop): BUILD_INFO'
+
+      - name: Prod E2E Tests on Desktop Firefox
+        # don't send GHA failure email if any of the E2E tests fail, can be annoying (I check the jobs each day in BrowserStack)
+        continue-on-error: true
+        run: |
+          cd ./test/e2e
+          cp .env.prod.example .env
+          npm run prod-nightly-tests-browserstack-firefox

--- a/.github/workflows/nightly-tests-desktop-safari.yml
+++ b/.github/workflows/nightly-tests-desktop-safari.yml
@@ -1,0 +1,58 @@
+name: nightly-tests-desktop-safari
+
+concurrency:
+  group: nightly-tests-desktop-safari
+  cancel-in-progress: true
+
+on:
+  schedule:
+    # run every day at 1:20am UTC
+    - cron:  '20 1 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read    # This is required for actions/checkout
+
+jobs:
+  nightly-prod-desktop-e2e:
+    name: nightly-prod-desktop-e2e-safari
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      deployment: false
+    env:
+      TB_ACCTS_EMAIL: ${{ secrets.E2E_APPT_PROD_TB_ACCTS_EMAIL }}
+      TB_ACCTS_PWORD: ${{ secrets.E2E_APPT_PROD_TB_ACCTS_PWORD }}
+      APPT_DISPLAY_NAME: ${{ secrets.E2E_APPT_PROD_DISPLAY_NAME }}
+      APPT_MY_SHARE_LINK: ${{ secrets.E2E_APPT_PROD_MY_SHARE_LINK }}
+      APPT_BOOKEE_EMAIL: ${{ secrets.E2E_APPT_PROD_BOOKEE_EMAIL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'test/e2e/package-lock.json'
+
+      - name: Install dependencies
+        run: |
+          cd ./test/e2e
+          npm install
+
+      - name: BrowserStack Env Setup
+        uses: browserstack/github-actions/setup-env@master
+        with:
+          username:  ${{ secrets.BROWSERSTACK_USERNAME }}
+          access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          project-name: 'Thunderbird Appointment'
+          build-name: 'TB Appointment Nightly Tests (Desktop): BUILD_INFO'
+
+      - name: Prod E2E Tests on Desktop Safari Webkit
+        # don't send GHA failure email if any of the E2E tests fail, can be annoying (I check the jobs each day in BrowserStack)
+        continue-on-error: true
+        run: |
+          cd ./test/e2e
+          cp .env.prod.example .env
+          npm run prod-nightly-tests-browserstack-safari

--- a/.github/workflows/nightly-tests-mobile-android.yml
+++ b/.github/workflows/nightly-tests-mobile-android.yml
@@ -1,13 +1,13 @@
-name: nightly-tests-desktop
+name: nightly-tests-mobile-android
 
 concurrency:
-  group: nightly-tests-desktop
+  group: nightly-tests-mobile-android
   cancel-in-progress: true
 
 on:
   schedule:
-    # run every day at 1am UTC (8PM EST)
-    - cron:  '0 1 * * *'
+    # run every day at 1:30am UTC
+    - cron:  '30 1 * * *'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -15,15 +15,18 @@ permissions:
   contents: read    # This is required for actions/checkout
 
 jobs:
-  nightly-prod-desktop-e2e:
-    name: nightly-prod-desktop-e2e
+  nightly-prod-mobile-e2e:
+    name: nightly-prod-mobile-e2e-android
     runs-on: ubuntu-latest
-    environment: production
+    environment:
+      name: production
+      deployment: false
     env:
       TB_ACCTS_EMAIL: ${{ secrets.E2E_APPT_PROD_TB_ACCTS_EMAIL }}
       TB_ACCTS_PWORD: ${{ secrets.E2E_APPT_PROD_TB_ACCTS_PWORD }}
       APPT_DISPLAY_NAME: ${{ secrets.E2E_APPT_PROD_DISPLAY_NAME }}
       APPT_MY_SHARE_LINK: ${{ secrets.E2E_APPT_PROD_MY_SHARE_LINK }}
+      APPT_BOOKEE_NAME: ${{ secrets.E2E_APPT_PROD_BOOKEE_NAME }}
       APPT_BOOKEE_EMAIL: ${{ secrets.E2E_APPT_PROD_BOOKEE_EMAIL }}
     steps:
       - uses: actions/checkout@v4
@@ -45,28 +48,12 @@ jobs:
           username:  ${{ secrets.BROWSERSTACK_USERNAME }}
           access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           project-name: 'Thunderbird Appointment'
-          build-name: 'TB Appointment Nightly Tests (Desktop): BUILD_INFO'
+          build-name: 'TB Appointment Nightly Tests (Mobile): BUILD_INFO'
 
-      - name: Prod E2E Tests on Desktop Firefox
+      - name: Prod E2E Tests on Android Chrome
         # don't send GHA failure email if any of the E2E tests fail, can be annoying (I check the jobs each day in BrowserStack)
         continue-on-error: true
         run: |
           cd ./test/e2e
           cp .env.prod.example .env
-          npm run prod-nightly-tests-browserstack-firefox
-
-      - name: Prod E2E Tests on Desktop Safari Webkit
-        # don't send GHA failure email if any of the E2E tests fail, can be annoying (I check the jobs each day in BrowserStack)
-        continue-on-error: true
-        run: |
-          cd ./test/e2e
-          cp .env.prod.example .env
-          npm run prod-nightly-tests-browserstack-safari
-
-      - name: Prod E2E Tests on Desktop Chromium
-        # don't send GHA failure email if any of the E2E tests fail, can be annoying (I check the jobs each day in BrowserStack)
-        continue-on-error: true
-        run: |
-          cd ./test/e2e
-          cp .env.prod.example .env
-          npm run prod-nightly-tests-browserstack-chromium
+          npm run prod-nightly-tests-mobile-browserstack-android-chrome

--- a/.github/workflows/nightly-tests-mobile-ios.yml
+++ b/.github/workflows/nightly-tests-mobile-ios.yml
@@ -1,0 +1,59 @@
+name: nightly-tests-mobile-ios
+
+concurrency:
+  group: nightly-tests-mobile-ios
+  cancel-in-progress: true
+
+on:
+  schedule:
+    # run every day at 1:40am UTC
+    - cron:  '40 1 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read    # This is required for actions/checkout
+
+jobs:
+  nightly-prod-mobile-e2e:
+    name: nightly-prod-mobile-e2e-ios
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      deployment: false
+    env:
+      TB_ACCTS_EMAIL: ${{ secrets.E2E_APPT_PROD_TB_ACCTS_EMAIL }}
+      TB_ACCTS_PWORD: ${{ secrets.E2E_APPT_PROD_TB_ACCTS_PWORD }}
+      APPT_DISPLAY_NAME: ${{ secrets.E2E_APPT_PROD_DISPLAY_NAME }}
+      APPT_MY_SHARE_LINK: ${{ secrets.E2E_APPT_PROD_MY_SHARE_LINK }}
+      APPT_BOOKEE_NAME: ${{ secrets.E2E_APPT_PROD_BOOKEE_NAME }}
+      APPT_BOOKEE_EMAIL: ${{ secrets.E2E_APPT_PROD_BOOKEE_EMAIL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'test/e2e/package-lock.json'
+
+      - name: Install dependencies
+        run: |
+          cd ./test/e2e
+          npm install
+
+      - name: BrowserStack Env Setup
+        uses: browserstack/github-actions/setup-env@master
+        with:
+          username:  ${{ secrets.BROWSERSTACK_USERNAME }}
+          access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          project-name: 'Thunderbird Appointment'
+          build-name: 'TB Appointment Nightly Tests (Mobile): BUILD_INFO'
+
+      - name: Prod E2E Tests on iOS Safari
+        # don't send GHA failure email if any of the E2E tests fail, can be annoying (I check the jobs each day in BrowserStack)
+        continue-on-error: true
+        run: |
+          cd ./test/e2e
+          cp .env.prod.example .env
+          npm run prod-nightly-tests-mobile-browserstack-ios-safari

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -256,10 +256,21 @@ If you notice an email from Github actions indicating that the Nightly E2E Tests
   - Click on the `View workflow run` link in the email - or -
   - Go into the Github repo, and
     - Choose `Actions` at the top
-    - On the list of Actions on the left side choose `nightly-tests-desktop`
+    - On the list of Actions on the left side i.e. `nightly-tests-desktop-<platform>` or `nightly-tests-mobile-<platform>`
     - In the corresponding list of completed nightly test action jobs, click on the failing one
   - Then click on the failed E2E test step to open the console view
   - In the console view, expand the E2E tests job and read the test failure details
   - The nightly tests run in BrowserStack which records a video playback of all of the tests
     - In the console view search the logs for the string `View build on BrowserStack dashboard` and retrieve the associated BrowserStack session link
     - Click on the link and sign into BrowserStack with your credentials and view the video replay of the failing test
+
+### Manually re-run/re-trigger a Nightly E2E Tests CI Job
+
+If a nightly test job failed on a specific platform you can manually trigger the nightly test job to run on a specific platform only. For example maybe one single test failed on one of the browsers, and you want to rerun the tests only on that specific browser to determine if the test failure was just a one-off intermittent failure. To manually trigger the nightly E2E tests on a specific platform:
+
+- Open the failing Github nightly-tests action job:
+  - Go into the Github repo, and
+    - Choose `Actions` at the top
+    - On the list of Actions on the left side find the one for the desired platform; for example to run the tests on Firefox desktop on OSX select the `nightly-test-desktop-firefox` action
+    - Once the desired action's page is opened, click on the `Run workflow` button on the top-right, leave the branch as main, and click the green `Run workflow` button
+    - The E2E tests will start running on the selected platform in BrowserStack; when finished you can go into the `Browserstack Automate` dashboard and find your job (or open the gitflow action workflow console and find the BrowserStack link)


### PR DESCRIPTION
Separate the nightly E2E test workflows so that the test jobs can be manually triggered for individual browsers/platforms instead of having to run on all platforms. Also set the new GHA environment `deployment: false` option. Fixes #1584.