### PR TITLE
Add TB_ACCOUNTS_HOST to pulumi env vars

### DIFF
--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -297,6 +297,8 @@ resources:
                 value: "False"
               - name: TB_ACCOUNTS_CALDAV_URL
                 value: https://thundermail.com
+              - name: TB_ACCOUNTS_HOST
+                value: https://accounts.tb.pro
 
   tb:autoscale:EcsServiceAutoscaler:
     backend:

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -298,6 +298,8 @@ resources:
                 value: https://appointment-stage.tb.pro/api/v1/zoom/callback
               - name: TB_ACCOUNTS_CALDAV_URL
                 value: https://stage-thundermail.com
+              - name: TB_ACCOUNTS_HOST
+                value: https://accounts-stage.tb.pro
 
   tb:autoscale:EcsServiceAutoscaler:
     backend:


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
It seems like we were missing a `TB_ACCOUNTS_HOST` env var in Appointment and that causes the auto-configuration of the Thundermail CalDAV to fail :(

Ref https://github.com/thunderbird/appointment/blob/main/backend/src/appointment/routes/caldav.py#L166-L170

## Benefits

<!-- What benefits will be realized by the code change? -->
Hopefully the env var will be defined and the auto configuration of CalDAV will work

## Related tickets

<!-- Enter any applicable issues here -->
Related https://github.com/thunderbird/appointment/issues/1352