### PR TITLE
Fix E2E nightly jobs Part 2: Add new E2E workflows

### DIFF
--- a/.github/workflows/e2e-desktop-nightly-chrome.yml
+++ b/.github/workflows/e2e-desktop-nightly-chrome.yml
@@ -28,11 +28,11 @@ jobs:
       APPT_MY_SHARE_LINK: ${{ secrets.E2E_APPT_PROD_MY_SHARE_LINK }}
       APPT_BOOKEE_EMAIL: ${{ secrets.E2E_APPT_PROD_BOOKEE_EMAIL }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
           cache-dependency-path: 'test/e2e/package-lock.json'
 

--- a/.github/workflows/e2e-desktop-nightly-firefox.yml
+++ b/.github/workflows/e2e-desktop-nightly-firefox.yml
@@ -28,11 +28,11 @@ jobs:
       APPT_MY_SHARE_LINK: ${{ secrets.E2E_APPT_PROD_MY_SHARE_LINK }}
       APPT_BOOKEE_EMAIL: ${{ secrets.E2E_APPT_PROD_BOOKEE_EMAIL }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
           cache-dependency-path: 'test/e2e/package-lock.json'
 

--- a/.github/workflows/e2e-desktop-nightly-safari.yml
+++ b/.github/workflows/e2e-desktop-nightly-safari.yml
@@ -28,11 +28,11 @@ jobs:
       APPT_MY_SHARE_LINK: ${{ secrets.E2E_APPT_PROD_MY_SHARE_LINK }}
       APPT_BOOKEE_EMAIL: ${{ secrets.E2E_APPT_PROD_BOOKEE_EMAIL }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
           cache-dependency-path: 'test/e2e/package-lock.json'
 

--- a/.github/workflows/e2e-mobile-nightly-android.yml
+++ b/.github/workflows/e2e-mobile-nightly-android.yml
@@ -29,11 +29,11 @@ jobs:
       APPT_BOOKEE_NAME: ${{ secrets.E2E_APPT_PROD_BOOKEE_NAME }}
       APPT_BOOKEE_EMAIL: ${{ secrets.E2E_APPT_PROD_BOOKEE_EMAIL }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
           cache-dependency-path: 'test/e2e/package-lock.json'
 

--- a/.github/workflows/e2e-mobile-nightly-ios.yml
+++ b/.github/workflows/e2e-mobile-nightly-ios.yml
@@ -29,11 +29,11 @@ jobs:
       APPT_BOOKEE_NAME: ${{ secrets.E2E_APPT_PROD_BOOKEE_NAME }}
       APPT_BOOKEE_EMAIL: ${{ secrets.E2E_APPT_PROD_BOOKEE_EMAIL }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
           cache-dependency-path: 'test/e2e/package-lock.json'
 


### PR DESCRIPTION
Fixes #1594. Old E2E nightly test workflows were removed in #1600, now add new workflows for the nightly E2E test jobs (hopefully this will fix the GHA scheduling issue).
