### PR TITLE
Update stage image; fix boolean -> string in all envs

### DIFF
--- a/pulumi/config.dev.yaml
+++ b/pulumi/config.dev.yaml
@@ -384,7 +384,7 @@ resources:
                 - name: CONTAINER_ROLE
                   value: flower
                 - name: FLOWER_UNAUTHENTICATED_API
-                  value: true
+                  value: "true"
       
       targets:
         flower:

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -464,7 +464,7 @@ resources:
                 - name: CONTAINER_ROLE
                   value: flower
                 - name: FLOWER_UNAUTHENTICATED_API
-                  value: true
+                  value: "true"
       
       targets:
         flower:

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -3,7 +3,7 @@
 ### Special variables used throughout this file
 
 # Update this value to update all containers based on the thunderbird/appointment image
-.apmt_image: &APMT_IMAGE 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/appointment:e430fe06e3407e4b6b00b770b2e1f0f9dd5af7a3
+.apmt_image: &APMT_IMAGE 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/appointment:2a8e57c78807346aebf7d89cfbd1f00e065f727f
 
 # These variables are common to Accounts application environments. Some tasks will require additional configuration.
 .app_env: &VAR_APP_ENV {name: "APP_ENV", value: "stage"}
@@ -466,7 +466,7 @@ resources:
                 - name: CONTAINER_ROLE
                   value: flower
                 - name: FLOWER_UNAUTHENTICATED_API
-                  value: true
+                  value: "true"
       
       targets:
         flower:


### PR DESCRIPTION
When we merged [this PR](https://github.com/thunderbird/appointment/pull/1617), [this deploy to stage](https://github.com/thunderbird/appointment/actions/runs/24460284235/job/71472228939) failed with this error:

> error: aws:ecs/taskDefinition:TaskDefinition resource '[secret]-stage-afc-[secret]-taskdef-flower' has a problem: ECS Task Definition container_definitions is invalid: json: cannot unmarshal bool into Go struct field KeyValuePair.Environment.Value of type string. Examine values at '[secret]-stage-afc-[secret]-taskdef-flower.containerDefinitions'.

That's because I was missing some quotes around some "true" values in the Flower config. That's fixed here. I was able to reproduce the problem locally and then fix it with these changes locally.