### PR TITLE
Add meeting link url to confirmation email

### DIFF
--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -680,6 +680,8 @@ class Tools:
         # Emails to attendee should be sent in the attendee's language if available
         lang = attendee.language if attendee.language is not None else FALLBACK_LOCALE
 
+        meeting_link_url = slot.meeting_link_url if slot.meeting_link_url is not None else appointment.location_url
+
         # Send mail
         background_tasks.add_task(
             send_invite_email,
@@ -690,6 +692,7 @@ class Tools:
             to=attendee.email,
             attachment=ics_file,
             lang=lang,
+            meeting_link_url=meeting_link_url,
         )
 
     def send_hold_vevent(

--- a/backend/src/appointment/controller/mailer.py
+++ b/backend/src/appointment/controller/mailer.py
@@ -183,6 +183,7 @@ class BaseBookingMail(Mailer):
         self.email = email
         self.date = date
         self.duration = duration
+        self.meeting_link_url = kwargs.pop('meeting_link_url', None)
 
         # Pass to super now!
         super().__init__(*args, **kwargs)
@@ -238,6 +239,15 @@ class InvitationMail(BaseBookingMail):
         }
         super().__init__(*args, **default_kwargs, **kwargs)
 
+    def text(self):
+        plain = super().text()
+        if self.meeting_link_url:
+            meeting_link_text = l10n(
+                'invite-mail-plain-meeting-link', {'meeting_link_url': self.meeting_link_url}, lang=self.lang
+            )
+            plain = meeting_link_text + '\n\n' + plain
+        return plain
+
     def html(self):
         return get_template('invite.jinja2').render(
             name=self.name,
@@ -246,6 +256,7 @@ class InvitationMail(BaseBookingMail):
             timezone=self.timezone,
             day=self.day,
             duration=self.duration,
+            meeting_link_url=self.meeting_link_url,
             lang=self.lang,
             # Image cids
             tbpro_logo_cid=self._attachments()[0].filename,

--- a/backend/src/appointment/l10n/de/email.ftl
+++ b/backend/src/appointment/l10n/de/email.ftl
@@ -31,6 +31,10 @@ invite-mail-html-heading-name = { $name }
 invite-mail-html-heading-email = ({ $email })
 invite-mail-html-heading-text = hat deine Buchung bestätigt:
 invite-mail-html-time = { $duration } min
+# Variables:
+# $meeting_link_url (String) - URL for the meeting link
+invite-mail-plain-meeting-link = Meeting beitreten: { $meeting_link_url }
+invite-mail-html-meeting-link = Meeting beitreten
 invite-mail-html-invite-is-attached = Deine Kalendereinladung ist angehängt.
 invite-mail-html-download = Download
 

--- a/backend/src/appointment/l10n/en/email.ftl
+++ b/backend/src/appointment/l10n/en/email.ftl
@@ -31,6 +31,10 @@ invite-mail-html-heading-name = { $name }
 invite-mail-html-heading-email = ({ $email })
 invite-mail-html-heading-text = has accepted your booking:
 invite-mail-html-time = { $duration } mins
+# Variables:
+# $meeting_link_url (String) - URL for the meeting link
+invite-mail-plain-meeting-link = Join Meeting: { $meeting_link_url }
+invite-mail-html-meeting-link = Join Meeting
 invite-mail-html-invite-is-attached = Your calendar invite is attached.
 invite-mail-html-download = Download
 

--- a/backend/src/appointment/tasks/emails.py
+++ b/backend/src/appointment/tasks/emails.py
@@ -16,11 +16,11 @@ from appointment.controller.mailer import (
 from appointment.defines import APP_ENV_DEV
 
 
-def send_invite_email(owner_name, owner_email, date, duration, to, attachment, lang):
+def send_invite_email(owner_name, owner_email, date, duration, to, attachment, lang, meeting_link_url=None):
     try:
         mail = InvitationMail(
             name=owner_name, email=owner_email, date=date, duration=duration,
-            to=to, attachments=[attachment], lang=lang,
+            to=to, attachments=[attachment], lang=lang, meeting_link_url=meeting_link_url,
         )
         mail.send()
     except Exception as e:

--- a/backend/src/appointment/templates/email/includes/base.jinja2
+++ b/backend/src/appointment/templates/email/includes/base.jinja2
@@ -52,7 +52,7 @@
 <div style="text-align: center; margin-left: auto; margin-right: auto; margin-bottom: 24px; padding: 12px; max-width: 310px;">
 {# Negative because it's on every email except for one. #}
 {% if not hide_contact_form_url_hint %}
-{% set link = '<a href="%(url)s">%(label)s</a>'|format(url=homepage_url + '/contact', label=l10n('mail-brand-contact-form', lang=lang if lang else None)) %}
+{% set link = '<a href="%(url)s" style="color:%(colour)s;">%(label)s</a>'|format(url=homepage_url + '/contact', colour=colour_tbpro_apmt_primary, label=l10n('mail-brand-contact-form', lang=lang if lang else None)) %}
   {{ l10n('mail-brand-reply-hint', {'contact_form_link': link}, lang if lang else None)|safe }}
 </div>
 {% endif %}

--- a/backend/src/appointment/templates/email/invite.jinja2
+++ b/backend/src/appointment/templates/email/invite.jinja2
@@ -31,7 +31,7 @@
       {% if meeting_link_url %}
       <div style="word-break: break-all; padding-inline-start: 17px;">
         {{ l10n('invite-mail-html-meeting-link', lang=lang) }}:<br>
-        <a href="{{ meeting_link_url }}">{{ meeting_link_url }}</a>
+        <a href="{{ meeting_link_url }}" style="color:{{ colour_tbpro_apmt_primary }};">{{ meeting_link_url }}</a>
       </div>
       {% endif %}
     </div>

--- a/backend/src/appointment/templates/email/invite.jinja2
+++ b/backend/src/appointment/templates/email/invite.jinja2
@@ -28,6 +28,11 @@
       <div>
         {{ calendar_image|safe }} {{ day }}
       </div>
+      {% if meeting_link_url %}
+      <div style="margin-top: 18px; line-height: 1.3;">
+      {{ l10n('invite-mail-html-meeting-link', lang=lang) }}: <a href="{{ meeting_link_url }}">{{ meeting_link_url }}</a>
+      </div>
+      {% endif %}
     </div>
     {# Chip #}
     <div style="

--- a/backend/src/appointment/templates/email/invite.jinja2
+++ b/backend/src/appointment/templates/email/invite.jinja2
@@ -25,12 +25,13 @@
         {{ clock_image|safe }} {{ time_range }}
         <span style="color: {{ colour_icon_secondary }}; font-size: 9px">{{ timezone }}</span>
       </div>
-      <div>
+      <div style="margin-bottom: 6px;">
         {{ calendar_image|safe }} {{ day }}
       </div>
       {% if meeting_link_url %}
-      <div style="margin-top: 18px; line-height: 1.3;">
-      {{ l10n('invite-mail-html-meeting-link', lang=lang) }}: <a href="{{ meeting_link_url }}">{{ meeting_link_url }}</a>
+      <div style="word-break: break-all; padding-inline-start: 17px;">
+        {{ l10n('invite-mail-html-meeting-link', lang=lang) }}:<br>
+        <a href="{{ meeting_link_url }}">{{ meeting_link_url }}</a>
       </div>
       {% endif %}
     </div>

--- a/backend/src/appointment/templates/email/new_booking.jinja2
+++ b/backend/src/appointment/templates/email/new_booking.jinja2
@@ -42,7 +42,7 @@
       font-weight: 700;
       height: 16px;
       ">
-      {{ clock_image_small|safe }} {{ l10n('new-booking-html-time', {'duration': duration}) }}
+      {{ clock_image_small|safe }} {{ l10n('new-booking-html-time', {'duration': duration}, lang=lang) }}
     </div>
   </div>
 {% endblock %}

--- a/backend/test/unit/test_calendar_tools.py
+++ b/backend/test/unit/test_calendar_tools.py
@@ -523,8 +523,10 @@ class TestVEventTimezoneFallback:
         organizer.email = 'organizer@example.com'
         return organizer
 
-    def _make_appointment(self):
-        return Mock()
+    def _make_appointment(self, location_url=None):
+        appointment = Mock()
+        appointment.location_url = location_url
+        return appointment
 
     def _make_attendee(self, tz='America/New_York'):
         return schemas.AttendeeBase(email='attendee@example.com', name='Attendee', timezone=tz)
@@ -595,3 +597,42 @@ class TestVEventTimezoneFallback:
         call_kwargs = bg.add_task.call_args
         date_arg = call_kwargs.kwargs.get('date') or call_kwargs[1].get('date')
         assert date_arg.tzinfo is not None
+
+    def test_invitation_passes_slot_meeting_link_url(self):
+        tools = self._make_tools()
+        tools.create_vevent = Mock(return_value=b'VCALENDAR')
+        bg = MagicMock()
+        slot = self._make_slot()
+        slot.meeting_link_url = 'https://zoom.us/j/12345'
+        appointment = self._make_appointment(location_url='https://fallback.example.com')
+
+        tools.send_invitation_vevent(bg, appointment, slot, self._make_organizer(), self._make_attendee())
+
+        call_kwargs = bg.add_task.call_args
+        assert call_kwargs.kwargs['meeting_link_url'] == 'https://zoom.us/j/12345'
+
+    def test_invitation_falls_back_to_appointment_location_url(self):
+        tools = self._make_tools()
+        tools.create_vevent = Mock(return_value=b'VCALENDAR')
+        bg = MagicMock()
+        slot = self._make_slot()
+        slot.meeting_link_url = None
+        appointment = self._make_appointment(location_url='https://fallback.example.com')
+
+        tools.send_invitation_vevent(bg, appointment, slot, self._make_organizer(), self._make_attendee())
+
+        call_kwargs = bg.add_task.call_args
+        assert call_kwargs.kwargs['meeting_link_url'] == 'https://fallback.example.com'
+
+    def test_invitation_meeting_link_url_is_none_when_absent(self):
+        tools = self._make_tools()
+        tools.create_vevent = Mock(return_value=b'VCALENDAR')
+        bg = MagicMock()
+        slot = self._make_slot()
+        slot.meeting_link_url = None
+        appointment = self._make_appointment(location_url=None)
+
+        tools.send_invitation_vevent(bg, appointment, slot, self._make_organizer(), self._make_attendee())
+
+        call_kwargs = bg.add_task.call_args
+        assert call_kwargs.kwargs['meeting_link_url'] is None

--- a/backend/test/unit/test_mailer.py
+++ b/backend/test/unit/test_mailer.py
@@ -32,6 +32,33 @@ class TestMailer:
         assert mailer.html()
         assert mailer.text()
 
+    def test_invite_without_meeting_link(self, with_l10n):
+        mailer = InvitationMail(
+            to='to@example.org',
+            name='fake',
+            email='fake@example.org',
+            date=datetime.datetime.now(),
+            duration=30,
+            attachments=[Attachment(mime=('text', 'calendar'), filename='test.ics', data=b'')],
+        )
+        assert 'meeting_link_url' not in mailer.html()
+        assert 'Join Meeting' not in mailer.text()
+
+    def test_invite_with_meeting_link(self, with_l10n):
+        meeting_url = 'https://zoom.us/j/12345'
+
+        mailer = InvitationMail(
+            to='to@example.org',
+            name='fake',
+            email='fake@example.org',
+            date=datetime.datetime.now(),
+            duration=30,
+            attachments=[Attachment(mime=('text', 'calendar'), filename='test.ics', data=b'')],
+            meeting_link_url=meeting_url,
+        )
+        assert meeting_url in mailer.html()
+        assert meeting_url in mailer.text()
+
     def test_confirm(self, faker, with_l10n):
         confirm_url = 'https://example.org/yes'
         deny_url = 'https://example.org/no'


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->
- Added `meeting_link_url` to the confirmation email template with a fallback to the `location_url`. If none exists, nothing is added.
- Unified link colors to be appointment-primary
- Fixed a missing lang parameter for the meeting duration

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->
Users currently need to rely exclusively on the .ics / calendar invite to see the meeting url but for some, it might be easier to just go to the confirmation email instead.

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->
Design is currently cooking a new UI for the emails so this looks uh, not the greatest

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->
Fixes https://github.com/thunderbird/appointment/issues/909

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

<img width="855" height="631" alt="image" src="https://github.com/user-attachments/assets/45a7e59b-e914-4997-aee5-1a77ae7f98ae" />

