### PR TITLE
Destroy old Redis clusters

### DIFF
--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -92,7 +92,6 @@ for afc in afcs.values():
 backend_cache, cache_dns = redis_cache(
     cloudflare_zone_id=cloudflare_zone_id,
     project=project,
-    security_group=backend_cache_sg,
     security_groups=_redis_source_sgs,
     vpc=vpc,
     resources=resources,

--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -59,8 +59,8 @@ secrets_managers = {
     for name, config in resources.get('tb:secrets:PulumiSecretsManager', {}).items()
 }
 
-# Build security groups for load balancers, containers, and our Redis cache
-backend_cache_sg, container_sgs, lb_sgs = security_groups(project=project, resources=resources, vpc=vpc)
+# Build security groups for load balancers and containers
+container_sgs, lb_sgs = security_groups(project=project, resources=resources, vpc=vpc)
 
 # Fargate Service
 fargate_clusters, autoscalers = fargate(

--- a/pulumi/config.dev.yaml
+++ b/pulumi/config.dev.yaml
@@ -3,7 +3,7 @@
 ### Special variables used throughout this file
 
 # Update this value to update all containers based on the thunderbird/appointment image
-.apmt_image: &APMT_IMAGE 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/appointment:85f15a97bf5ee889bb3ca56cea3f4dac7f5c00d2
+.apmt_image: &APMT_IMAGE 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/appointment:254c359689cf6a28497f8923b191bc4e87ccb777
 
 # These variables are common to Accounts application environments. Some tasks will require additional configuration.
 .app_env: &VAR_APP_ENV {name: "APP_ENV", value: "dev"}
@@ -224,12 +224,6 @@ resources:
   #     ssh_keypair_name: your-ec2-keypair
   #     source_cidrs:
   #       - your.ip.addr.ess/32
-
-  aws:elasticache:ServerlessCache:
-    backend:
-      description: Appointment backend (dev)
-      engine: redis
-      major_engine_version: "7"
 
   tb:fargate:FargateClusterWithLogging:
     backend:

--- a/pulumi/config.dev.yaml
+++ b/pulumi/config.dev.yaml
@@ -168,38 +168,6 @@ resources:
               cidr_blocks:
                 - 0.0.0.0/0
     
-    other:
-      backend_cache:
-        rules:
-          ingress:
-            - description: Primary Redis traffic
-              # source_sgs set in code
-              protocol: tcp
-              from_port: 6379
-              to_port: 6379
-            - description: Replica Redis traffic
-              # source_sgs set in code
-              protocol: tcp
-              from_port: 6380
-              to_port: 6380
-            - description: Allow Redis traffic from Celery
-              protocol: tcp
-              from_port: 6379
-              to_port: 6379
-              source_security_group_id: sg-0e2da3bf63a814eda
-            - description: Allow Redis traffic from Flower
-              protocol: tcp
-              from_port: 6379
-              to_port: 6379
-              source_security_group_id: sg-01e3bef415d4ceb1b
-          egress:
-            - description: Allow outbound traffic to anywhere
-              protocol: tcp
-              from_port: 0
-              to_port: 65535
-              cidr_blocks:
-                - 0.0.0.0/0
-  
   tb:secrets:PulumiSecretsManager:
     pulumi:
       recovery_window_in_days: 0

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -261,12 +261,6 @@ resources:
   #     source_cidrs:
   #       - your.ip.addr.ess/32
 
-  aws:elasticache:ServerlessCache:
-    backend:
-      description: Appointment backend (prod)
-      engine: redis
-      major_engine_version: "7"
-
   tb:fargate:FargateClusterWithLogging:
     backend:
       assign_public_ip: True

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -189,38 +189,6 @@ resources:
               cidr_blocks:
                 - 0.0.0.0/0
     
-    other:
-      backend_cache:
-        rules:
-          ingress:
-            - description: Primary Redis traffic
-              # source_sgs set in code
-              protocol: tcp
-              from_port: 6379
-              to_port: 6379
-            - description: Replica Redis traffic
-              # source_sgs set in code
-              protocol: tcp
-              from_port: 6380
-              to_port: 6380
-            # - description: Allow Redis traffic from Celery
-            #   protocol: tcp
-            #   from_port: 6379
-            #   to_port: 6379
-            #   source_security_group_id: 
-            # - description: Allow Redis traffic from Flower
-            #   protocol: tcp
-            #   from_port: 6379
-            #   to_port: 6379
-            #   source_security_group_id: 
-          egress:
-            - description: Allow outbound traffic to anywhere
-              protocol: tcp
-              from_port: 0
-              to_port: 65535
-              cidr_blocks:
-                - 0.0.0.0/0
-  
   tb:secrets:PulumiSecretsManager:
     pulumi:
       recovery_window_in_days: 0

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -190,38 +190,6 @@ resources:
               cidr_blocks:
                 - 0.0.0.0/0
     
-    other:
-      backend_cache:
-        rules:
-          ingress:
-            - description: Primary Redis traffic
-              # source_sgs set in code
-              protocol: tcp
-              from_port: 6379
-              to_port: 6379
-            - description: Replica Redis traffic
-              # source_sgs set in code
-              protocol: tcp
-              from_port: 6380
-              to_port: 6380
-            - description: Allow Redis traffic from Celery
-              protocol: tcp
-              from_port: 6379
-              to_port: 6379
-              source_security_group_id: sg-0813bff6aa9832e2d
-            - description: Allow Redis traffic from Flower
-              protocol: tcp
-              from_port: 6379
-              to_port: 6379
-              source_security_group_id: sg-089861804a280fa38
-          egress:
-            - description: Allow outbound traffic to anywhere
-              protocol: tcp
-              from_port: 0
-              to_port: 65535
-              cidr_blocks:
-                - 0.0.0.0/0
-  
   tb:secrets:PulumiSecretsManager:
     pulumi:
       recovery_window_in_days: 0

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -263,12 +263,6 @@ resources:
   #     source_cidrs:
   #       - your.ip.addr.ess/32
 
-  aws:elasticache:ServerlessCache:
-    backend:
-      description: Appointment backend (stage)
-      engine: redis
-      major_engine_version: "7"
-
   tb:fargate:FargateClusterWithLogging:
     backend:
       assign_public_ip: True

--- a/pulumi/redis.py
+++ b/pulumi/redis.py
@@ -1,5 +1,4 @@
 import pulumi
-import pulumi_aws as aws
 import pulumi_cloudflare as cloudflare
 
 from tb_pulumi import ThunderbirdPulumiProject
@@ -10,12 +9,6 @@ from tb_pulumi.network import MultiCidrVpc, SecurityGroupWithRules
 def redis_cache(
     cloudflare_zone_id: str,
     project: ThunderbirdPulumiProject,
-    # **IN PROGRESS**
-    #
-    #    Keep "security_group" as a single group that gets access to the old serverless cache
-    # -> Add "security_groups" as a list of groups that get access to the new replicaset
-    #    Remove "security_group" when we destroy the old serverless cache
-    security_group: SecurityGroupWithRules,
     security_groups: list[SecurityGroupWithRules],
     resources: dict,
     vpc: MultiCidrVpc,
@@ -25,9 +18,6 @@ def redis_cache(
 
     :param project: The project to store all the resources in.
     :type project: ThunderbirdPulumiProject
-
-    :param security_group: The security group to apply to the old serverless cache.
-    :type security_group: SecurityGroupWithRules
 
     :param security_groups: List of SecurityGroupWithRules resources which should have access to the new cache replica
         set.
@@ -45,26 +35,6 @@ def redis_cache(
     :rtype: _type_
     """
 
-    # **IN PROGRESS**
-    #
-    #    Migrate traffic to new replicaset
-    # -> Delete this code block along with relevant config sections
-    backend_cache = aws.elasticache.ServerlessCache(
-        f'{project.name_prefix}-cache-backend',
-        security_group_ids=[security_group.resources.get('sg').id],
-        subnet_ids=[subnet.id for subnet in vpc.resources.get('subnets', {})],
-        tags=project.common_tags,
-        **resources.get('aws:elasticache:ServerlessCache', {}).get('backend', {}),
-        opts=pulumi.ResourceOptions(depends_on=[vpc]),
-    )
-    project.resources['backend_cache'] = backend_cache
-
-    # **IN PROGRESS**
-    #
-    #    Build new replication group alongside the old cluster
-    #    Move DNS to new replication group
-    # -> Destroy the old cluster
-
     redis_replica_group = ElastiCacheReplicationGroup(
         name=f'{project.name_prefix}-redis-replicaset',
         project=project,
@@ -79,7 +49,6 @@ def redis_cache(
     )
     project.resources['backend_cache_replicaset'] = redis_replica_group
 
-    backend_cache.endpoints.apply(lambda endpoints: endpoints[0]['address'])
     redis_replica_group_primary_endpoint = redis_replica_group.resources['replication_group'].primary_endpoint_address
     backend_cache_dns = cloudflare.DnsRecord(
         f'{project.name_prefix}-dns-redis',
@@ -92,4 +61,4 @@ def redis_cache(
     )
     project.resources['backend_cache_dns'] = backend_cache_dns
 
-    return (backend_cache, backend_cache_dns)
+    return (redis_replica_group, backend_cache_dns)

--- a/pulumi/security_groups.py
+++ b/pulumi/security_groups.py
@@ -63,20 +63,4 @@ def security_groups(
             **sg,
         )
 
-    # Build a security group to allow traffic from containers into Redis
-    backend_cache_sg_opts = (
-        resources.get('tb:network:SecurityGroupWithRules', {}).get('other', {}).get('backend_cache', {})
-    )
-    backend_cache_sg_ingress_rules = backend_cache_sg_opts.get('rules', {}).get('ingress', {})
-    for rule in backend_cache_sg_ingress_rules:
-        if 'source_security_group_id' not in rule and 'cidr_blocks' not in rule:
-            rule['source_security_group_id'] = container_sgs.get('backend').resources.get('sg').id
-    backend_cache_sg = tb_pulumi.network.SecurityGroupWithRules(
-        name=f'{project.name_prefix}-sg-cache-backend',
-        project=project,
-        vpc_id=vpc.resources['vpc'].id,
-        opts=pulumi.ResourceOptions(depends_on=depends_on),
-        **backend_cache_sg_opts,
-    )
-
-    return (backend_cache_sg, container_sgs, lb_sgs)
+    return (container_sgs, lb_sgs)


### PR DESCRIPTION
This wraps up the Redis migration for Appointment. Currently, the new Redis caches are online and taking all of the traffic in our environments. The old clusters' metrics have plummeted to zeroes. It's time to tear down the old, now-unused clusters. This PR removes the code that builds them and the YAML that configures them.