### PR TITLE
Update E2E test dependencies

### DIFF
--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@playwright/test": "1.58.2",
         "@types/node": "^24.1.0",
-        "browserstack-node-sdk": "^1.50.10",
+        "browserstack-node-sdk": "^1.52.1",
         "date-fns": "4.1.0",
         "dotenv": "^17.2.1"
       }
@@ -906,9 +906,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1074,9 +1074,9 @@
       }
     },
     "node_modules/browserstack-node-sdk": {
-      "version": "1.50.10",
-      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.50.10.tgz",
-      "integrity": "sha512-MRUVac8xwbtWptnDz/TQoe4/aecGT4jrgBZf60wWBkygvIFH1GYcIj+ZdRnfmY8RKA/3Px89/PB0R3MUuSdSBQ==",
+      "version": "1.52.1",
+      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.52.1.tgz",
+      "integrity": "sha512-2tRN1e9G9gIf5cSPTcQjs8IrlQyndPl69FYNTP47bWgKNDupGck8qYyfsToGAbyUmGHQ8lEyaTJAYUvy7NNJLw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
@@ -1112,7 +1112,7 @@
         "js-yaml": "^4.1.0",
         "js-yaml-cloudformation-schema": "^1.0.0",
         "js-yaml-js-types": "^1.0.1",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.0",
         "monkeypatch": "^1.0.0",
         "p-limit": "^3.1.0",
         "pac-proxy-agent": "^7.0.1",
@@ -2258,9 +2258,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -4324,9 +4324,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
-      "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@playwright/test": "1.58.2",
     "@types/node": "^24.1.0",
-    "browserstack-node-sdk": "^1.50.10",
+    "browserstack-node-sdk": "^1.52.1",
     "dotenv": "^17.2.1",
     "date-fns": "4.1.0"
   }


### PR DESCRIPTION
Update E2E test dependencies in order to reduce vulnerabilities.

BrowserStack links showing the tests still run successfully on [Desktop Firefox](https://automate.browserstack.com/projects/Thunderbird+Appointment/builds/Appointment+Tests+Firefox+Desktop/33?tab=sessions) and [Android Chrome](https://automate.browserstack.com/projects/Thunderbird+Appointment/builds/Appointment+Tests+Android+Chrome/48?tab=sessions&testListView=spec).

Fixes #1645.