### PR TITLE
Update OIDC external connection with preferred_username instead of email

### DIFF
--- a/backend/src/appointment/database/repo/external_connection.py
+++ b/backend/src/appointment/database/repo/external_connection.py
@@ -136,6 +136,14 @@ def get_subscriber_by_oidc_id(db: Session, type_id: str):
     return None
 
 
+def update_name(db: Session, db_external_connection: models.ExternalConnections, name: str):
+    """Update the name field of an existing external connection"""
+    db_external_connection.name = name
+    db.commit()
+    db.refresh(db_external_connection)
+    return db_external_connection
+
+
 def get_subscriber_without_oidc_by_email(db: Session, email: str):
     """Return a subscriber by the OIDC recovery email address without an OIDC connection"""
     # Subquery to check if a subscriber has an OIDC external connection

--- a/backend/src/appointment/routes/auth.py
+++ b/backend/src/appointment/routes/auth.py
@@ -624,9 +624,7 @@ def oidc_token(
     if oidc_connection:
         ec = oidc_connection[0]
         if ec.name != email:
-            ec.name = email
-            db.commit()
-            db.refresh(ec)
+            repo.external_connection.update_name(db, ec, email)
     else:
         external_connection_schema = schemas.ExternalConnection(
             name=email,

--- a/backend/src/appointment/routes/auth.py
+++ b/backend/src/appointment/routes/auth.py
@@ -621,9 +621,15 @@ def oidc_token(
 
         raise HTTPException(403, l10n('invalid-credentials'))
 
-    if not oidc_connection:
+    if oidc_connection:
+        ec = oidc_connection[0]
+        if ec.name != email:
+            ec.name = email
+            db.commit()
+            db.refresh(ec)
+    else:
         external_connection_schema = schemas.ExternalConnection(
-            name=token_data.get('email'),
+            name=email,
             type=ExternalConnectionType.oidc,
             type_id=oidc_id,
             owner_id=subscriber.id,

--- a/backend/test/integration/test_auth.py
+++ b/backend/test/integration/test_auth.py
@@ -996,7 +996,7 @@ class TestOIDCToken:
             data = response.json()
             assert 'not valid' in data['detail']
 
-    def test_oidc_token_existing_subscriber(self, with_client, make_pro_subscriber, make_external_connections):
+    def test_oidc_token_existing_subscriber(self, with_db, with_client, make_pro_subscriber, make_external_connections):
         """Test successful login for existing subscriber with OIDC connection"""
         os.environ['AUTH_SCHEME'] = 'oidc'
 
@@ -1005,14 +1005,15 @@ class TestOIDCToken:
 
         # Create existing OIDC external connection
         make_external_connections(
-            subscriber_id=subscriber.id, type=models.ExternalConnectionType.oidc, type_id=oidc_id, name=subscriber.email
+            subscriber_id=subscriber.id, type=models.ExternalConnectionType.oidc, type_id=oidc_id, name='stale@old.com'
         )
 
         # Mock OIDCClient to return valid token data
         with patch('appointment.controller.apis.oidc_client.OIDCClient.introspect_token') as mock_introspect:
             mock_introspect.return_value = {
                 'sub': oidc_id,
-                'email': subscriber.email,
+                'email': 'different@email.com',
+                'preferred_username': subscriber.email,
                 'username': subscriber.username,
                 'name': subscriber.name,
             }
@@ -1023,6 +1024,12 @@ class TestOIDCToken:
 
             assert response.status_code == 200, response.text
             assert response.json() is True
+
+            with with_db() as db:
+                oidc_connection = repo.external_connection.get_by_type(
+                    db, subscriber.id, models.ExternalConnectionType.oidc, oidc_id
+                )
+                assert oidc_connection[0].name == subscriber.email
 
     def test_oidc_token_fallback_match_by_email(self, with_db, with_client, make_pro_subscriber):
         """Test that fallback email matching works when OIDC_FALLBACK_MATCH_BY_EMAIL is True"""

--- a/backend/test/integration/test_auth.py
+++ b/backend/test/integration/test_auth.py
@@ -1012,8 +1012,8 @@ class TestOIDCToken:
         with patch('appointment.controller.apis.oidc_client.OIDCClient.introspect_token') as mock_introspect:
             mock_introspect.return_value = {
                 'sub': oidc_id,
-                'email': 'different@email.com',
-                'preferred_username': subscriber.email,
+                'email': subscriber.username,
+                'preferred_username': subscriber.username,
                 'username': subscriber.username,
                 'name': subscriber.name,
             }
@@ -1029,7 +1029,7 @@ class TestOIDCToken:
                 oidc_connection = repo.external_connection.get_by_type(
                     db, subscriber.id, models.ExternalConnectionType.oidc, oidc_id
                 )
-                assert oidc_connection[0].name == subscriber.email
+                assert oidc_connection[0].name == subscriber.username
 
     def test_oidc_token_fallback_match_by_email(self, with_db, with_client, make_pro_subscriber):
         """Test that fallback email matching works when OIDC_FALLBACK_MATCH_BY_EMAIL is True"""


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

Upon login, we are updating the OIDC external connection's name to be the `preferred_username` or `username` fields from the token.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

We can't use `email` anymore since this is being remapped (used to be the recovery email field during signup).

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->
Fixes https://github.com/thunderbird/appointment/issues/1647