### PR TITLE
Add celery-redbeat instead of two separate celery containers

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,6 +4,7 @@ argon2-cffi-bindings==25.*
 Babel==2.*
 caldav==1.6.0
 celery[redis]==5.*
+celery-redbeat>=2.3.0
 cryptography==46.0.7
 dnspython==2.*
 fastapi[standard]==0.*

--- a/backend/scripts/entry.sh
+++ b/backend/scripts/entry.sh
@@ -9,11 +9,8 @@
 echo "Entry script starting..."
 
 if [[ "$CONTAINER_ROLE" == "worker" ]]; then
-    echo "Starting Celery worker..."
-    celery -A appointment.celery_app:celery worker -l INFO -Q appointment
-elif [[ "$CONTAINER_ROLE" == "beat" ]]; then
-    echo "Starting Celery beat scheduler..."
-    celery -A appointment.celery_app:celery beat -l INFO
+    echo "Starting Celery..."
+    celery -A appointment.celery_app:celery worker -l INFO --beat -Q appointment
 elif [[ "$CONTAINER_ROLE" == "flower" ]]; then
     celery -A appointment.celery_app:celery flower -l INFO
 elif [[ "$CONTAINER_ROLE" == "api" ]]; then

--- a/backend/src/appointment/celery_app.py
+++ b/backend/src/appointment/celery_app.py
@@ -58,6 +58,7 @@ def create_celery_app() -> Celery:
         'accept_content': ['json'],
         'timezone': 'UTC',
         'enable_utc': True,
+        'beat_scheduler': 'redbeat.RedBeatScheduler',
         'beat_schedule': {
             'heartbeat-every-60s': {
                 'task': 'appointment.tasks.health.heartbeat',
@@ -68,7 +69,6 @@ def create_celery_app() -> Celery:
                 'schedule': google_channel_renew_interval,
             },
         },
-        'beat_schedule_filename': 'celerybeat-appointment-schedule',
     })
 
     app.autodiscover_tasks(['appointment'])

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -76,6 +76,7 @@ dependencies = [
     { name = "babel" },
     { name = "caldav" },
     { name = "celery", extra = ["redis"] },
+    { name = "celery-redbeat" },
     { name = "cryptography" },
     { name = "dnspython" },
     { name = "fastapi", extra = ["standard"] },
@@ -140,6 +141,7 @@ requires-dist = [
     { name = "babel", specifier = "==2.*" },
     { name = "caldav", specifier = "==1.6.0" },
     { name = "celery", extras = ["redis"], specifier = "==5.*" },
+    { name = "celery-redbeat", specifier = ">=2.3.0" },
     { name = "coverage", marker = "extra == 'test'", specifier = "==7.6.1" },
     { name = "cryptography", specifier = "==46.0.7" },
     { name = "dnspython", specifier = "==2.*" },
@@ -315,6 +317,21 @@ wheels = [
 [package.optional-dependencies]
 redis = [
     { name = "kombu", extra = ["redis"] },
+]
+
+[[package]]
+name = "celery-redbeat"
+version = "2.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "celery" },
+    { name = "python-dateutil" },
+    { name = "redis" },
+    { name = "tenacity" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/d5/cebf6a03a4716ae33315ce1dad68f2465ea30491a560293ecd2a4ad3148a/celery_redbeat-2.3.3.tar.gz", hash = "sha256:f52664b490b2923a787d9f348f291243601430bf8ec383b6e79870a1731ee92a", size = 34429, upload-time = "2025-07-02T13:08:55.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/c1/ea03e5c737b4b0f4054001d8db64bec693b1506cbb68f93ebecd710b2785/celery_redbeat-2.3.3-py2.py3-none-any.whl", hash = "sha256:0d6da101c46c0147b88f3ae2bfaed42548545934263a31d325a8b0e6585c3fb1", size = 14674, upload-time = "2025-07-02T13:08:54.062Z" },
 ]
 
 [[package]]
@@ -2103,6 +2120,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0f/7c/53c57b4cd76c9a4493a8525d34a76d7e4bbe0ff957de1c53f30241aa757a/starlette_csrf-3.0.0.tar.gz", hash = "sha256:7afaca8c72cc3c726e5942778af53454607ca3e653fd86cd75ee35d8cd1cfa77", size = 8371, upload-time = "2023-06-27T13:23:24.387Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/83/6641e4fdcf33b1cc614a74ecabe5835236a1b2564bf6735db7e35d788795/starlette_csrf-3.0.0-py3-none-any.whl", hash = "sha256:aac29b366e83621d3fc56be690866e16f3c56df91ab5e184b77950540a4e2761", size = 6170, upload-time = "2023-06-27T13:23:25.563Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,17 +22,15 @@ services:
   celery-worker:
     <<: *backend
     ports: []
+    # Workaround for embedded beat (--beat) spinning at 100% CPU in Docker.
+    # Docker inherits a huge SC_OPEN_MAX (~1B) causing close_open_fds() to loop.
+    # https://github.com/celery/celery/issues/8306
+    ulimits:
+      nofile:
+        soft: 10000
+        hard: 10000
     environment:
       - CONTAINER_ROLE=worker
-    depends_on:
-      - backend
-      - redis
-
-  celery-beat:
-    <<: *backend
-    ports: []
-    environment:
-      - CONTAINER_ROLE=beat
     depends_on:
       - backend
       - redis


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- Added `celery-redbeat` to `requirements.txt`
- Removed the `celery-beat` container from `docker-compose.yml`
- Adjusted the `entry.sh` file to run with a `--beat` argument and updated the `celery_app` to have `beat_scheduler` as `redbeat.RedBeatScheduler`

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

Infrastructure-wise, it wouldn't be great to have two separate containers for celery and celery without `celery-redbeat` have concurrency issues when scaling.

## How to test

Run the following:

- `docker compose down -v`
- `docker compose up -d --build`

Check the `celery-worker` docker container logs and see the pre-existing tasks registered and the heartbeat running successfully.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Fixes https://github.com/thunderbird/appointment/issues/1648