### PR TITLE
Fix migration branching error for google_calendar_channels

### DIFF
--- a/backend/src/appointment/migrations/versions/2026_02_23_1200-a1b2c3d4e5f6_add_google_calendar_channels_.py
+++ b/backend/src/appointment/migrations/versions/2026_02_23_1200-a1b2c3d4e5f6_add_google_calendar_channels_.py
@@ -26,6 +26,8 @@ def upgrade() -> None:
         sa.Column('resource_id', sa.String),
         sa.Column('expiration', sa.DateTime),
         sa.Column('sync_token', sa.String, nullable=True),
+        sa.Column('time_created', sa.DateTime, server_default=sa.func.now(), index=True),
+        sa.Column('time_updated', sa.DateTime, server_default=sa.func.now(), index=True),
     )
 
 

--- a/backend/src/appointment/migrations/versions/2026_04_01_1200-b3c4d5e6f7a8_add_state_to_google_calendar_.py
+++ b/backend/src/appointment/migrations/versions/2026_04_01_1200-b3c4d5e6f7a8_add_state_to_google_calendar_.py
@@ -15,7 +15,7 @@ from appointment.database.models import encrypted_type
 revision = 'b3c4d5e6f7a8'
 down_revision = 'd9c5594694c5'
 branch_labels = None
-depends_on = None
+depends_on = ('a1b2c3d4e5f6',)
 
 
 def upgrade() -> None:

--- a/backend/src/appointment/migrations/versions/2026_04_28_1950-c7a1b2d3e4f5_add_timestamps_to_google_.py
+++ b/backend/src/appointment/migrations/versions/2026_04_28_1950-c7a1b2d3e4f5_add_timestamps_to_google_.py
@@ -1,0 +1,43 @@
+"""add timestamps to google_calendar_channels
+
+Revision ID: c7a1b2d3e4f5
+Revises: 04f5df8311e9
+Create Date: 2026-04-28 19:50:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import func, inspect
+
+
+# revision identifiers, used by Alembic.
+revision = 'c7a1b2d3e4f5'
+down_revision = '04f5df8311e9'
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(connection, table, column) -> bool:
+    insp = inspect(connection)
+    cols = [c['name'] for c in insp.get_columns(table)]
+    return column in cols
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if not _column_exists(conn, 'google_calendar_channels', 'time_created'):
+        op.add_column(
+            'google_calendar_channels',
+            sa.Column('time_created', sa.DateTime, server_default=func.now(), index=True),
+        )
+    if not _column_exists(conn, 'google_calendar_channels', 'time_updated'):
+        op.add_column(
+            'google_calendar_channels',
+            sa.Column('time_updated', sa.DateTime, server_default=func.now(), index=True),
+        )
+
+
+def downgrade() -> None:
+    op.drop_column('google_calendar_channels', 'time_updated')
+    op.drop_column('google_calendar_channels', 'time_created')


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- Added `time_created` and `time_updated` to the existing `add_google_calendar_channels` migration
- Fixed the dependency of `add_state_to_google_calendar` migration so that the table can be created before the state is added
- Add a new migration to add the timestamps in case they are not added yet

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

The `time_created` and `time_updated` fields are defined on the SQLAlchemy model but not in the migration, so when we run the db creation methods from scratch when blowing up our local envs, it creates the correct tables from the model definitions.

However, if the DB already exists (ran on this during stage testing and would happen in prod too), these columns wouldn't exist since they are not defined in the migration explicitly.

Also, there was an ordering bug on the migrations which made the `add-column` run before the `create-table`. Added an extra migration to stay on the safe side to make sure that the missing columns will be there.


## Related PRs

https://github.com/thunderbird/appointment/pull/1529