### PR TITLE
chore(ci): remove legacy IAM CI users — OIDC soak complete (#203)

### DIFF
--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -130,11 +130,6 @@ monitoring = tb_pulumi.cloudwatch.CloudWatchMonitoringGroup(
     name=f'{project.name_prefix}-monitoring', project=project, **monitoring_opts
 )
 
-# CI Automation User
-auto_users_opts = resources.get('tb:ci:AwsAutomationUser', {})
-for user, user_opts in auto_users_opts.items():
-    tb_pulumi.ci.AwsAutomationUser(f'{project.name_prefix}-{user}', project=project, **user_opts)
-
 # IAM policies granting access to these resources
 sap = tb_pulumi.iam.StackAccessPolicies(
     f'{project.name_prefix}-sap',

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -583,24 +583,3 @@ resources:
             response_time:
               threshold: 2
 
-  tb:ci:AwsAutomationUser:
-    ci:
-      access_keys: {}
-      enable_legacy_access_key: True
-      additional_policies:
-        - arn:aws:iam::768512802988:policy/appointment-prod-frontend-cache-invalidation
-      enable_ecr_image_push: True
-      ecr_repositories:
-        - thunderbird/appointment
-      enable_fargate_deployments: True
-      fargate_clusters:
-        - appointment-prod-fargate-backend
-        - appointment-prod
-      fargate_task_role_arns:
-        - arn:aws:iam::768512802988:role/appointment-prod-fargate-backend
-        - arn:aws:iam::768512802988:role/appointment-prod-afc-appointment-celery
-        - arn:aws:iam::768512802988:role/appointment-prod-afc-appointment-flower
-      enable_full_s3_access: False
-      enable_s3_bucket_upload: True
-      s3_upload_buckets:
-        - tb-appointment-prod-frontend

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -582,24 +582,3 @@ resources:
       config:
         alarms: {}
 
-  tb:ci:AwsAutomationUser:
-    ci:
-      access_keys: {}
-      enable_legacy_access_key: True
-      additional_policies:
-        - arn:aws:iam::768512802988:policy/appointment-stage-frontend-cache-invalidation
-      enable_ecr_image_push: True
-      ecr_repositories:
-        - thunderbird/appointment
-      enable_fargate_deployments: True
-      fargate_clusters:
-        - appointment-stage-fargate-backend
-        - appointment-stage
-      fargate_task_role_arns:
-        - arn:aws:iam::768512802988:role/appointment-stage-fargate-backend
-        - arn:aws:iam::768512802988:role/appointment-stage-afc-appointment-celery
-        - arn:aws:iam::768512802988:role/appointment-stage-afc-appointment-flower
-      enable_full_s3_access: False
-      enable_s3_bucket_upload: True
-      s3_upload_buckets:
-        - tb-appointment-stage-frontend


### PR DESCRIPTION
## Summary

Removes the `tb_pulumi.ci.AwsAutomationUser` resources for `appointment-prod-ci-ci` and `appointment-stage-ci-ci` now that the OIDC soak period has passed.

- `pulumi/__main__.py` — remove `# CI Automation User` block (3 lines)
- `pulumi/config.prod.yaml` — remove `tb:ci:AwsAutomationUser` stanza
- `pulumi/config.stage.yaml` — remove `tb:ci:AwsAutomationUser` stanza

## Soak evidence

- OIDC migration merged: [appt#1639](https://github.com/thunderbird/appointment/pull/1639) on 2026-04-22
- Production deploys via OIDC: v1.4.1 (2026-04-22), v1.4.2 (2026-04-29) — both successful
- CloudTrail audit: zero events on `appointment-prod-ci-ci` and `appointment-stage-ci-ci` since 2026-04-23 (7 days clean)

## After merge

Platform-infrastructure team will:
1. Run `pulumi up` in the appointment stack to destroy the two IAM user resources
2. Delete `AWS_ACCESS_KEY_ID_PULUMI` / `AWS_SECRET_ACCESS_KEY_PULUMI` from the `staging` and `production` GitHub Environments

Part of thunderbird/platform-infrastructure#250. Closes thunderbird/platform-infrastructure#203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)