### PR TITLE
Initialize custom availabilities when first activating them

### DIFF
--- a/frontend/src/views/AvailabilityView/components/AvailabilitySettings/components/AvailabilitySelect.vue
+++ b/frontend/src/views/AvailabilityView/components/AvailabilitySettings/components/AvailabilitySelect.vue
@@ -64,20 +64,6 @@ const defaultAvailabilitySet = () => Object.fromEntries(isoWeekdays.map((d) => {
   return [d.iso, existing.length ? existing.sort(compareAvailabilityStart) : [defaultAvailability(d.iso)]];
 })) as AvailabilitySet;
 
-// Prefill existing availabilities from schedule
-onMounted(() => {
-  availabilitySet.value = defaultAvailabilitySet();
-});
-
-// Track schedule reset
-watch(
-  () => props.availabilities,
-  () => {
-    availabilitySet.value = defaultAvailabilitySet();
-    validationErrors.value = Object.fromEntries(isoWeekdays.map((d) => [d.iso, []]));
-  },
-);
-
 /**
  * Returns true, if validation was successful.
  */
@@ -217,7 +203,26 @@ const removeAvailability = (option: SelectOption, index: number) => {
   }
 };
 
+// Prefill existing availabilities from schedule when mounted
+onMounted(() => {
+  availabilitySet.value = defaultAvailabilitySet();
+  
+  // If we don't have any availabilities yet, e.g when the user activates
+  // custom availabilities for the first time, update the store with the
+  // default values.
+  if (props.availabilities.length === 0) {
+    update();
+  }
+});
 
+// Track schedule reset
+watch(
+  () => props.availabilities,
+  () => {
+    availabilitySet.value = defaultAvailabilitySet();
+    validationErrors.value = Object.fromEntries(isoWeekdays.map((d) => [d.iso, []]));
+  },
+);
 </script>
 
 <template>


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->
This change emits an update when activating custom availability for the first time. Also, `onMounted` and `watch` were moved to the bottom of the script section, to keep logical definition-call order of functions intact.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->
This change emits the default availabilities to the store. Otherwise, the store would just keep being empty if no change was made and the time slot would not be available for bookees.

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->
None.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->
Closes #1657 

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->
None.
