### PR TITLE
Fix E2E test jobs BrowserStack issue

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -130,7 +130,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 20
           cache: 'npm'
           cache-dependency-path: 'test/e2e/package-lock.json'
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -235,7 +235,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 20
           cache: 'npm'
           cache-dependency-path: 'test/e2e/package-lock.json'
 

--- a/.github/workflows/e2e-desktop-nightly-chrome.yml
+++ b/.github/workflows/e2e-desktop-nightly-chrome.yml
@@ -30,9 +30,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 20
           cache: 'npm'
           cache-dependency-path: 'test/e2e/package-lock.json'
 

--- a/.github/workflows/e2e-desktop-nightly-firefox.yml
+++ b/.github/workflows/e2e-desktop-nightly-firefox.yml
@@ -30,9 +30,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 20
           cache: 'npm'
           cache-dependency-path: 'test/e2e/package-lock.json'
 

--- a/.github/workflows/e2e-desktop-nightly-safari.yml
+++ b/.github/workflows/e2e-desktop-nightly-safari.yml
@@ -30,9 +30,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 20
           cache: 'npm'
           cache-dependency-path: 'test/e2e/package-lock.json'
 

--- a/.github/workflows/e2e-mobile-nightly-android.yml
+++ b/.github/workflows/e2e-mobile-nightly-android.yml
@@ -31,9 +31,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 20
           cache: 'npm'
           cache-dependency-path: 'test/e2e/package-lock.json'
 

--- a/.github/workflows/e2e-mobile-nightly-ios.yml
+++ b/.github/workflows/e2e-mobile-nightly-ios.yml
@@ -31,9 +31,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 20
           cache: 'npm'
           cache-dependency-path: 'test/e2e/package-lock.json'
 


### PR DESCRIPTION
## What changed?
Reverting back to Node v20 for the E2E tests ran via GHA workflows.

## Why?
The nightly E2E test jobs have been running via Github Actions however no tests were actually running in BrowserStack. Turns out the current version of the BrowserStack node sdk used in CI is not compatible with node 20, causing the BrowserStack node SDK and CLI versions not to connect to BrowserStack properly. Note that in the other services E2E tests we are still using node 20 and they are working fine.

ChatGPT also notes that this is an issue: `Also, you’re running Node v24.16.0. That is very likely risky with BrowserStack SDK tooling. I’d try Node 20`. When I switched back to Node v20 the tests started running successfully again in BrowserStack.

## Applicable Issues
Fixes #1697.

## QA Log
Ran the nightly E2E test jobs by manually triggering the GHA workflows on this branch. GHA workflow job links and corresponding BrowserStack links showing that the tests did indeed run:

- Nightly E2E on Firefox desktop: [GHA job](https://github.com/thunderbird/appointment/actions/runs/27021787648/job/79751358012), corresponding [BrowserStack link](https://automate.browserstack.com/projects/Thunderbird+Appointment/builds/Appointment+Nightly+Tests+Firefox+Desktop/207?tab=sessions&testListView=spec)
- Nightly E2E on Chromium desktop: [GHA job](https://github.com/thunderbird/appointment/actions/runs/27024673672/job/79761517133), corresponding [BrowserStack link](https://automate.browserstack.com/projects/Thunderbird+Appointment/builds/Appointment+Nightly+Tests+Chromium+Desktop/217?tab=sessions&testListView=spec)
- Nightly E2E on Safari desktop: [GHA job](https://github.com/thunderbird/appointment/actions/runs/27025298457/job/79763688780), corresponding [BrowserStack link](https://automate.browserstack.com/projects/Thunderbird+Appointment/builds/Appointment+Nightly+Tests+Safari+Desktop/205?tab=sessions)
- Nightly E2E on Android Chrome: [GHA job](https://github.com/thunderbird/appointment/actions/runs/27026487393/job/79767724578), corresponding [BrowserStack link](https://automate.browserstack.com/projects/Thunderbird+Appointment/builds/Appointment+Nightly+Tests+Android+Chrome/230?tab=sessions)
-  Nightly E2E on iOS Safari: [GHA job](https://github.com/thunderbird/appointment/actions/runs/27026970688/job/79769336401), corresponding [BrowserStack link](https://automate.browserstack.com/projects/Thunderbird+Appointment/builds/Appointment+Nightly+Tests+iOS+Safari/178?tab=sessions)