### PR TITLE
Fix slug generation & improve error handling

### DIFF
--- a/backend/src/appointment/database/repo/schedule.py
+++ b/backend/src/appointment/database/repo/schedule.py
@@ -7,6 +7,7 @@ import uuid
 import zoneinfo
 
 from datetime import datetime, time, timezone
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from .. import models, schemas, repo
 from ... import utils
@@ -152,22 +153,24 @@ def generate_slug(db: Session, schedule_id: int) -> str | None:
     if schedule.slug:
         return schedule.slug
 
-    # If slug isn't provided, give them the last 8 characters from a uuid4
-    # Try up-to-3 times to create a unique slug
+    # If slug isn't provided, give them the last 8 characters from a uuid4.
+    # Try up-to-3 times to create a unique slug.
     for _ in range(3):
         slug = uuid.uuid4().hex[-8:]
-        if not slug_exists(db, slug):
-            schedule.slug = slug
-            break
+        if slug_exists(db, slug):
+            continue
 
-    # Could not create slug due to randomness overlap
-    if schedule.slug is None:
-        return None
+        schedule.slug = slug
+        db.add(schedule)
 
-    db.add(schedule)
-    db.commit()
+        try:
+            db.commit()
+            return schedule.slug
+        except IntegrityError:
+            db.rollback()
+            schedule.slug = None
 
-    return schedule.slug
+    return None
 
 
 def hard_delete(db: Session, schedule_id: int):

--- a/backend/src/appointment/database/repo/schedule.py
+++ b/backend/src/appointment/database/repo/schedule.py
@@ -44,13 +44,20 @@ def get_by_slug(db: Session, slug: str, subscriber_id: int) -> models.Schedule |
     )
 
 
-def slug_exists(db: Session, slug: str) -> bool:
-    """Check if a slug is already in use (globally unique in the database)."""
+def slug_taken(db: Session, slug: str) -> bool:
+    """True if any schedule already uses this slug."""
+    return db.query(models.Schedule).filter(models.Schedule.slug == slug).first() is not None
+
+
+def slug_available_for_schedule(db: Session, slug: str, schedule_id: int) -> bool:
+    """True if this slug is unused or already belongs to the given schedule."""
     return (
         db.query(models.Schedule)
-        .filter(models.Schedule.slug == slug)
-        .first() is not None
+        .filter(models.Schedule.slug == slug, models.Schedule.id != schedule_id)
+        .first()
+        is None
     )
+
 
 def get(db: Session, schedule_id: int):
     """retrieve schedule by id"""
@@ -157,7 +164,7 @@ def generate_slug(db: Session, schedule_id: int) -> str | None:
     # Try up-to-3 times to create a unique slug.
     for _ in range(3):
         slug = uuid.uuid4().hex[-8:]
-        if slug_exists(db, slug):
+        if slug_taken(db, slug):
             continue
 
         schedule.slug = slug

--- a/backend/src/appointment/database/repo/schedule.py
+++ b/backend/src/appointment/database/repo/schedule.py
@@ -43,6 +43,14 @@ def get_by_slug(db: Session, slug: str, subscriber_id: int) -> models.Schedule |
     )
 
 
+def slug_exists(db: Session, slug: str) -> bool:
+    """Check if a slug is already in use (globally unique in the database)."""
+    return (
+        db.query(models.Schedule)
+        .filter(models.Schedule.slug == slug)
+        .first() is not None
+    )
+
 def get(db: Session, schedule_id: int):
     """retrieve schedule by id"""
     if schedule_id:
@@ -144,14 +152,11 @@ def generate_slug(db: Session, schedule_id: int) -> str | None:
     if schedule.slug:
         return schedule.slug
 
-    owner_id = schedule.owner.id
-
     # If slug isn't provided, give them the last 8 characters from a uuid4
     # Try up-to-3 times to create a unique slug
     for _ in range(3):
         slug = uuid.uuid4().hex[-8:]
-        exists = repo.schedule.get_by_slug(db, slug, owner_id)
-        if not exists:
+        if not slug_exists(db, slug):
             schedule.slug = slug
             break
 

--- a/backend/src/appointment/exceptions/validation.py
+++ b/backend/src/appointment/exceptions/validation.py
@@ -171,6 +171,16 @@ class ScheduleCreationException(APIException):
         return l10n('unknown-error')
 
 
+class ScheduleSlugTakenException(APIException):
+    """Raise when a schedule slug is already in use."""
+
+    id_code = 'SCHEDULE_SLUG_TAKEN'
+    status_code = 400
+
+    def get_msg(self):
+        return l10n('schedule-slug-taken')
+
+
 class InvalidAvailabilityException(APIException):
     """Raise when any custom availability is invalid, e.g. start time after end time."""
 

--- a/backend/src/appointment/l10n/de/main.ftl
+++ b/backend/src/appointment/l10n/de/main.ftl
@@ -35,6 +35,7 @@ slot-not-auth = Keine Berechtigung, dieses Zeitfenster zu sehen oder zu ändern.
 account-delete-fail = Bei der Löschung der Daten ist ein Problem aufgetreten. Dieser Vorfall wurde protokolliert und die Daten werden manuell gelöscht.
 protected-route-fail = Keine gültigen Authentifizierungsdaten angegeben.
 username-not-available = Dieser Benutzername ist bereits vergeben.
+schedule-slug-taken = Dieser Link-Slug ist bereits vergeben. Bitte einen anderen wählen.
 invalid-link = Dieser Link ist nicht mehr gültig.
 calendar-sync-fail = Bei der Synchronisierung von Kalendern ist ein Fehler aufgetreten. Bitte später noch einmal versuchen.
 calendar-not-active = Der Kalender ist nicht verbunden.

--- a/backend/src/appointment/l10n/en/main.ftl
+++ b/backend/src/appointment/l10n/en/main.ftl
@@ -35,6 +35,7 @@ slot-not-auth = You are not authorized to view or modify this time slot.
 account-delete-fail = There was a problem deleting your data. This incident has been logged and your data will manually be removed.
 protected-route-fail = No valid authentication credentials provided.
 username-not-available = This username has already been taken.
+schedule-slug-taken = This link slug is already in use. Please choose a different one.
 invalid-link = This link is no longer valid.
 calendar-sync-fail = An error occurred while syncing calendars. Please try again later.
 calendar-not-active = The calendar connection is not active.

--- a/backend/src/appointment/routes/schedule.py
+++ b/backend/src/appointment/routes/schedule.py
@@ -209,6 +209,9 @@ def update_schedule(
     if schedule.use_custom_availabilities and not repo.schedule.all_availability_is_valid(schedule):
         raise validation.InvalidAvailabilityException()
 
+    if schedule.slug and not repo.schedule.slug_available_for_schedule(db, schedule.slug, id):
+        raise validation.ScheduleSlugTakenException()
+
     result = repo.schedule.update(db=db, schedule=schedule, schedule_id=id)
 
     if os.getenv('GOOGLE_INVITE_ENABLED') == 'True':

--- a/backend/test/integration/test_schedule.py
+++ b/backend/test/integration/test_schedule.py
@@ -198,6 +198,54 @@ class TestSchedule:
         response = with_client.get(f'/schedule/{generated_schedule.id}', headers=auth_headers)
         assert response.status_code == 403, response.text
 
+    def test_update_schedule_rejects_duplicate_slug(
+        self, with_client, make_caldav_calendar, make_schedule, schedule_input
+    ):
+        calendar = make_caldav_calendar(connected=True)
+        make_schedule(slug='my-booking', calendar_id=calendar.id)
+        other_schedule = make_schedule(slug='other-link', calendar_id=calendar.id)
+
+        response = with_client.put(
+            f'/schedule/{other_schedule.id}',
+            json={
+                'calendar_id': other_schedule.calendar_id,
+                'slug': 'my-booking',
+                **schedule_input,
+            },
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 400, response.text
+        data = response.json()
+        assert data['detail']['id'] == 'SCHEDULE_SLUG_TAKEN'
+
+    def test_update_schedule_allows_unchanged_slug(self, with_client, make_schedule):
+        generated_schedule = make_schedule(slug='my-booking')
+
+        response = with_client.put(
+            f'/schedule/{generated_schedule.id}',
+            json={
+                'calendar_id': generated_schedule.calendar_id,
+                'name': 'Schedulex',
+                'location_type': 1,
+                'location_url': 'https://testx.org',
+                'details': 'Lorem Ipsumx',
+                'start_date': DAY2,
+                'end_date': DAY5,
+                'start_time': '09:00',
+                'end_time': '17:00',
+                'earliest_booking': 1000,
+                'farthest_booking': 20000,
+                'weekdays': [2, 4, 6],
+                'slot_duration': 60,
+                'slug': 'my-booking',
+            },
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json()['slug'] == 'my-booking'
+
     def test_update_existing_schedule(self, with_client, make_schedule):
         generated_schedule = make_schedule()
 

--- a/backend/test/unit/test_schedule_repo.py
+++ b/backend/test/unit/test_schedule_repo.py
@@ -1,6 +1,8 @@
 import uuid
 from unittest.mock import patch
 
+from sqlalchemy.exc import IntegrityError
+
 from appointment.database import repo
 from defines import TEST_USER_ID
 
@@ -82,3 +84,26 @@ class TestScheduleSlug:
                 result = repo.schedule.generate_slug(db, schedule.id)
 
         assert result is None
+
+    def test_generate_slug_retries_on_integrity_error(self, with_db, make_schedule):
+        schedule = make_schedule(slug=None)
+        unique_uuid = uuid.UUID('00000000-0000-0000-0000-0000cafebabe')
+
+        with patch('appointment.database.repo.schedule.slug_exists', return_value=False):
+            with patch('appointment.database.repo.schedule.uuid.uuid4', return_value=unique_uuid):
+                with with_db() as db:
+                    real_commit = db.commit
+                    attempts = 0
+
+                    def commit_once_then_succeed():
+                        nonlocal attempts
+                        attempts += 1
+                        if attempts == 1:
+                            raise IntegrityError('insert', {}, Exception('duplicate key'))
+                        return real_commit()
+
+                    with patch.object(db, 'commit', side_effect=commit_once_then_succeed):
+                        result = repo.schedule.generate_slug(db, schedule.id)
+
+        assert result == 'cafebabe'
+        assert attempts == 2

--- a/backend/test/unit/test_schedule_repo.py
+++ b/backend/test/unit/test_schedule_repo.py
@@ -1,0 +1,84 @@
+import uuid
+from unittest.mock import patch
+
+from appointment.database import repo
+from defines import TEST_USER_ID
+
+
+class TestScheduleSlug:
+    def test_slug_exists_returns_false_when_unused(self, with_db):
+        with with_db() as db:
+            assert repo.schedule.slug_exists(db, 'unused01') is False
+
+    def test_slug_exists_returns_true_when_slug_is_taken(self, with_db, make_schedule):
+        make_schedule(slug='taken001')
+
+        with with_db() as db:
+            assert repo.schedule.slug_exists(db, 'taken001') is True
+
+    def test_get_by_slug_is_scoped_to_owner(
+        self, with_db, make_schedule, make_pro_subscriber, make_caldav_calendar
+    ):
+        slug = 'scoped01'
+        make_schedule(slug=slug)
+
+        other_subscriber = make_pro_subscriber()
+        make_caldav_calendar(subscriber_id=other_subscriber.id, connected=True)
+
+        with with_db() as db:
+            assert repo.schedule.get_by_slug(db, slug, TEST_USER_ID) is not None
+            assert repo.schedule.get_by_slug(db, slug, other_subscriber.id) is None
+            assert repo.schedule.slug_exists(db, slug) is True
+
+    def test_generate_slug_returns_existing_slug(self, with_db, make_schedule):
+        schedule = make_schedule(slug='existing1')
+
+        with with_db() as db:
+            result = repo.schedule.generate_slug(db, schedule.id)
+
+        assert result == 'existing1'
+
+    def test_generate_slug_assigns_unique_slug(self, with_db, make_schedule):
+        schedule = make_schedule(slug=None)
+
+        with with_db() as db:
+            result = repo.schedule.generate_slug(db, schedule.id)
+
+        assert result is not None
+        assert len(result) == 8
+
+        with with_db() as db:
+            saved = repo.schedule.get(db, schedule.id)
+            assert saved.slug == result
+
+    def test_generate_slug_avoids_cross_owner_collision(
+        self, with_db, make_schedule, make_pro_subscriber, make_caldav_calendar
+    ):
+        make_schedule(slug='deadbeef')
+
+        other_subscriber = make_pro_subscriber()
+        other_calendar = make_caldav_calendar(subscriber_id=other_subscriber.id, connected=True)
+        other_schedule = make_schedule(slug=None, calendar_id=other_calendar.id)
+
+        collision_uuid = uuid.UUID('00000000-0000-0000-0000-0000deadbeef')
+        unique_uuid = uuid.UUID('00000000-0000-0000-0000-0000cafebabe')
+
+        with patch('appointment.database.repo.schedule.uuid.uuid4') as mock_uuid:
+            mock_uuid.side_effect = [collision_uuid, unique_uuid]
+
+            with with_db() as db:
+                result = repo.schedule.generate_slug(db, other_schedule.id)
+
+        assert result == 'cafebabe'
+
+    def test_generate_slug_returns_none_when_all_attempts_collide(self, with_db, make_schedule):
+        make_schedule(slug='deadbeef')
+        schedule = make_schedule(slug=None)
+
+        collision_uuid = uuid.UUID('00000000-0000-0000-0000-0000deadbeef')
+
+        with patch('appointment.database.repo.schedule.uuid.uuid4', return_value=collision_uuid):
+            with with_db() as db:
+                result = repo.schedule.generate_slug(db, schedule.id)
+
+        assert result is None

--- a/backend/test/unit/test_schedule_repo.py
+++ b/backend/test/unit/test_schedule_repo.py
@@ -8,15 +8,28 @@ from defines import TEST_USER_ID
 
 
 class TestScheduleSlug:
-    def test_slug_exists_returns_false_when_unused(self, with_db):
+    def test_slug_taken_returns_false_when_unused(self, with_db):
         with with_db() as db:
-            assert repo.schedule.slug_exists(db, 'unused01') is False
+            assert repo.schedule.slug_taken(db, 'unused01') is False
 
-    def test_slug_exists_returns_true_when_slug_is_taken(self, with_db, make_schedule):
+    def test_slug_taken_returns_true_when_slug_is_in_use(self, with_db, make_schedule):
         make_schedule(slug='taken001')
 
         with with_db() as db:
-            assert repo.schedule.slug_exists(db, 'taken001') is True
+            assert repo.schedule.slug_taken(db, 'taken001') is True
+
+    def test_slug_available_for_schedule_allows_unchanged_slug(self, with_db, make_schedule):
+        schedule = make_schedule(slug='taken001')
+
+        with with_db() as db:
+            assert repo.schedule.slug_available_for_schedule(db, 'taken001', schedule.id) is True
+
+    def test_slug_available_for_schedule_rejects_other_schedule_slug(self, with_db, make_schedule):
+        make_schedule(slug='taken001')
+        other = make_schedule(slug='other001')
+
+        with with_db() as db:
+            assert repo.schedule.slug_available_for_schedule(db, 'taken001', other.id) is False
 
     def test_get_by_slug_is_scoped_to_owner(
         self, with_db, make_schedule, make_pro_subscriber, make_caldav_calendar
@@ -30,7 +43,7 @@ class TestScheduleSlug:
         with with_db() as db:
             assert repo.schedule.get_by_slug(db, slug, TEST_USER_ID) is not None
             assert repo.schedule.get_by_slug(db, slug, other_subscriber.id) is None
-            assert repo.schedule.slug_exists(db, slug) is True
+            assert repo.schedule.slug_taken(db, slug) is True
 
     def test_generate_slug_returns_existing_slug(self, with_db, make_schedule):
         schedule = make_schedule(slug='existing1')
@@ -89,7 +102,7 @@ class TestScheduleSlug:
         schedule = make_schedule(slug=None)
         unique_uuid = uuid.UUID('00000000-0000-0000-0000-0000cafebabe')
 
-        with patch('appointment.database.repo.schedule.slug_exists', return_value=False):
+        with patch('appointment.database.repo.schedule.slug_taken', return_value=False):
             with patch('appointment.database.repo.schedule.uuid.uuid4', return_value=unique_uuid):
                 with with_db() as db:
                     real_commit = db.commit

--- a/frontend/src/views/AvailabilityView/components/BookingPageLink/index.vue
+++ b/frontend/src/views/AvailabilityView/components/BookingPageLink/index.vue
@@ -16,6 +16,8 @@ const userStore = useUserStore();
 const availabilityStore = useAvailabilityStore();
 const { currentState } = storeToRefs(availabilityStore);
 
+const emit = defineEmits<{ 'link-refreshed': [] }>();
+
 const refreshLinkModalRef = useTemplateRef('refreshLinkModalRef');
 const copyButtonLabel = ref(t('label.copy'));
 
@@ -40,6 +42,7 @@ async function refreshLinkConfirm() {
   });
 
   refreshLinkModalRef.value.hide();
+  emit('link-refreshed');
 
   if (usePosthog) {
     posthog.capture(MetricEvents.RefreshLink);

--- a/frontend/src/views/AvailabilityView/index.vue
+++ b/frontend/src/views/AvailabilityView/index.vue
@@ -176,7 +176,7 @@ export default {
           </section>
 
           <section>
-            <booking-page-link />
+            <booking-page-link @link-refreshed="clearNotices" />
           </section>
         </div>
       </div>


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- Slugs are now generated considering global scope instead of subscriber's scope
- If the subscriber manually input a slug that conflicts during availability / schedule update, we are catching this error and we show a better error message (screenshot below) instead of a generic cryptic 500
- Added a slew of tests

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

Slugs are unique globally but they were generated scoped on the requester's / owner's / subscriber's id which already caused conflicts / support tickets.

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->

We might want to increase the number of characters of the slug in the near-ish future or consider a better strategy for collision.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Closes https://github.com/thunderbird/appointment/issues/1696

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

When a manually input slug collides with an existing slug:

<img width="1016" height="180" alt="image" src="https://github.com/user-attachments/assets/7f736c0c-7af9-4c87-a8fa-19eec758220c" />
