### PR TITLE
Make slug generation / validation be constrained on the owner_id

### DIFF
--- a/backend/src/appointment/database/models.py
+++ b/backend/src/appointment/database/models.py
@@ -11,7 +11,20 @@ import uuid
 import zoneinfo
 from functools import cached_property
 
-from sqlalchemy import Column, ForeignKey, Integer, String, DateTime, Enum, Boolean, JSON, Date, Time, Uuid
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Integer,
+    String,
+    DateTime,
+    Enum,
+    Boolean,
+    JSON,
+    Date,
+    Time,
+    Uuid,
+    UniqueConstraint,
+)
 from sqlalchemy_utils import StringEncryptedType, ChoiceType
 from sqlalchemy_utils.types.encrypted.encrypted_type import AesEngine
 from sqlalchemy.orm import relationship, as_declarative, declared_attr, Mapped
@@ -338,12 +351,14 @@ class Schedule(Base):
     """
 
     __tablename__ = 'schedules'
+    __table_args__ = (UniqueConstraint('owner_id', 'slug', name='uq_schedules_owner_slug'),)
 
     id: int = Column(Integer, primary_key=True, index=True)
     calendar_id: int = Column(Integer, ForeignKey('calendars.id'))
+    owner_id: int = Column(Integer, ForeignKey('subscribers.id'), index=True, nullable=False)
     active: bool = Column(Boolean, index=True, default=True)
     name: str = Column(encrypted_type(String), index=True)
-    slug: str = Column(encrypted_type(String), index=True, unique=True)
+    slug: str = Column(encrypted_type(String), index=True)
     location_type: LocationType = Column(Enum(LocationType), default=LocationType.inperson)
     location_url: str = Column(encrypted_type(String, length=2048))
     details: str = Column(encrypted_type(String))

--- a/backend/src/appointment/database/repo/schedule.py
+++ b/backend/src/appointment/database/repo/schedule.py
@@ -16,7 +16,8 @@ from ...controller.auth import signed_url_by_subscriber
 
 def create(db: Session, schedule: schemas.ScheduleBase):
     """create a new schedule with slots for calendar"""
-    db_schedule = models.Schedule(**schedule.model_dump())
+    calendar = repo.calendar.get(db, schedule.calendar_id)
+    db_schedule = models.Schedule(**schedule.model_dump(), owner_id=calendar.owner_id)
     db.add(db_schedule)
     db.commit()
     db.refresh(db_schedule)
@@ -44,16 +45,29 @@ def get_by_slug(db: Session, slug: str, subscriber_id: int) -> models.Schedule |
     )
 
 
-def slug_taken(db: Session, slug: str) -> bool:
-    """True if any schedule already uses this slug."""
-    return db.query(models.Schedule).filter(models.Schedule.slug == slug).first() is not None
+def slug_taken(db: Session, slug: str, owner_id: int) -> bool:
+    """True if the owner already has a schedule using this slug."""
+    return (
+        db.query(models.Schedule)
+        .filter(models.Schedule.slug == slug, models.Schedule.owner_id == owner_id)
+        .first()
+        is not None
+    )
 
 
 def slug_available_for_schedule(db: Session, slug: str, schedule_id: int) -> bool:
-    """True if this slug is unused or already belongs to the given schedule."""
+    """True if this slug is unused or already belongs to the given schedule for the same owner."""
+    schedule = get(db, schedule_id)
+    if not schedule:
+        return False
+
     return (
         db.query(models.Schedule)
-        .filter(models.Schedule.slug == slug, models.Schedule.id != schedule_id)
+        .filter(
+            models.Schedule.slug == slug,
+            models.Schedule.id != schedule_id,
+            models.Schedule.owner_id == schedule.owner_id,
+        )
         .first()
         is None
     )
@@ -160,11 +174,13 @@ def generate_slug(db: Session, schedule_id: int) -> str | None:
     if schedule.slug:
         return schedule.slug
 
+    owner_id = schedule.owner_id
+
     # If slug isn't provided, give them the last 8 characters from a uuid4.
-    # Try up-to-3 times to create a unique slug.
+    # Try up-to-3 times to create a unique slug for this owner.
     for _ in range(3):
         slug = uuid.uuid4().hex[-8:]
-        if slug_taken(db, slug):
+        if slug_taken(db, slug, owner_id):
             continue
 
         schedule.slug = slug

--- a/backend/src/appointment/migrations/versions/2026_06_15_1200-d4e5f6a7b8c9_add_owner_id_scoped_schedule_slug.py
+++ b/backend/src/appointment/migrations/versions/2026_06_15_1200-d4e5f6a7b8c9_add_owner_id_scoped_schedule_slug.py
@@ -1,0 +1,90 @@
+"""add owner_id and scoped schedule slug uniqueness
+
+Revision ID: d4e5f6a7b8c9
+Revises: c7a1b2d3e4f5
+Create Date: 2026-06-15 12:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+from sqlalchemy.orm import Session
+
+from appointment.database import models
+
+# revision identifiers, used by Alembic.
+revision = 'd4e5f6a7b8c9'
+down_revision = 'c7a1b2d3e4f5'
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(connection, table, column) -> bool:
+    insp = inspect(connection)
+    cols = [c['name'] for c in insp.get_columns(table)]
+    return column in cols
+
+
+def _constraint_exists(connection, name) -> bool:
+    insp = inspect(connection)
+    return name in {c['name'] for c in insp.get_unique_constraints('schedules')}
+
+
+def _drop_global_slug_unique(connection) -> None:
+    insp = inspect(connection)
+    for idx in insp.get_indexes('schedules'):
+        if idx.get('unique') and idx.get('column_names') == ['slug']:
+            op.drop_index(idx['name'], table_name='schedules')
+
+    for constraint in insp.get_unique_constraints('schedules'):
+        if constraint.get('column_names') == ['slug']:
+            op.drop_constraint(constraint['name'], 'schedules', type_='unique')
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+
+    if not _column_exists(connection, 'schedules', 'owner_id'):
+        op.add_column('schedules', sa.Column('owner_id', sa.Integer(), nullable=True))
+        op.create_index(op.f('ix_schedules_owner_id'), 'schedules', ['owner_id'], unique=False)
+        op.create_foreign_key(
+            'fk_schedules_owner_id_subscribers',
+            'schedules',
+            'subscribers',
+            ['owner_id'],
+            ['id'],
+        )
+
+    session = Session(connection)
+    schedules = session.query(models.Schedule).where(models.Schedule.owner_id.is_(None)).all()
+    for schedule in schedules:
+        schedule.owner_id = schedule.calendar.owner_id
+        session.add(schedule)
+    session.commit()
+
+    op.alter_column('schedules', 'owner_id', existing_type=sa.Integer(), nullable=False)
+
+    _drop_global_slug_unique(connection)
+
+    if not _constraint_exists(connection, 'uq_schedules_owner_slug'):
+        op.create_unique_constraint('uq_schedules_owner_slug', 'schedules', ['owner_id', 'slug'])
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+
+    if _constraint_exists(connection, 'uq_schedules_owner_slug'):
+        op.drop_constraint('uq_schedules_owner_slug', 'schedules', type_='unique')
+
+    insp = inspect(connection)
+    slug_unique_exists = any(
+        idx.get('unique') and idx.get('column_names') == ['slug'] for idx in insp.get_indexes('schedules')
+    )
+    if not slug_unique_exists:
+        op.create_index(op.f('ix_schedules_slug'), 'schedules', ['slug'], unique=True)
+
+    if _column_exists(connection, 'schedules', 'owner_id'):
+        op.drop_constraint('fk_schedules_owner_id_subscribers', 'schedules', type_='foreignkey')
+        op.drop_index(op.f('ix_schedules_owner_id'), table_name='schedules')
+        op.drop_column('schedules', 'owner_id')

--- a/backend/src/appointment/routes/schedule.py
+++ b/backend/src/appointment/routes/schedule.py
@@ -140,6 +140,8 @@ def create_calendar_schedule(
         raise validation.CalendarNotAuthorizedException()
     if not repo.calendar.is_connected(db, calendar_id=schedule.calendar_id):
         raise validation.CalendarNotConnectedException()
+    if schedule.slug and repo.schedule.slug_taken(db, schedule.slug, subscriber.id):
+        raise validation.ScheduleSlugTakenException()
 
     db_schedule = repo.schedule.create(db=db, schedule=schedule)
 

--- a/backend/test/integration/test_schedule.py
+++ b/backend/test/integration/test_schedule.py
@@ -3,6 +3,7 @@ from datetime import date, time, datetime, timedelta, timezone, UTC
 from unittest.mock import patch, Mock
 
 import pytest
+from fastapi import Request
 from freezegun import freeze_time
 
 from appointment import defines
@@ -11,6 +12,7 @@ from appointment.controller.auth import signed_url_by_subscriber
 from appointment.controller.calendar import CalDavConnector
 from appointment.database import schemas, models, repo
 from appointment.exceptions import validation
+from appointment.dependencies import auth
 from defines import DAY1, DAY5, DAY14, DAY2, TEST_USER_ID, auth_headers
 
 
@@ -218,6 +220,60 @@ class TestSchedule:
         assert response.status_code == 400, response.text
         data = response.json()
         assert data['detail']['id'] == 'SCHEDULE_SLUG_TAKEN'
+
+    def test_create_schedule_rejects_duplicate_slug(
+        self, with_client, make_caldav_calendar, make_schedule, schedule_input
+    ):
+        calendar = make_caldav_calendar(connected=True)
+        make_schedule(slug='my-booking', calendar_id=calendar.id)
+
+        response = with_client.post(
+            '/schedule',
+            json={'calendar_id': calendar.id, 'slug': 'my-booking', **schedule_input},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 400, response.text
+        data = response.json()
+        assert data['detail']['id'] == 'SCHEDULE_SLUG_TAKEN'
+
+    def test_update_schedule_allows_slug_used_by_other_owner(
+        self,
+        with_client,
+        with_db,
+        make_schedule,
+        make_pro_subscriber,
+        make_caldav_calendar,
+        schedule_input,
+    ):
+        make_schedule(slug='my-booking')
+        other_subscriber = make_pro_subscriber()
+        other_calendar = make_caldav_calendar(subscriber_id=other_subscriber.id, connected=True)
+        other_schedule = make_schedule(slug='other-link', calendar_id=other_calendar.id)
+
+        def override_other_subscriber(request: Request):
+            if 'authorization' not in request.headers:
+                raise validation.InvalidTokenException()
+            db = with_db()
+            return repo.subscriber.get(db, other_subscriber.id)
+
+        original_override = with_client.app.dependency_overrides[auth.get_subscriber]
+        with_client.app.dependency_overrides[auth.get_subscriber] = override_other_subscriber
+
+        try:
+            response = with_client.put(
+                f'/schedule/{other_schedule.id}',
+                json={
+                    'calendar_id': other_schedule.calendar_id,
+                    'slug': 'my-booking',
+                    **schedule_input,
+                },
+                headers=auth_headers,
+            )
+            assert response.status_code == 200, response.text
+            assert response.json()['slug'] == 'my-booking'
+        finally:
+            with_client.app.dependency_overrides[auth.get_subscriber] = original_override
 
     def test_update_schedule_allows_unchanged_slug(self, with_client, make_schedule):
         generated_schedule = make_schedule(slug='my-booking')

--- a/backend/test/unit/test_schedule_repo.py
+++ b/backend/test/unit/test_schedule_repo.py
@@ -10,13 +10,27 @@ from defines import TEST_USER_ID
 class TestScheduleSlug:
     def test_slug_taken_returns_false_when_unused(self, with_db):
         with with_db() as db:
-            assert repo.schedule.slug_taken(db, 'unused01') is False
+            assert repo.schedule.slug_taken(db, 'unused01', TEST_USER_ID) is False
 
     def test_slug_taken_returns_true_when_slug_is_in_use(self, with_db, make_schedule):
         make_schedule(slug='taken001')
 
         with with_db() as db:
-            assert repo.schedule.slug_taken(db, 'taken001') is True
+            assert repo.schedule.slug_taken(db, 'taken001', TEST_USER_ID) is True
+
+    def test_slug_taken_allows_same_slug_for_different_owners(
+        self, with_db, make_schedule, make_pro_subscriber, make_caldav_calendar
+    ):
+        slug = 'consult'
+        make_schedule(slug=slug)
+
+        other_subscriber = make_pro_subscriber()
+        other_calendar = make_caldav_calendar(subscriber_id=other_subscriber.id, connected=True)
+        make_schedule(slug=slug, calendar_id=other_calendar.id)
+
+        with with_db() as db:
+            assert repo.schedule.slug_taken(db, slug, TEST_USER_ID) is True
+            assert repo.schedule.slug_taken(db, slug, other_subscriber.id) is True
 
     def test_slug_available_for_schedule_allows_unchanged_slug(self, with_db, make_schedule):
         schedule = make_schedule(slug='taken001')
@@ -31,6 +45,19 @@ class TestScheduleSlug:
         with with_db() as db:
             assert repo.schedule.slug_available_for_schedule(db, 'taken001', other.id) is False
 
+    def test_slug_available_for_schedule_allows_slug_used_by_other_owner(
+        self, with_db, make_schedule, make_pro_subscriber, make_caldav_calendar
+    ):
+        slug = 'shared01'
+        make_schedule(slug=slug)
+
+        other_subscriber = make_pro_subscriber()
+        other_calendar = make_caldav_calendar(subscriber_id=other_subscriber.id, connected=True)
+        other_schedule = make_schedule(slug='other001', calendar_id=other_calendar.id)
+
+        with with_db() as db:
+            assert repo.schedule.slug_available_for_schedule(db, slug, other_schedule.id) is True
+
     def test_get_by_slug_is_scoped_to_owner(
         self, with_db, make_schedule, make_pro_subscriber, make_caldav_calendar
     ):
@@ -43,7 +70,8 @@ class TestScheduleSlug:
         with with_db() as db:
             assert repo.schedule.get_by_slug(db, slug, TEST_USER_ID) is not None
             assert repo.schedule.get_by_slug(db, slug, other_subscriber.id) is None
-            assert repo.schedule.slug_taken(db, slug) is True
+            assert repo.schedule.slug_taken(db, slug, TEST_USER_ID) is True
+            assert repo.schedule.slug_taken(db, slug, other_subscriber.id) is False
 
     def test_generate_slug_returns_existing_slug(self, with_db, make_schedule):
         schedule = make_schedule(slug='existing1')
@@ -66,7 +94,7 @@ class TestScheduleSlug:
             saved = repo.schedule.get(db, schedule.id)
             assert saved.slug == result
 
-    def test_generate_slug_avoids_cross_owner_collision(
+    def test_generate_slug_allows_same_slug_across_owners(
         self, with_db, make_schedule, make_pro_subscriber, make_caldav_calendar
     ):
         make_schedule(slug='deadbeef')
@@ -76,15 +104,12 @@ class TestScheduleSlug:
         other_schedule = make_schedule(slug=None, calendar_id=other_calendar.id)
 
         collision_uuid = uuid.UUID('00000000-0000-0000-0000-0000deadbeef')
-        unique_uuid = uuid.UUID('00000000-0000-0000-0000-0000cafebabe')
 
-        with patch('appointment.database.repo.schedule.uuid.uuid4') as mock_uuid:
-            mock_uuid.side_effect = [collision_uuid, unique_uuid]
-
+        with patch('appointment.database.repo.schedule.uuid.uuid4', return_value=collision_uuid):
             with with_db() as db:
                 result = repo.schedule.generate_slug(db, other_schedule.id)
 
-        assert result == 'cafebabe'
+        assert result == 'deadbeef'
 
     def test_generate_slug_returns_none_when_all_attempts_collide(self, with_db, make_schedule):
         make_schedule(slug='deadbeef')


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- Added a migration that:
  - Adds `owner_id` to `schedules` table
  - Backfills `owner_id` to existing schedules
  - Replaces the global constraint on the slug only to a combined constraint with slug and owner_id
- Updates schedule model with the new `owner_id` where applicable
- Add tests

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

Before, we had a DB constraint on the slug being global across all users which is ok except that the generation of the slug was not checking it globally. This already caused collisions on users and cryptic errors on the frontend.

Later, we've changed the generation to be considered globally, to avoid said collisions and added better errors on the frontend. However, since slugs can be typed manually, a user could add `meeting` as a slug essentially making it taken globally, which is not ideal.

This PR now makes it so that the DB constraint is actually on the owner and the slug together. Allowing two users to have the slug `meeting` for example. Slug generation also should never collide.

## How to test

- Go through FTUE with 2 users (if you're using the password AUTH_SCHEME, remember to change backend/src/appointment/routes/auth.py#L469 locally)
- Manually input `meeting` as a slug and save the availability, check that it has been saved correctly
- Logout and login with the other user, manually input `meeting` as a slug and save the availability, check that it has been saved correctly
- Generate a few slugs to make sure that auto-generation is also working as before

Bonus points, when running locally, please try to do the upgrade and downgrade of the migration instead of starting from scratch to make sure that there's no problems there!

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Closes https://github.com/thunderbird/appointment/issues/1706
