### PR TITLE
Fix remote events being cut off when adjacent to selected date border

### DIFF
--- a/frontend/src/views/DashboardView/components/WeekCalendar.vue
+++ b/frontend/src/views/DashboardView/components/WeekCalendar.vue
@@ -288,7 +288,7 @@ const filteredRemoteEventsForGrid = computed(() => {
 
   const { start, end } = props.activeDateRange;
   const remoteEventsWithinActiveWeek = props.events.filter((remoteEvent) =>
-    dj(remoteEvent.start).isBetween(start, end)
+    dj(remoteEvent.start).isBetween(start, end, 'day', '[]')
   );
 
   return remoteEventsWithinActiveWeek


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->
This fixes a bug where remote events were not shown on the dashboard when they were adjacent to the selected / active date range.

## Steps to test this

0. Don't checkout this branch yet. Have a daily repeated remote event ready that spans over at least a week
1. Go to availability settings and activate all weekdays
2. Go to the dashboard and see, that there are events from the repeated remote event, but the event on the far right is missing (otherwise the missing event might not be visible because of the day being blocked in general)
3. Now checkout this branch and refresh the dashboard
4. See, that the dashboard now shows all repeated events.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->
This fixes missing events reported by users.

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->
This is a fix for just *one* issue I was able to reproduce. There might be more issues since there are reports about missing events, but also for repeated remote events that are not adjacent as described here.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->
Related to #1678 

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->
Before the fix:

<img width="1343" height="893" alt="image" src="https://github.com/user-attachments/assets/804810a5-a147-4566-ba98-8605118565c8" />


After the fix:

<img width="1343" height="893" alt="image" src="https://github.com/user-attachments/assets/13e2f5a7-6615-4566-a8d8-53e1a4537142" />
