### PR TITLE
Fix farthest booking calculation being cut by 1d

### DIFF
--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -1058,7 +1058,7 @@ class Tools:
         now = datetime.now()
 
         earliest_booking = now + timedelta(minutes=schedule.earliest_booking)
-        farthest_booking = now + timedelta(minutes=schedule.farthest_booking)
+        farthest_booking = now + timedelta(days=1, minutes=schedule.farthest_booking)
 
         start = max([datetime.combine(schedule.start_date, schedule.start_time), earliest_booking])
         end = (


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->
This change fixes a bug where the last day of an availability time window wasn't considered for remote event retrieval.

## How to test

0. Have remote events at the last day of the configured booking window (e.g. if the window is 7d, have events at that exact day).
1. Don't checkout this branch yet and go to your bookers page and see, that the last day in the booking window is completely bookable
2. Now checkout this branch and reload the bookers page
3. See that there are blockers now on the last available day where the remote events are

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->
Prevention of bookings at potentially already blocked times.

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->
It would be good to have tests for those event edge cases.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->
Closes #1719

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->
None