### PR TITLE
Update E2E tests to ensure settings values are populated before proceeding

### DIFF
--- a/test/e2e/pages/availability-page.ts
+++ b/test/e2e/pages/availability-page.ts
@@ -95,13 +95,21 @@ export class AvailabilityPage {
     await this.page.goto(APPT_AVAILABILITY_PAGE, { timeout: TIMEOUT_30_SECONDS });
     await this.page.waitForTimeout(TIMEOUT_10_SECONDS);
 
-    // the bookable toggle especially seems to take a long time to load in BrowserStack
-    if (! await this.bookableToggle.isEnabled()) {
-      await this.page.waitForTimeout(TIMEOUT_10_SECONDS);
-    }
+    // ensure that the bookable toggle is loaded/enabled
+    await expect
+      .poll(async () => (await this.bookableToggle.isEnabled()), {
+        timeout: TIMEOUT_30_SECONDS,
+        message: 'Waiting for bookable toggle to be populated',
+      })
+      .toBe(true);
 
     // the timezone field also sometimes takes a long time to populate in BrowserStack
-    await this.timeZoneSelect.waitFor({ state: 'visible', timeout: TIMEOUT_30_SECONDS });
+    await expect
+      .poll(async () => (await this.timeZoneSelect.inputValue()).trim(), {
+        timeout: TIMEOUT_30_SECONDS,
+        message: 'Waiting for timezone field to be populated',
+      })
+      .not.toBe('');
 
     await this.bookableToggleContainer.waitFor({ timeout: TIMEOUT_30_SECONDS });
     await this.allStartTimeInput.waitFor({ timeout: TIMEOUT_30_SECONDS });

--- a/test/e2e/pages/settings-page.ts
+++ b/test/e2e/pages/settings-page.ts
@@ -6,10 +6,11 @@ import {
   TIMEOUT_1_SECOND,
   TIMEOUT_2_SECONDS,
   TIMEOUT_5_SECONDS,
+  TIMEOUT_10_SECONDS,
   TIMEOUT_30_SECONDS,
   APPT_LANGUAGE_SETTING_EN,
   APPT_START_OF_WEEK_MON,
-  } from '../const/constants';
+} from '../const/constants';
 
 
 export class SettingsPage {
@@ -124,9 +125,19 @@ export class SettingsPage {
   async gotoAccountSettings() {
     await this.page.goto(APPT_SETTINGS_PAGE);
     await this.page.waitForTimeout(TIMEOUT_5_SECONDS);
+    await this.page.waitForURL(APPT_SETTINGS_PAGE, { timeout: TIMEOUT_30_SECONDS });
     await this.scrollIntoView(this.accountSettingsBtn);
     await this.accountSettingsBtn.click();
     await this.page.waitForTimeout(TIMEOUT_1_SECOND);
+    // settings seems to take awhile to populate on prod, especially BrowserStack, so let's
+    // ensure that the settings are loaded i.e. the 'Display Name' field is not blank
+    await expect(this.displayNameInput).toBeEnabled({ timeout: TIMEOUT_10_SECONDS });
+    await expect
+      .poll(async () => (await this.displayNameInput.inputValue()).trim(), {
+        timeout: TIMEOUT_30_SECONDS,
+        message: 'Waiting for display name field to be populated',
+      })
+      .not.toBe('');
   }
 
   /**
@@ -135,9 +146,19 @@ export class SettingsPage {
   async gotoPreferencesSettings() {
     await this.page.goto(APPT_SETTINGS_PAGE);
     await this.page.waitForTimeout(TIMEOUT_5_SECONDS);
+    await this.page.waitForURL(APPT_SETTINGS_PAGE, { timeout: TIMEOUT_30_SECONDS });    
     await this.scrollIntoView(this.preferencesBtn, TIMEOUT_30_SECONDS);
     await this.preferencesBtn.click();
     await this.page.waitForTimeout(TIMEOUT_1_SECOND);
+    // settings seems to take awhile to populate on prod, especially BrowserStack, so let's
+    // ensure that the settings are loaded i.e. the 'Theme' field is not blank
+    await expect(this.themeSelect).toBeEnabled({ timeout: TIMEOUT_10_SECONDS });
+    await expect
+      .poll(async () => (await this.themeSelect.inputValue()).trim(), {
+        timeout: TIMEOUT_30_SECONDS,
+        message: 'Waiting for theme field to be populated',
+      })
+      .not.toBe('');
   }
 
   /**

--- a/test/e2e/tests/desktop/auth.desktop.setup.ts
+++ b/test/e2e/tests/desktop/auth.desktop.setup.ts
@@ -1,17 +1,17 @@
 import { test as setup, expect } from '@playwright/test';
 import { AvailabilityPage } from '../../pages/availability-page';
+import { SettingsPage } from '../../pages/settings-page';
 import path from 'path';
 
 import { navigateToAppointmentAndSignIn, setDefaultUserSettingsLocalStore } from '../../utils/utils';
 
 import {
     APPT_DASHBOARD_HOME_PAGE,
-    APPT_SETTINGS_PAGE,
     APPT_TIMEZONE_SETTING_PRIMARY,
     TIMEOUT_1_SECOND,
     TIMEOUT_2_SECONDS,
-    TIMEOUT_30_SECONDS,
     TIMEOUT_5_SECONDS,
+    TIMEOUT_30_SECONDS,
 } from "../../const/constants";
 
 const fs = require('fs');
@@ -48,7 +48,8 @@ setup('desktop browser authenticate', async ({ page }) => {
 
   // ensure our settings are set to what the tests expect as default (in case a
   // previous test run failed and left the settings in an incorrect state)
-  await page.goto(APPT_SETTINGS_PAGE);
+  const settingsPage = new SettingsPage(page);
+  await settingsPage.gotoAccountSettings();
   await page.waitForTimeout(TIMEOUT_5_SECONDS);
   await setDefaultUserSettingsLocalStore(page);
   await page.waitForTimeout(TIMEOUT_2_SECONDS);

--- a/test/e2e/utils/utils.ts
+++ b/test/e2e/utils/utils.ts
@@ -1,5 +1,6 @@
 // utility functions that may be used by any tests
 import { TBAcctsPage } from "../pages/tb-accts-page";
+import { SettingsPage } from '../pages/settings-page';
 import { expect, type Page } from '@playwright/test';
 import path from 'path';
 
@@ -7,7 +8,6 @@ import {
   APPT_TARGET_ENV,
   APPT_URL,
   APPT_PAGE_TITLE,
-  APPT_SETTINGS_PAGE,
   APPT_DISPLAY_NAME,
   APPT_TIMEZONE_SETTING_PRIMARY,
   APPT_BROWSER_STORE_LANGUAGE_EN,
@@ -93,8 +93,6 @@ export const setDefaultUserSettingsLocalStore = async (page: Page, setTimeZone: 
   if (setTimeZone == 'UTC')
      setTimeZone = 'Europe/Dublin';
 
-  console.log(`setting Appointment timezone setting to: ${setTimeZone}`);
-
   // now set them
   localUserStoreData['name'] = APPT_DISPLAY_NAME;
   localUserStoreData['settings'] = {
@@ -105,13 +103,13 @@ export const setDefaultUserSettingsLocalStore = async (page: Page, setTimeZone: 
       "startOfWeek": APPT_BROWSER_STORE_START_WEEK_SUN,
   }
 
+  console.log(`setting user settings in local browser store to: ${JSON.stringify(localUserStoreData['settings'])}`);
   await page.evaluate(`localStorage.setItem('tba/user', '${JSON.stringify(localUserStoreData)}')`);
   await page.waitForTimeout(TIMEOUT_1_SECOND);
 
   // get them again and verify were set
   var updatedLocalUserStoreData = JSON.parse(await page.evaluate("localStorage.getItem('tba/user')"));
-
-  console.log(`updated user settings from local browser store: ${JSON.stringify(updatedLocalUserStoreData['settings'])}`);
+  console.log(`user settings from local browser store are now: ${JSON.stringify(updatedLocalUserStoreData['settings'])}`);
   expect(updatedLocalUserStoreData['settings']).toStrictEqual(localUserStoreData['settings']);
 }
 
@@ -124,9 +122,9 @@ export const mobileSignInAndSetup = async (page: Page, testProjectName: string) 
   await navigateToAppointmentAndSignIn(page, testProjectName);
   // ensure our settings are set to what the tests expect as default (in case a
   // previous test run failed and left the settings in an incorrect state)
-  await page.goto(APPT_SETTINGS_PAGE);
+  const settingsPage = new SettingsPage(page);
+  await settingsPage.gotoAccountSettings();
   await page.waitForTimeout(TIMEOUT_5_SECONDS);
-  await page.waitForURL(APPT_SETTINGS_PAGE);
   await setDefaultUserSettingsLocalStore(page);
   await page.waitForTimeout(TIMEOUT_2_SECONDS);
 }


### PR DESCRIPTION
## What changed?
Improve the Appointment E2E tests by ensuring that the settings page field values are actually populated before proceeding.

# Why
Sometimes production Appointment can run quite slow (especially in BrowserStack) and after navigating to the Appointment Settings page, the DOM is loaded however the actual values in the settings fields aren't populated for several seconds. I previously filed an issue about Settings being slow to load in #1371. Here [is an example](https://automate.browserstack.com/projects/Thunderbird+Appointment/builds/Appointment+Nightly+Tests+Firefox+Desktop/241?testListView=spec&details=3713593457) BrowserStack video where you see the settings page opens but the actual field values aren't populated and the tests attempts to proceed.

Allow more time for the Settings pages to be populated with the actual Settings values; and check actual field values and ensure they're not blank, before proceeding to the test's next step.

## Applicable Issues
Fixes #1734.

## QA Log
- Ran the E2E tests on desktop locally
- Ran the updated E2E tests on stage on Firefox desktop [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Appointment/builds/Appointment+Tests+Firefox+Desktop/42?tab=sessions&testListView=spec)
- Ran the updated E2E tests on stage on Android Chrome [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Appointment/builds/Appointment+Tests+Android+Chrome/56?bls_localTimezone=true&testListView=spec)
