### PR TITLE
Handle midnight to midnight all day events

### DIFF
--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -652,6 +652,8 @@ class CalDavConnector(BaseConnector):
 
             if is_midnight_one_day_span(vevent) and has_domain(self.url, MIDNIGHT_SPAN_DOMAIN_WHITELIST):
                 all_day = True
+                start = start.replace(tzinfo=None)
+                end = end.replace(tzinfo=None)
             # -- fix end --
 
             events.append(

--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -608,6 +608,41 @@ class CalDavConnector(BaseConnector):
             # if start doesn't hold time information (no datetime), it's a whole day
             all_day = not isinstance(start, datetime)
 
+            # FIXME: Temporary Workaround for known CalDAV servers returning all day events
+            # as datetime spanning from midnight to midnight. This WILL FAIL, if a DST happens
+            # in between start and end times.
+            # -- fix start --
+            def is_midnight_one_day_span(vevent):
+                dtstart = vevent.dtstart.value
+                dtend = vevent.dtend.value
+
+                # Must both be actual datetimes (not plain dates) to have a meaningful "time"
+                if not isinstance(dtstart, datetime) or not isinstance(dtend, datetime):
+                    return False
+
+                starts_at_midnight = (
+                    dtstart.hour == 0 and dtstart.minute == 0 and
+                    dtstart.second == 0 and dtstart.microsecond == 0
+                )
+                ends_at_midnight = (
+                    dtend.hour == 0 and dtend.minute == 0 and
+                    dtend.second == 0 and dtend.microsecond == 0
+                )
+
+                exactly_one_day = (dtend - dtstart) == timedelta(days=1)
+
+                return starts_at_midnight and ends_at_midnight and exactly_one_day
+            
+            def has_domain(url, domain):
+                hostname = urlparse(url).hostname
+                if hostname is None:
+                    return False
+                return hostname == domain or hostname.endswith('.' + domain)
+            
+            if not all_day and is_midnight_one_day_span(vevent) and has_domain(self.url, 'thundermail.com'):
+                all_day = True
+            # -- fix end --
+
             events.append(
                 schemas.Event(
                     title=title,

--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -28,7 +28,7 @@ from enum import Enum
 from sqlalchemy.orm import Session
 
 from .. import utils
-from ..defines import REDIS_REMOTE_EVENTS_KEY, DATEFMT, DEFAULT_CALENDAR_COLOUR, FALLBACK_LOCALE
+from ..defines import REDIS_REMOTE_EVENTS_KEY, DATEFMT, DEFAULT_CALENDAR_COLOUR, FALLBACK_LOCALE, APP_ENV_DEV
 from .apis.google_client import EventStatus, GoogleClient, ResponseStatus, SendUpdates
 from ..database.models import CalendarProvider, BookingStatus
 from ..database import schemas, models, repo
@@ -612,7 +612,12 @@ class CalDavConnector(BaseConnector):
             # as datetime spanning from midnight to midnight. This WILL FAIL, if a DST happens
             # in between start and end times.
             # -- fix start --
+            MIDNIGHT_SPAN_DOMAIN_WHITELIST = ('thundermail.com', 'stage-thundermail.com')
+
             def is_midnight_one_day_span(vevent):
+                """For a given vevent object, check if it is an event spanning from midnight
+                   to midnight for exactly 24h.
+                """
                 dtstart = vevent.dtstart.value
                 dtend = vevent.dtend.value if hasattr(vevent, 'dtend') else None
 
@@ -633,13 +638,19 @@ class CalDavConnector(BaseConnector):
 
                 return starts_at_midnight and ends_at_midnight and exactly_one_day
             
-            def has_domain(url, domain):
+            def has_domain(url, whitelist):
+                """Return True if the given url contains a whitelisted domain.
+                   Always True for development environments.
+                """
+                if os.getenv('APP_ENV') == APP_ENV_DEV:
+                    return True
+
                 hostname = urlparse(url).hostname
                 if hostname is None:
                     return False
-                return hostname == domain or hostname.endswith('.' + domain)
-            
-            if not all_day and is_midnight_one_day_span(vevent) and has_domain(self.url, 'thundermail.com'):
+                return any(hostname == domain or hostname.endswith('.' + domain) for domain in whitelist)
+
+            if is_midnight_one_day_span(vevent) and has_domain(self.url, MIDNIGHT_SPAN_DOMAIN_WHITELIST):
                 all_day = True
             # -- fix end --
 

--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -614,10 +614,10 @@ class CalDavConnector(BaseConnector):
             # -- fix start --
             def is_midnight_one_day_span(vevent):
                 dtstart = vevent.dtstart.value
-                dtend = vevent.dtend.value
+                dtend = vevent.dtend.value if hasattr(vevent, 'dtend') else None
 
-                # Must both be actual datetimes (not plain dates) to have a meaningful "time"
-                if not isinstance(dtstart, datetime) or not isinstance(dtend, datetime):
+                # Must both be actual datetimes (not plain dates) and end must exist
+                if not dtend or not isinstance(dtstart, datetime) or not isinstance(dtend, datetime):
                     return False
 
                 starts_at_midnight = (

--- a/backend/test/integration/test_calendar.py
+++ b/backend/test/integration/test_calendar.py
@@ -1,6 +1,7 @@
 import os
 from datetime import date, datetime, timedelta
 from unittest.mock import MagicMock
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -736,6 +737,59 @@ class TestCaldavListEventsMidnightSpanWorkaround:
 
         assert len(events) == 1
         assert not events[0].all_day
+
+    def test_midnight_span_event_with_timezone_aware_datetimes_is_treated_as_all_day(self):
+        """The midnight check reads the wall-clock hour/minute/second of the datetime as-is,
+        so a tz-aware midnight-to-midnight event must be picked up regardless of its timezone,
+        and the fix strips the tzinfo so it renders as a plain all-day date."""
+        tz = ZoneInfo('America/New_York')
+        vevent = MockVEvent(
+            dtstart=datetime(2024, 6, 1, 0, 0, 0, tzinfo=tz), dtend=datetime(2024, 6, 2, 0, 0, 0, tzinfo=tz)
+        )
+        event = MockCaldavEvent(vevent, duration=timedelta(days=1))
+        connector = make_caldav_connector([event], url='https://caldav.thundermail.com/dav/john/')
+
+        events = connector.list_events('2024-06-01', '2024-06-02')
+
+        assert len(events) == 1
+        assert events[0].all_day
+        assert events[0].start == datetime(2024, 6, 1, 0, 0, 0)
+        assert events[0].end == datetime(2024, 6, 2, 0, 0, 0)
+        assert events[0].start.tzinfo is None
+        assert events[0].end.tzinfo is None
+
+    @pytest.mark.parametrize(
+        'tz_name', ['UTC', 'America/New_York', 'Europe/Berlin', 'Asia/Tokyo', 'Pacific/Kiritimati']
+    )
+    def test_midnight_span_event_is_treated_as_all_day_regardless_of_timezone(self, tz_name):
+        tz = ZoneInfo(tz_name)
+        vevent = MockVEvent(
+            dtstart=datetime(2024, 6, 1, 0, 0, 0, tzinfo=tz), dtend=datetime(2024, 6, 2, 0, 0, 0, tzinfo=tz)
+        )
+        event = MockCaldavEvent(vevent, duration=timedelta(days=1))
+        connector = make_caldav_connector([event], url='https://caldav.thundermail.com/dav/john/')
+
+        events = connector.list_events('2024-06-01', '2024-06-02')
+
+        assert len(events) == 1
+        assert events[0].all_day, f'Expected midnight span in {tz_name} to be treated as all day'
+
+    def test_non_midnight_timezone_aware_event_on_thundermail_keeps_its_timezone(self):
+        """When the workaround doesn't apply, a tz-aware event must be passed through untouched."""
+        tz = ZoneInfo('Europe/Berlin')
+        dtstart = datetime(2024, 6, 1, 9, 0, 0, tzinfo=tz)
+        dtend = datetime(2024, 6, 1, 17, 0, 0, tzinfo=tz)
+        vevent = MockVEvent(dtstart=dtstart, dtend=dtend)
+        event = MockCaldavEvent(vevent, duration=timedelta(hours=8))
+        connector = make_caldav_connector([event], url='https://caldav.thundermail.com/dav/john/')
+
+        events = connector.list_events('2024-06-01', '2024-06-02')
+
+        assert len(events) == 1
+        assert not events[0].all_day
+        assert events[0].start == dtstart
+        assert events[0].end == dtend
+        assert events[0].start.tzinfo is not None
 
     def test_midnight_span_check_handles_event_without_dtend(self):
         """Events that only expose a duration (no dtend attribute at all) must not crash

--- a/backend/test/integration/test_calendar.py
+++ b/backend/test/integration/test_calendar.py
@@ -1,4 +1,6 @@
 import os
+from datetime import date, datetime, timedelta
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -511,6 +513,229 @@ class TestCaldav:
             calendar_titles = [cal.title for cal in calendars]
             assert 'Test Calendar 1' in calendar_titles
             assert 'Test Calendar 2' in calendar_titles
+
+
+class MockVEvent:
+    """A fake vobject vevent exposing only the attributes list_events() reads.
+    Attributes are only set if a value is passed in, so tests can exercise the
+    hasattr()-guarded "missing property" branches in list_events()."""
+
+    def __init__(self, dtstart=None, dtend=None, duration=None, summary=None):
+        if dtstart is not None:
+            self.dtstart = MagicMock()
+            self.dtstart.value = dtstart
+
+        if dtend is not None:
+            self.dtend = MagicMock()
+            self.dtend.value = dtend
+
+        if duration is not None:
+            self.duration = MagicMock()
+            self.duration.value = duration
+
+        if summary is not None:
+            self.summary = MagicMock()
+            self.summary.value = summary
+
+
+class MockVObjectInstance:
+    def __init__(self, vevent):
+        self.vevent = vevent
+
+
+class MockCaldavEvent:
+    """A fake caldav event, as returned by calendar.search()."""
+
+    def __init__(self, vevent, status='confirmed', transp=None, description=None, duration=timedelta(hours=1)):
+        self.icalendar_component = {'status': status}
+        if transp is not None:
+            self.icalendar_component['transp'] = transp
+        if description is not None:
+            self.icalendar_component['description'] = description
+
+        self.vobject_instance = MockVObjectInstance(vevent)
+        self._duration = duration
+
+    def get_duration(self):
+        return self._duration
+
+
+def make_caldav_connector(events, url='https://test.com/caldav'):
+    """Build a CalDavConnector whose remote client is mocked to return the given events,
+    and whose redis cache is mocked out (no redis instance in tests)."""
+
+    def mock_search(start, end, event=True, expand=True):
+        return events
+
+    def mock_calendar(url):
+        calendar_mock = MagicMock()
+        calendar_mock.search = mock_search
+        return calendar_mock
+
+    connector = CalDavConnector(
+        db=None,
+        subscriber_id=1,
+        calendar_id=1,
+        redis_instance=None,
+        url=url,
+        user='test',
+        password='test',
+    )
+    connector.client = MagicMock()
+    connector.client.calendar = MagicMock(side_effect=mock_calendar)
+    connector.get_cached_events = MagicMock(return_value=None)
+    connector.put_cached_events = MagicMock()
+
+    return connector
+
+
+class TestCaldavListEvents:
+    """Tests for CalDavConnector.list_events()"""
+
+    def test_list_events_returns_basic_event(self):
+        vevent = MockVEvent(
+            dtstart=datetime(2024, 1, 1, 9, 0, 0), dtend=datetime(2024, 1, 1, 10, 0, 0), summary='Standup'
+        )
+        event = MockCaldavEvent(vevent, description='Daily standup', duration=timedelta(hours=1))
+        connector = make_caldav_connector([event])
+
+        events = connector.list_events('2024-01-01', '2024-01-02')
+
+        assert len(events) == 1
+        assert events[0].title == 'Standup'
+        assert events[0].start == datetime(2024, 1, 1, 9, 0, 0)
+        assert events[0].end == datetime(2024, 1, 1, 10, 0, 0)
+        assert events[0].description == 'Daily standup'
+        assert not events[0].all_day
+        assert not events[0].tentative
+
+    def test_list_events_uses_cache_when_available(self):
+        connector = make_caldav_connector([])
+        cached_events = [schemas.Event(title='Cached event', start=datetime(2024, 1, 1), end=datetime(2024, 1, 1, 1))]
+        connector.get_cached_events = MagicMock(return_value=cached_events)
+
+        events = connector.list_events('2024-01-01', '2024-01-02')
+
+        assert events == cached_events
+        connector.client.calendar.assert_not_called()
+
+    def test_list_events_ignores_cancelled_and_transparent_events(self):
+        cancelled_vevent = MockVEvent(dtstart=datetime(2024, 1, 1, 9), dtend=datetime(2024, 1, 1, 10))
+        cancelled_event = MockCaldavEvent(cancelled_vevent, status='cancelled')
+
+        transparent_vevent = MockVEvent(dtstart=datetime(2024, 1, 1, 9), dtend=datetime(2024, 1, 1, 10))
+        transparent_event = MockCaldavEvent(transparent_vevent, transp='transparent')
+
+        connector = make_caldav_connector([cancelled_event, transparent_event])
+
+        events = connector.list_events('2024-01-01', '2024-01-02')
+
+        assert events == []
+
+    def test_list_events_marks_tentative_events(self):
+        vevent = MockVEvent(dtstart=datetime(2024, 1, 1, 9), dtend=datetime(2024, 1, 1, 10))
+        event = MockCaldavEvent(vevent, status='tentative')
+        connector = make_caldav_connector([event])
+
+        events = connector.list_events('2024-01-01', '2024-01-02')
+
+        assert len(events) == 1
+        assert events[0].tentative
+
+    def test_list_events_whole_day_event_uses_date_values(self):
+        """A properly formed whole-day event uses date (not datetime) dtstart/dtend values
+        and should be marked all_day on its own, without the thundermail workaround below."""
+        vevent = MockVEvent(dtstart=date(2024, 1, 1), dtend=date(2024, 1, 2))
+        event = MockCaldavEvent(vevent, duration=timedelta(days=1))
+        connector = make_caldav_connector([event])
+
+        events = connector.list_events('2024-01-01', '2024-01-02')
+
+        assert len(events) == 1
+        assert events[0].all_day
+
+    def test_list_events_caches_the_result(self):
+        vevent = MockVEvent(dtstart=datetime(2024, 1, 1, 9), dtend=datetime(2024, 1, 1, 10))
+        event = MockCaldavEvent(vevent)
+        connector = make_caldav_connector([event])
+
+        events = connector.list_events('2024-01-01', '2024-01-02')
+
+        connector.put_cached_events.assert_called_once_with('2024-01-01_2024-01-02', events)
+
+
+class TestCaldavListEventsMidnightSpanWorkaround:
+    """Tests for the temporary FIXME workaround in CalDavConnector.list_events() that
+    treats midnight-to-midnight one-day datetime events from known CalDAV servers
+    (thundermail.com) as all-day events."""
+
+    def test_midnight_span_event_on_thundermail_is_treated_as_all_day(self):
+        vevent = MockVEvent(dtstart=datetime(2024, 1, 1, 0, 0, 0), dtend=datetime(2024, 1, 2, 0, 0, 0))
+        event = MockCaldavEvent(vevent, duration=timedelta(days=1))
+        connector = make_caldav_connector([event], url='https://caldav.thundermail.com/dav/john/')
+
+        events = connector.list_events('2024-01-01', '2024-01-02')
+
+        assert len(events) == 1
+        assert events[0].all_day
+
+    def test_midnight_span_event_on_thundermail_subdomain_is_treated_as_all_day(self):
+        """has_domain() matches subdomains of thundermail.com too."""
+        vevent = MockVEvent(dtstart=datetime(2024, 1, 1, 0, 0, 0), dtend=datetime(2024, 1, 2, 0, 0, 0))
+        event = MockCaldavEvent(vevent, duration=timedelta(days=1))
+        connector = make_caldav_connector([event], url='https://eu.thundermail.com/dav/john/')
+
+        events = connector.list_events('2024-01-01', '2024-01-02')
+
+        assert len(events) == 1
+        assert events[0].all_day
+
+    def test_midnight_span_event_on_other_server_is_not_treated_as_all_day(self):
+        """The workaround is scoped to thundermail.com; other CalDAV servers keep the
+        (technically correct, per RFC) datetime-based event untouched."""
+        vevent = MockVEvent(dtstart=datetime(2024, 1, 1, 0, 0, 0), dtend=datetime(2024, 1, 2, 0, 0, 0))
+        event = MockCaldavEvent(vevent, duration=timedelta(days=1))
+        connector = make_caldav_connector([event], url='https://caldav.example.com/dav/john/')
+
+        events = connector.list_events('2024-01-01', '2024-01-02')
+
+        assert len(events) == 1
+        assert not events[0].all_day
+
+    def test_non_midnight_event_on_thundermail_is_not_treated_as_all_day(self):
+        """Only events that start and end exactly at midnight are affected."""
+        vevent = MockVEvent(dtstart=datetime(2024, 1, 1, 9, 0, 0), dtend=datetime(2024, 1, 1, 17, 0, 0))
+        event = MockCaldavEvent(vevent, duration=timedelta(hours=8))
+        connector = make_caldav_connector([event], url='https://caldav.thundermail.com/dav/john/')
+
+        events = connector.list_events('2024-01-01', '2024-01-02')
+
+        assert len(events) == 1
+        assert not events[0].all_day
+
+    def test_multi_day_midnight_span_on_thundermail_is_not_treated_as_all_day(self):
+        """The workaround only applies to an exact one-day span; a DST-safe guard against
+        misclassifying genuinely multi-day timed events."""
+        vevent = MockVEvent(dtstart=datetime(2024, 1, 1, 0, 0, 0), dtend=datetime(2024, 1, 3, 0, 0, 0))
+        event = MockCaldavEvent(vevent, duration=timedelta(days=2))
+        connector = make_caldav_connector([event], url='https://caldav.thundermail.com/dav/john/')
+
+        events = connector.list_events('2024-01-01', '2024-01-03')
+
+        assert len(events) == 1
+        assert not events[0].all_day
+
+    def test_midnight_span_check_handles_event_without_dtend(self):
+        """Events that only expose a duration (no dtend attribute at all) must not crash
+        is_midnight_one_day_span() - it should treat them as not matching the workaround."""
+        vevent = MockVEvent(dtstart=datetime(2024, 1, 1, 0, 0, 0), duration='P1D')
+        event = MockCaldavEvent(vevent, duration=timedelta(days=1))
+        connector = make_caldav_connector([event], url='https://caldav.thundermail.com/dav/john/')
+
+        events = connector.list_events('2024-01-01', '2024-01-02')
+
+        assert len(events) == 1
+        assert not events[0].all_day
 
 
 class TestCalendarUpdateOrCreate:

--- a/backend/test/integration/test_calendar.py
+++ b/backend/test/integration/test_calendar.py
@@ -690,6 +690,18 @@ class TestCaldavListEventsMidnightSpanWorkaround:
         assert len(events) == 1
         assert events[0].all_day
 
+    def test_midnight_span_event_matches_any_domain_in_a_multi_domain_whitelist(self):
+        """has_domain() must match against every entry of the whitelist, not just the first."""
+        for url in ('https://caldav.thundermail.com/dav/john/', 'https://caldav.stage-thundermail.com/dav/john/'):
+            vevent = MockVEvent(dtstart=datetime(2024, 1, 1, 0, 0, 0), dtend=datetime(2024, 1, 2, 0, 0, 0))
+            event = MockCaldavEvent(vevent, duration=timedelta(days=1))
+            connector = make_caldav_connector([event], url=url)
+
+            events = connector.list_events('2024-01-01', '2024-01-02')
+
+            assert len(events) == 1
+            assert events[0].all_day, f'Expected {url} to match the whitelist'
+
     def test_midnight_span_event_on_other_server_is_not_treated_as_all_day(self):
         """The workaround is scoped to thundermail.com; other CalDAV servers keep the
         (technically correct, per RFC) datetime-based event untouched."""


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->
This PR adds a temporary fix for CalDAV servers serving all day events in datetime format with 00:00 time. The fix only applies if:

- **dtstart** and **dtend exist**
- both are of type **datetime** and have hours, minutes, seconds and ms set to **0**
- the diff of both is **exactly 24h**
- the CalDAV domain is **thundermail.com**

Also 12 tests were added to cover CalDAV events and this issue in particular.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->
For some reason, Thundermail (Stalwart) serves events marked as all-day not in the usual date format, but as datetime. This is an attempt to fix that quickly while waiting for a possible upstream fix. On the other hand, there might always be other CalDAV servers handling it like this. So we can discuss keeping this fix longer, but there are trade-offs.

## How to test

0. Don't check out this branch yet and have a Thundermal CalDAV connection active with at least one all-day event
1. Check the dashboard and see, the event is not positioned on top of the column but actually spans over all rows as normal event (wrong).
2. Now check out this branch and reload the dashboard page
3. See, that the same event now is listed on top of the column (correct).

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->
- This fix fails, if a DST switch happens on the event day
- This fix is currently scoped to only apply to thundermail.com domains

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->
Related to #580 

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->
Before the change:

<img width="1315" height="903" alt="image" src="https://github.com/user-attachments/assets/03e585db-005a-4ca5-9990-1592c4829059" />


After the change:

<img width="1315" height="903" alt="image" src="https://github.com/user-attachments/assets/82f957fa-aea5-4cc5-8bf9-0a09be18b04d" />
