### PR TITLE
Fix missing repeated event instances

### DIFF
--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -614,8 +614,7 @@ class CalDavConnector(BaseConnector):
             tentative = status == EventStatus.TENTATIVE
 
             start = vevent['DTSTART'].dt
-            # get_duration grabs either end or duration into a timedelta
-            end = (start + vevent['DURATION'].dt if 'DURATION' in vevent else vevent['DTEND'].dt)
+            end = vevent['DTEND'].dt
             # if start doesn't hold time information (no datetime), it's a whole day
             all_day = not isinstance(start, datetime)
 
@@ -630,10 +629,10 @@ class CalDavConnector(BaseConnector):
                    to midnight for exactly 24h.
                 """
                 dtstart = vevent['DTSTART'].dt
-                dtend = vevent['DTEND'].dt if 'DTEND' in vevent else None
+                dtend = vevent['DTEND'].dt
 
-                # Must both be actual datetimes (not plain dates) and end must exist
-                if not dtend or not isinstance(dtstart, datetime) or not isinstance(dtend, datetime):
+                # Must both be actual datetimes, not plain dates
+                if not isinstance(dtstart, datetime) or not isinstance(dtend, datetime):
                     return False
 
                 starts_at_midnight = (

--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -10,6 +10,7 @@ import zoneinfo
 import os
 from functools import cache
 from urllib.parse import urlparse, urljoin
+import recurring_ical_events
 
 import caldav.lib.error
 import lxml.etree
@@ -566,45 +567,55 @@ class CalDavConnector(BaseConnector):
 
         events = []
         calendar = self.client.calendar(url=self.url)
+        search_start = datetime.strptime(start, DATEFMT)
+        search_end = datetime.strptime(end, DATEFMT)
+
         result = calendar.search(
-            start=datetime.strptime(start, DATEFMT),
-            end=datetime.strptime(end, DATEFMT),
+            start=search_start,
+            end=search_end,
             event=True,
-            expand=True,
+            expand=False,
         )
-        for e in result:
-            transparency = e.icalendar_component['transp'].lower() if 'transp' in e.icalendar_component else 'opaque'
-            status = e.icalendar_component['status'].lower() if 'status' in e.icalendar_component else ''
+
+        all_instances = []
+
+        # First run to manually expand recurring events
+        for record in result:
+            component = record.icalendar_component
+
+            # Ignore events missing dtstart, or missing both dtend and duration:
+            # recurring_ical_events requires dtstart, and would otherwise synthesize
+            # a zero-duration dtend for events that don't have an end at all.
+            if 'DTSTART' not in component:
+                continue
+            if 'DTEND' not in component and 'DURATION' not in component:
+                continue
+
+            query = recurring_ical_events.of(component)
+            instances = query.between(search_start, search_end)
+            all_instances.extend(instances)
+
+        # Now that we have all event instances, do the actual vevent processing
+        # At this point it's guaranteed by recurring_ical_events that instances
+        # have both DTSTART and a synthesized DTEND.
+        for vevent in all_instances:
+            transparency = vevent['TRANSP'].lower() if 'TRANSP' in vevent else 'opaque'
+            status = vevent['STATUS'].lower() if 'STATUS' in vevent else ''
 
             # Ignore cancelled events
             if status == EventStatus.CANCELLED or transparency == 'transparent':
                 continue
 
-            vevent = e.vobject_instance.vevent
-            if not vevent:
-                continue
-
-            # Ignore events with missing dtstart
-            if not hasattr(vevent, 'dtstart') or not vevent.dtstart:
-                continue
-
-            # Check for either dtend or duration (need at least one to determine event end)
-            has_dtend = hasattr(vevent, 'dtend') and vevent.dtend
-            has_duration = hasattr(vevent, 'duration') and vevent.duration
-
-            if not has_dtend and not has_duration:
-                continue
-
             # Check for event summary or use default title
-            has_summary = hasattr(vevent, 'summary') and vevent.summary
-            title = vevent.summary.value if has_summary else l10n('event-summary-default')
+            has_summary = 'SUMMARY' in vevent and vevent['SUMMARY']
+            title = vevent['SUMMARY'] if has_summary else l10n('event-summary-default')
 
             # Mark tentative events
             tentative = status == EventStatus.TENTATIVE
 
-            start = vevent.dtstart.value
+            start = vevent['DTSTART'].dt
             # get_duration grabs either end or duration into a timedelta
-            end = start + e.get_duration()
+            end = (start + vevent['DURATION'].dt if 'DURATION' in vevent else vevent['DTEND'].dt)
             # if start doesn't hold time information (no datetime), it's a whole day
             all_day = not isinstance(start, datetime)
 
@@ -618,8 +629,8 @@ class CalDavConnector(BaseConnector):
                 """For a given vevent object, check if it is an event spanning from midnight
                    to midnight for exactly 24h.
                 """
-                dtstart = vevent.dtstart.value
-                dtend = vevent.dtend.value if hasattr(vevent, 'dtend') else None
+                dtstart = vevent['DTSTART'].dt
+                dtend = vevent['DTEND'].dt if 'DTEND' in vevent else None
 
                 # Must both be actual datetimes (not plain dates) and end must exist
                 if not dtend or not isinstance(dtstart, datetime) or not isinstance(dtend, datetime):
@@ -663,7 +674,7 @@ class CalDavConnector(BaseConnector):
                     end=end,
                     all_day=all_day,
                     tentative=tentative,
-                    description=e.icalendar_component['description'] if 'description' in e.icalendar_component else '',
+                    description=vevent['DESCRIPTION'] if 'DESCRIPTION' in vevent else '',
                 )
             )
 

--- a/backend/test/integration/test_appointment.py
+++ b/backend/test/integration/test_appointment.py
@@ -1,7 +1,8 @@
+import icalendar
 import pytest
 import dateutil.parser
 from unittest.mock import patch, MagicMock
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from defines import DAY1, DAY3, auth_headers, TEST_USER_ID
 from appointment.database.repo import appointment as appointment_repo
@@ -59,35 +60,27 @@ class TestAppointment:
         from appointment.controller.calendar import CalDavConnector
 
         # Create mock events with various missing properties
-        class MockVEvent:
-            def __init__(self, has_summary=True, has_dtend=True, has_duration=False):
-                self.dtstart = MagicMock()
-                self.dtstart.value = datetime(2023, 12, 1, 10, 0, 0)
+        class MockEvent:
+            """A fake caldav event, as returned by calendar.search(), whose icalendar_component
+               is a real icalendar.Event so it can go through recurring_ical_events expansion.
+            """
+
+            def __init__(self, has_dtstart=True, has_summary=True, has_dtend=True, has_duration=False):
+                vevent = icalendar.Event()
+                vevent.add('status', 'confirmed')
+
+                if has_dtstart:
+                    vevent.add('dtstart', datetime(2023, 12, 1, 10, 0, 0))
 
                 if has_summary:
-                    self.summary = MagicMock()
-                    self.summary.value = 'Test Event'
+                    vevent.add('summary', 'Test Event')
 
                 if has_dtend:
-                    self.dtend = MagicMock()
-                    self.dtend.value = datetime(2023, 12, 1, 11, 0, 0)
+                    vevent.add('dtend', datetime(2023, 12, 1, 11, 0, 0))
                 elif has_duration:
-                    self.duration = MagicMock()
-                    self.duration.value = 'PT1H'  # 1 hour
+                    vevent.add('duration', timedelta(hours=1))
 
-        class MockVObjectInstance:
-            def __init__(self, has_summary=True, has_dtend=True, has_duration=False):
-                self.vevent = MockVEvent(has_summary, has_dtend, has_duration)
-
-        class MockEvent:
-            def __init__(self, has_summary=True, has_dtend=True, has_duration=False):
-                self.icalendar_component = {'status': 'confirmed'}
-                self.vobject_instance = MockVObjectInstance(has_summary, has_dtend, has_duration)
-
-            def get_duration(self):
-                from datetime import timedelta
-
-                return timedelta(hours=1)
+                self.icalendar_component = vevent
 
         # Create various test events
         mock_events = [
@@ -98,37 +91,10 @@ class TestAppointment:
         ]
 
         # Add events that should be filtered out by our guards
-        class MockBadVEvent:
-            """VEvent with missing critical properties"""
-
-            def __init__(self, missing_dtstart=False, missing_both_end_props=False):
-                if not missing_dtstart:
-                    self.dtstart = MagicMock()
-                    self.dtstart.value = datetime(2023, 12, 1, 10, 0, 0)
-
-                if not missing_both_end_props:
-                    self.dtend = MagicMock()
-                    self.dtend.value = datetime(2023, 12, 1, 11, 0, 0)
-
-        class MockBadVObjectInstance:
-            def __init__(self, missing_dtstart=False, missing_both_end_props=False):
-                self.vevent = MockBadVEvent(missing_dtstart, missing_both_end_props)
-
-        class MockBadEvent:
-            def __init__(self, missing_dtstart=False, missing_both_end_props=False):
-                self.icalendar_component = {'status': 'confirmed'}
-                self.vobject_instance = MockBadVObjectInstance(missing_dtstart, missing_both_end_props)
-
-            def get_duration(self):
-                from datetime import timedelta
-
-                return timedelta(hours=1)
-
-        # Add events that should be filtered out
         mock_events.extend(
             [
-                MockBadEvent(missing_dtstart=True),  # Missing dtstart - should be filtered
-                MockBadEvent(missing_both_end_props=True),  # Missing both dtend and duration - should be filtered
+                MockEvent(has_dtstart=False),  # Missing dtstart - should be filtered
+                MockEvent(has_dtend=False, has_duration=False),  # Missing both dtend and duration - should be filtered
             ]
         )
 

--- a/backend/test/integration/test_calendar.py
+++ b/backend/test/integration/test_calendar.py
@@ -3,6 +3,7 @@ from datetime import date, datetime, timedelta
 from unittest.mock import MagicMock
 from zoneinfo import ZoneInfo
 
+import icalendar
 import pytest
 
 from appointment.database.models import CalendarProvider
@@ -516,49 +517,37 @@ class TestCaldav:
             assert 'Test Calendar 2' in calendar_titles
 
 
-class MockVEvent:
-    """A fake vobject vevent exposing only the attributes list_events() reads.
-    Attributes are only set if a value is passed in, so tests can exercise the
-    hasattr()-guarded "missing property" branches in list_events()."""
+def MockVEvent(dtstart=None, dtend=None, duration=None, summary=None):
+    """Build a fake VEVENT component exposing only the properties list_events() reads.
+    Properties are only set if a value is passed in, so tests can exercise the
+    "missing property" branches in list_events()."""
+    vevent = icalendar.Event()
+    if dtstart is not None:
+        vevent.add('dtstart', dtstart)
 
-    def __init__(self, dtstart=None, dtend=None, duration=None, summary=None):
-        if dtstart is not None:
-            self.dtstart = MagicMock()
-            self.dtstart.value = dtstart
+    if dtend is not None:
+        vevent.add('dtend', dtend)
 
-        if dtend is not None:
-            self.dtend = MagicMock()
-            self.dtend.value = dtend
+    if duration is not None:
+        vevent.add('duration', duration)
 
-        if duration is not None:
-            self.duration = MagicMock()
-            self.duration.value = duration
+    if summary is not None:
+        vevent.add('summary', summary)
 
-        if summary is not None:
-            self.summary = MagicMock()
-            self.summary.value = summary
-
-
-class MockVObjectInstance:
-    def __init__(self, vevent):
-        self.vevent = vevent
+    return vevent
 
 
 class MockCaldavEvent:
     """A fake caldav event, as returned by calendar.search()."""
 
-    def __init__(self, vevent, status='confirmed', transp=None, description=None, duration=timedelta(hours=1)):
-        self.icalendar_component = {'status': status}
+    def __init__(self, vevent, status='confirmed', transp=None, description=None):
+        vevent.add('status', status)
         if transp is not None:
-            self.icalendar_component['transp'] = transp
+            vevent.add('transp', transp)
         if description is not None:
-            self.icalendar_component['description'] = description
+            vevent.add('description', description)
 
-        self.vobject_instance = MockVObjectInstance(vevent)
-        self._duration = duration
-
-    def get_duration(self):
-        return self._duration
+        self.icalendar_component = vevent
 
 
 def make_caldav_connector(events, url='https://test.com/caldav'):
@@ -597,7 +586,7 @@ class TestCaldavListEvents:
         vevent = MockVEvent(
             dtstart=datetime(2024, 1, 1, 9, 0, 0), dtend=datetime(2024, 1, 1, 10, 0, 0), summary='Standup'
         )
-        event = MockCaldavEvent(vevent, description='Daily standup', duration=timedelta(hours=1))
+        event = MockCaldavEvent(vevent, description='Daily standup')
         connector = make_caldav_connector([event])
 
         events = connector.list_events('2024-01-01', '2024-01-02')
@@ -647,7 +636,7 @@ class TestCaldavListEvents:
         """A properly formed whole-day event uses date (not datetime) dtstart/dtend values
         and should be marked all_day on its own, without the thundermail workaround below."""
         vevent = MockVEvent(dtstart=date(2024, 1, 1), dtend=date(2024, 1, 2))
-        event = MockCaldavEvent(vevent, duration=timedelta(days=1))
+        event = MockCaldavEvent(vevent)
         connector = make_caldav_connector([event])
 
         events = connector.list_events('2024-01-01', '2024-01-02')
@@ -672,7 +661,7 @@ class TestCaldavListEventsMidnightSpanWorkaround:
 
     def test_midnight_span_event_on_thundermail_is_treated_as_all_day(self):
         vevent = MockVEvent(dtstart=datetime(2024, 1, 1, 0, 0, 0), dtend=datetime(2024, 1, 2, 0, 0, 0))
-        event = MockCaldavEvent(vevent, duration=timedelta(days=1))
+        event = MockCaldavEvent(vevent)
         connector = make_caldav_connector([event], url='https://caldav.thundermail.com/dav/john/')
 
         events = connector.list_events('2024-01-01', '2024-01-02')
@@ -683,7 +672,7 @@ class TestCaldavListEventsMidnightSpanWorkaround:
     def test_midnight_span_event_on_thundermail_subdomain_is_treated_as_all_day(self):
         """has_domain() matches subdomains of thundermail.com too."""
         vevent = MockVEvent(dtstart=datetime(2024, 1, 1, 0, 0, 0), dtend=datetime(2024, 1, 2, 0, 0, 0))
-        event = MockCaldavEvent(vevent, duration=timedelta(days=1))
+        event = MockCaldavEvent(vevent)
         connector = make_caldav_connector([event], url='https://eu.thundermail.com/dav/john/')
 
         events = connector.list_events('2024-01-01', '2024-01-02')
@@ -695,7 +684,7 @@ class TestCaldavListEventsMidnightSpanWorkaround:
         """has_domain() must match against every entry of the whitelist, not just the first."""
         for url in ('https://caldav.thundermail.com/dav/john/', 'https://caldav.stage-thundermail.com/dav/john/'):
             vevent = MockVEvent(dtstart=datetime(2024, 1, 1, 0, 0, 0), dtend=datetime(2024, 1, 2, 0, 0, 0))
-            event = MockCaldavEvent(vevent, duration=timedelta(days=1))
+            event = MockCaldavEvent(vevent)
             connector = make_caldav_connector([event], url=url)
 
             events = connector.list_events('2024-01-01', '2024-01-02')
@@ -707,7 +696,7 @@ class TestCaldavListEventsMidnightSpanWorkaround:
         """The workaround is scoped to thundermail.com; other CalDAV servers keep the
         (technically correct, per RFC) datetime-based event untouched."""
         vevent = MockVEvent(dtstart=datetime(2024, 1, 1, 0, 0, 0), dtend=datetime(2024, 1, 2, 0, 0, 0))
-        event = MockCaldavEvent(vevent, duration=timedelta(days=1))
+        event = MockCaldavEvent(vevent)
         connector = make_caldav_connector([event], url='https://caldav.example.com/dav/john/')
 
         events = connector.list_events('2024-01-01', '2024-01-02')
@@ -718,7 +707,7 @@ class TestCaldavListEventsMidnightSpanWorkaround:
     def test_non_midnight_event_on_thundermail_is_not_treated_as_all_day(self):
         """Only events that start and end exactly at midnight are affected."""
         vevent = MockVEvent(dtstart=datetime(2024, 1, 1, 9, 0, 0), dtend=datetime(2024, 1, 1, 17, 0, 0))
-        event = MockCaldavEvent(vevent, duration=timedelta(hours=8))
+        event = MockCaldavEvent(vevent)
         connector = make_caldav_connector([event], url='https://caldav.thundermail.com/dav/john/')
 
         events = connector.list_events('2024-01-01', '2024-01-02')
@@ -730,7 +719,7 @@ class TestCaldavListEventsMidnightSpanWorkaround:
         """The workaround only applies to an exact one-day span; a DST-safe guard against
         misclassifying genuinely multi-day timed events."""
         vevent = MockVEvent(dtstart=datetime(2024, 1, 1, 0, 0, 0), dtend=datetime(2024, 1, 3, 0, 0, 0))
-        event = MockCaldavEvent(vevent, duration=timedelta(days=2))
+        event = MockCaldavEvent(vevent)
         connector = make_caldav_connector([event], url='https://caldav.thundermail.com/dav/john/')
 
         events = connector.list_events('2024-01-01', '2024-01-03')
@@ -746,7 +735,7 @@ class TestCaldavListEventsMidnightSpanWorkaround:
         vevent = MockVEvent(
             dtstart=datetime(2024, 6, 1, 0, 0, 0, tzinfo=tz), dtend=datetime(2024, 6, 2, 0, 0, 0, tzinfo=tz)
         )
-        event = MockCaldavEvent(vevent, duration=timedelta(days=1))
+        event = MockCaldavEvent(vevent)
         connector = make_caldav_connector([event], url='https://caldav.thundermail.com/dav/john/')
 
         events = connector.list_events('2024-06-01', '2024-06-02')
@@ -766,7 +755,7 @@ class TestCaldavListEventsMidnightSpanWorkaround:
         vevent = MockVEvent(
             dtstart=datetime(2024, 6, 1, 0, 0, 0, tzinfo=tz), dtend=datetime(2024, 6, 2, 0, 0, 0, tzinfo=tz)
         )
-        event = MockCaldavEvent(vevent, duration=timedelta(days=1))
+        event = MockCaldavEvent(vevent)
         connector = make_caldav_connector([event], url='https://caldav.thundermail.com/dav/john/')
 
         events = connector.list_events('2024-06-01', '2024-06-02')
@@ -780,7 +769,7 @@ class TestCaldavListEventsMidnightSpanWorkaround:
         dtstart = datetime(2024, 6, 1, 9, 0, 0, tzinfo=tz)
         dtend = datetime(2024, 6, 1, 17, 0, 0, tzinfo=tz)
         vevent = MockVEvent(dtstart=dtstart, dtend=dtend)
-        event = MockCaldavEvent(vevent, duration=timedelta(hours=8))
+        event = MockCaldavEvent(vevent)
         connector = make_caldav_connector([event], url='https://caldav.thundermail.com/dav/john/')
 
         events = connector.list_events('2024-06-01', '2024-06-02')
@@ -792,16 +781,18 @@ class TestCaldavListEventsMidnightSpanWorkaround:
         assert events[0].start.tzinfo is not None
 
     def test_midnight_span_check_handles_event_without_dtend(self):
-        """Events that only expose a duration (no dtend attribute at all) must not crash
-        is_midnight_one_day_span() - it should treat them as not matching the workaround."""
-        vevent = MockVEvent(dtstart=datetime(2024, 1, 1, 0, 0, 0), duration='P1D')
-        event = MockCaldavEvent(vevent, duration=timedelta(days=1))
+        """Events that only expose a duration (no dtend property at all) must not crash
+        is_midnight_one_day_span(). The recurring_ical_events expansion always resolves
+        duration into a concrete dtend, so a midnight-to-midnight duration-only event is
+        still picked up by the workaround, same as if dtend had been given explicitly."""
+        vevent = MockVEvent(dtstart=datetime(2024, 1, 1, 0, 0, 0), duration=timedelta(days=1))
+        event = MockCaldavEvent(vevent)
         connector = make_caldav_connector([event], url='https://caldav.thundermail.com/dav/john/')
 
         events = connector.list_events('2024-01-01', '2024-01-02')
 
         assert len(events) == 1
-        assert not events[0].all_day
+        assert events[0].all_day
 
 
 class TestCalendarUpdateOrCreate:


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

This PR changes the event retrieval for CalDAV calendars. We used to rely on `calendar.search(expand=True)`, assuming this would provide all instances of recurring events. But some CalDAV servers were cutting of the last instances when the recurring event was based on an end date. So this PR introduces a manually approach of expanding recurring events and modifies existing tests accordingly.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->
Retrieving and processing recurring event instances from CalDAV servers more reliably.

## How to test

0. Have a recurring (e.g. daily) all-day event and a recurring normal event available in Thundermail and have the Thundermail CalDAV connected to Appointment. **Important: The issue only occurs when the recurring event was configured with an end date. Specifying a recurrence count was fine on my end.**
1. Don't checkout this branch yet and go to the dashboard.
2. See that the last occurrence of each event chain is missing
3. Now checkout this branch (and reload containers to clear event caches)
4. Reload the dashboard and see that the last occurrence now shows up for each event chain

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->
- We now use `recurring_ical_events.of()` to expand events. This slightly changes the event processing, since we now get actual vevent instances directly instead of the caldav events returned by `calendar.search()`. That made some changes on existing tests necessary.
- The issue of multiple day events is out of scope was reported here: #1755
- Implementation was done by me. Tests were modified by Claude Code.

## Applicable Issues

Closes #1678 

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

Before:

<img width="1287" height="879" alt="Image" src="https://github.com/user-attachments/assets/af092908-2c09-4410-97a2-b8353dad1300" />

After:

<img width="1289" height="877" alt="image" src="https://github.com/user-attachments/assets/b4e61031-0635-4cad-93fb-2ae762c3d45f" />

