### PR TITLE
Introspect OIDC token to fix automatic Thundermail CalDAV connection

### DIFF
--- a/backend/src/appointment/routes/caldav.py
+++ b/backend/src/appointment/routes/caldav.py
@@ -11,6 +11,7 @@ from redis import Redis
 from sqlalchemy.orm import Session
 
 from appointment import utils
+from appointment.controller.apis.oidc_client import OIDCClient
 from appointment.controller.calendar import CalDavConnector, Tools
 from appointment.database import models, schemas, repo
 from appointment.dependencies.auth import get_subscriber, get_bearer_token
@@ -169,6 +170,14 @@ def oidc_autodiscover_auth(
     if not tb_accounts_host or not appointment_caldav_secret:
         raise RemoteCalendarConnectionError()
 
+    # The CalDAV server authenticates against the account's OIDC login (`preferred_username`),
+    # which can differ from `subscriber.email` (the standard OIDC `email` claim, used for
+    # notifications). Introspect the token to recover the login identity for CalDAV auth.
+    token_data = OIDCClient().introspect_token(token)
+    if not token_data:
+        raise RemoteCalendarConnectionError()
+    caldav_user = token_data.get('preferred_username') or token_data.get('username') or subscriber.email
+
     try:
         response = requests.post(
             f'{tb_accounts_host}/appointment/caldav/setup/',
@@ -199,7 +208,7 @@ def oidc_autodiscover_auth(
         url=connection_url,
         subscriber_id=subscriber.id,
         calendar_id=None,
-        user=subscriber.email,
+        user=caldav_user,
         password=app_password,
     )
 

--- a/backend/test/integration/test_caldav_routes.py
+++ b/backend/test/integration/test_caldav_routes.py
@@ -2,6 +2,8 @@ import json
 import os
 from unittest.mock import patch, MagicMock
 
+import pytest
+
 from appointment.controller.calendar import CalDavConnector, Tools
 from appointment.database import models
 from appointment.exceptions.calendar import TestConnectionFailed
@@ -13,6 +15,16 @@ from defines import auth_headers, TEST_USER_ID
 
 class TestOidcAutodiscoverAuth:
     """Tests for POST /caldav/oidc/auth"""
+
+    @pytest.fixture(autouse=True)
+    def mock_oidc_introspection(self, monkeypatch):
+        """The route introspects the token to recover the OIDC login (`preferred_username`) used
+        for CalDAV Basic Auth, since it can differ from subscriber.email. Default the mock to the
+        test subscriber's email so unrelated tests don't have to care about the distinction."""
+        monkeypatch.setattr(
+            'appointment.routes.caldav.OIDCClient.introspect_token',
+            lambda self, token: {'preferred_username': os.getenv('TEST_USER_EMAIL')},
+        )
 
     def _mock_tb_accounts_success(self, app_password='test-app-password'):
         mock_response = MagicMock()
@@ -300,6 +312,54 @@ class TestOidcAutodiscoverAuth:
         assert call_args[0][0] == 'https://accounts.test.example/appointment/caldav/setup/'
         assert call_args[1]['json']['appointment-secret'] == 'my-secret'
         assert call_args[1]['json']['oidc-access-token'] == 'testtokenplsignore'
+
+    def test_oidc_auth_uses_preferred_username_for_caldav_login(self, with_client, monkeypatch):
+        """CalDAV Basic Auth must use the OIDC login (`preferred_username`), not subscriber.email:
+        the CalDAV server may only recognize the login identity, treating the standard OIDC
+        `email` claim as a non-authenticating alias."""
+        monkeypatch.setenv('TB_ACCOUNTS_HOST', 'https://accounts.test.example')
+        monkeypatch.setenv('APPOINTMENT_CALDAV_SECRET', 'test-secret')
+        monkeypatch.setenv('TB_ACCOUNTS_CALDAV_URL', 'https://caldav.test.example')
+
+        monkeypatch.setattr(Tools, 'dns_caldav_lookup', lambda *a, **kw: (None, None))
+        monkeypatch.setattr(Tools, 'well_known_caldav_lookup', lambda *a, **kw: None)
+
+        login_username = 'login-handle@example.org'
+        assert login_username != os.getenv('TEST_USER_EMAIL')
+        monkeypatch.setattr(
+            'appointment.routes.caldav.OIDCClient.introspect_token',
+            lambda self, token: {'preferred_username': login_username},
+        )
+
+        captured_users = []
+
+        def capturing_init(self, db, redis_instance, url, user, password, subscriber_id, calendar_id):
+            captured_users.append(user)
+
+        monkeypatch.setattr(CalDavConnector, '__init__', capturing_init)
+        monkeypatch.setattr(CalDavConnector, 'test_connection', lambda self: True)
+        monkeypatch.setattr(CalDavConnector, 'sync_calendars', lambda self, **kw: None)
+
+        with patch('appointment.routes.caldav.requests.post', return_value=self._mock_tb_accounts_success()):
+            response = with_client.post('/caldav/oidc/auth', headers=auth_headers)
+
+        assert response.status_code == 200, response.text
+        assert captured_users == [login_username]
+
+    def test_oidc_auth_introspection_failure(self, with_client, monkeypatch):
+        """Should raise RemoteCalendarConnectionError when the token can't be introspected."""
+        monkeypatch.setenv('TB_ACCOUNTS_HOST', 'https://accounts.test.example')
+        monkeypatch.setenv('APPOINTMENT_CALDAV_SECRET', 'test-secret')
+        monkeypatch.setenv('TB_ACCOUNTS_CALDAV_URL', 'https://caldav.test.example')
+
+        monkeypatch.setattr('appointment.routes.caldav.OIDCClient.introspect_token', lambda self, token: None)
+
+        with patch('appointment.routes.caldav.requests.post') as mock_post:
+            response = with_client.post('/caldav/oidc/auth', headers=auth_headers)
+            mock_post.assert_not_called()
+
+        assert response.status_code == 400, response.text
+        assert response.json()['detail']['id'] == 'REMOTE_CALENDAR_CONNECTION_ERROR'
 
     def test_oidc_auth_requires_authentication(self, with_client, monkeypatch):
         """Request without auth headers should be rejected."""


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

During the automatic Thundermail CalDAV connection, instead of using `Subscriber.email` for the auth, we are introspecting the OIDC token and using a fallback of `preferred_username` -> `username` -> `Subscriber.email`.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

We shouldn't rely on `Subscriber.email` to attempt to connect with the Thundermail CalDAV. The credentials should be derived / introspected from the OIDC token instead.


## How to test

This might be a bit troublesome to test but you'd need to run both `thunderbird-accounts` and `appointment` in your local dev environment and change the `.env` vars from `appointment` to point to `thunderbird-accounts` ports. Also don't forget to change the `AUTH_SCHEME` to `oidc`.

1. Navigate to `http://localhost:8090
2. Sign up with `admin@example.org / admin` (if this works, you have successfully setup both projects together)
3. In the FTUE, click on "Connect Thundermail Calendar" and click Continue
4. Check that there shouldn't be any errors

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Closes https://github.com/thunderbird/appointment/issues/1757
Related with https://github.com/thunderbird/appointment/pull/1689
