### PR TITLE
Custom log format for uvicorn

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,6 +14,7 @@ COPY requirements.txt .
 COPY pyproject.toml .
 COPY alembic.ini.example alembic.ini
 COPY scripts/entry.sh scripts/entry.sh
+COPY scripts/uvicorn_log_config.json scripts/uvicorn_log_config.json
 COPY scripts/cron /etc/cron.d/appointment-cron
 
 # Setup cron permissions

--- a/backend/scripts/entry.sh
+++ b/backend/scripts/entry.sh
@@ -26,10 +26,10 @@ elif [[ "$CONTAINER_ROLE" == "api" ]]; then
         service cron start
     fi
 
-    ARGS="--factory appointment.main:server --host 0.0.0.0 --port 5000"
+    ARGS="--factory appointment.main:server --host 0.0.0.0 --port 5000 --log-config scripts/uvicorn_log_config.json"
 
     if [[ "$IS_LOCAL_DEV" == "yes" ]]; then
-        ARGS="$ARGS --reload --log-level trace"
+        ARGS="$ARGS --reload --log-level info"
     fi
 
     echo "Running uvicorn with these arguments: '$ARGS'"

--- a/backend/scripts/uvicorn_log_config.json
+++ b/backend/scripts/uvicorn_log_config.json
@@ -1,0 +1,48 @@
+{
+  "version": 1,
+  "disable_existing_loggers": false,
+  "formatters": {
+    "default": {
+      "()": "uvicorn.logging.DefaultFormatter",
+      "fmt": "%(asctime)s %(levelprefix)s %(message)s",
+      "datefmt": "%Y-%m-%d %H:%M:%S",
+      "use_colors": true
+    },
+    "access": {
+      "()": "uvicorn.logging.AccessFormatter",
+      "fmt": "%(asctime)s %(levelprefix)s %(client_addr)s - \"%(request_line)s\" %(status_code)s",
+      "datefmt": "%Y-%m-%d %H:%M:%S"
+    }
+  },
+  "handlers": {
+    "default": {
+      "formatter": "default",
+      "class": "logging.StreamHandler",
+      "stream": "ext://sys.stderr"
+    },
+    "access": {
+      "formatter": "access",
+      "class": "logging.StreamHandler",
+      "stream": "ext://sys.stdout"
+    }
+  },
+  "loggers": {
+    "uvicorn": {
+      "handlers": [
+        "default"
+      ],
+      "level": "INFO",
+      "propagate": false
+    },
+    "uvicorn.error": {
+      "level": "INFO"
+    },
+    "uvicorn.access": {
+      "handlers": [
+        "access"
+      ],
+      "level": "INFO",
+      "propagate": false
+    }
+  }
+}

--- a/backend/scripts/uvicorn_log_config.json
+++ b/backend/scripts/uvicorn_log_config.json
@@ -1,6 +1,11 @@
 {
   "version": 1,
   "disable_existing_loggers": false,
+  "filters": {
+    "access_log_level": {
+      "()": "appointment.logs.AccessLogLevelFilter"
+    }
+  },
   "formatters": {
     "default": {
       "()": "uvicorn.logging.DefaultFormatter",
@@ -11,7 +16,8 @@
     "access": {
       "()": "uvicorn.logging.AccessFormatter",
       "fmt": "%(asctime)s %(levelprefix)s %(client_addr)s - \"%(request_line)s\" %(status_code)s",
-      "datefmt": "%Y-%m-%d %H:%M:%S"
+      "datefmt": "%Y-%m-%d %H:%M:%S",
+      "use_colors": true
     }
   },
   "handlers": {
@@ -22,6 +28,7 @@
     },
     "access": {
       "formatter": "access",
+      "filters": ["access_log_level"],
       "class": "logging.StreamHandler",
       "stream": "ext://sys.stdout"
     }

--- a/backend/src/appointment/logs.py
+++ b/backend/src/appointment/logs.py
@@ -1,0 +1,12 @@
+import logging
+
+
+class AccessLogLevelFilter(logging.Filter):
+    """Elevate uvicorn access log records for failed requests (status >= 400) to ERROR."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        status_code = record.args[-1] if record.args else None
+        if isinstance(status_code, int) and status_code >= 400:
+            record.levelno = logging.ERROR
+            record.levelname = logging.getLevelName(logging.ERROR)
+        return True

--- a/backend/src/appointment/main.py
+++ b/backend/src/appointment/main.py
@@ -35,6 +35,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.exception_handlers import (
     http_exception_handler,
 )
+from uvicorn.logging import DefaultFormatter
 
 from slowapi.errors import RateLimitExceeded
 
@@ -51,17 +52,14 @@ def _common_setup():
     level = os.getenv('LOG_LEVEL', 'ERROR')
     use_log_stream = os.getenv('LOG_USE_STREAM', False)
 
-    log_config = {
-        'format': '%(asctime)s %(levelname)-8s %(message)s',
-        'level': getattr(logging, level),
-        'datefmt': '%Y-%m-%d %H:%M:%S',
-    }
-    if use_log_stream:
-        log_config['stream'] = sys.stdout
-    else:
-        log_config['filename'] = 'appointment.log'
+    log_handler = logging.StreamHandler(sys.stdout) if use_log_stream else logging.FileHandler('appointment.log')
+    log_handler.setFormatter(DefaultFormatter(
+        fmt='%(asctime)s %(levelprefix)s %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S',
+        use_colors=True,
+    ))
 
-    logging.basicConfig(**log_config)
+    logging.basicConfig(level=getattr(logging, level), handlers=[log_handler])
 
     # Adjust caldav
     caldav_logger = logging.getLogger('caldav')


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

This PR introduces a `uvicorn_log_config.json` file to customize the log format the uvicorn server uses and updates the docker file and entry.sh accordingly. It's almost exactly what they suggest in the docs (I only removed the dashes):
https://uvicorn.dev/concepts/logging/#yaml-example

## Why?

Uvicorn uses its own loggers, independent from our application level logging we set up in main.py.

## How to test

0. Don't checkout this branch yet
1. Start the backend container and inspect the logs (see no timestamps, lots of traces, no colors)
2. Now checkout this branch
3. Rebuild the backend `docker compose up -d --build backend`
4. Now check the backend container logs again (see timestamps, no traces, colors)

## Limitations and Notes

Two things I did that are related but not necessary for this issue:

- I intentionally switched the uvicorn logging level from `trace` to `info`. We can discuss this, but I found absolutely no value in all those spammy trace messages. On the contrary, I searched for relevant logging entries between them on a regular basis. But if we need those for any reason, please let me know - we can totally keep it like it was. Check the logs I put in detail tags below to see the huge difference.
- I activated colors for the log. Another improvement to find things in the log. Again, this is up for discussion.

## Applicable Issues

Closes #455 

## Screenshots

**Before**, on startup:

<img width="933" height="231" alt="appointment_uvicorn_log_start_before" src="https://github.com/user-attachments/assets/b02eff0a-095a-4fa5-a0d6-57e3ca00ab27" />

<details><summary>Before: on page load of the dashboard</summary>
<pre>2026-07-23 23:03:37.246 | TRACE:    172.20.0.1:62066 - HTTP connection made
2026-07-23 23:03:37.246 | TRACE:    172.20.0.1:62066 - ASGI [2] Started scope={'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('172.20.0.6', 5000), 'client': ('172.20.0.1', 62066), 'scheme': 'http', 'root_path': '', 'headers': '<...>', 'state': {}, 'method': 'OPTIONS', 'path': '/session-info', 'raw_path': b'/session-info', 'query_string': b''}
2026-07-23 23:03:37.250 | TRACE:    172.20.0.1:62066 - ASGI [2] Send {'type': 'http.response.start', 'status': 200, 'headers': '<...>'}
2026-07-23 23:03:37.250 | INFO:     172.20.0.1:62066 - "OPTIONS /session-info HTTP/1.1" 200 OK
2026-07-23 23:03:37.250 | TRACE:    172.20.0.1:62066 - ASGI [2] Send {'type': 'http.response.body', 'body': '<2 bytes>', 'more_body': True}
2026-07-23 23:03:37.250 | TRACE:    172.20.0.1:62066 - ASGI [2] Send {'type': 'http.response.body', 'body': '<0 bytes>', 'more_body': False}
2026-07-23 23:03:37.251 | TRACE:    172.20.0.1:62066 - ASGI [2] Completed
2026-07-23 23:03:37.256 | TRACE:    172.20.0.1:62076 - HTTP connection made
2026-07-23 23:03:37.258 | TRACE:    172.20.0.1:62076 - ASGI [3] Started scope={'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('172.20.0.6', 5000), 'client': ('172.20.0.1', 62076), 'scheme': 'http', 'root_path': '', 'headers': '<...>', 'state': {}, 'method': 'GET', 'path': '/session-info', 'raw_path': b'/session-info', 'query_string': b''}
2026-07-23 23:03:37.261 | TRACE:    172.20.0.1:62076 - ASGI [3] Send {'type': 'http.response.start', 'status': 200, 'headers': '<...>'}
2026-07-23 23:03:37.261 | INFO:     172.20.0.1:62076 - "GET /session-info HTTP/1.1" 200 OK
2026-07-23 23:03:37.261 | TRACE:    172.20.0.1:62076 - ASGI [3] Send {'type': 'http.response.body', 'body': '<4 bytes>', 'more_body': True}
2026-07-23 23:03:37.261 | TRACE:    172.20.0.1:62076 - ASGI [3] Send {'type': 'http.response.body', 'body': '<0 bytes>', 'more_body': False}
2026-07-23 23:03:37.261 | TRACE:    172.20.0.1:62076 - ASGI [3] Completed
2026-07-23 23:03:37.294 | TRACE:    172.20.0.1:62066 - ASGI [4] Started scope={'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('172.20.0.6', 5000), 'client': ('172.20.0.1', 62066), 'scheme': 'http', 'root_path': '', 'headers': '<...>', 'state': {}, 'method': 'OPTIONS', 'path': '/me/appointments_count_by_status', 'raw_path': b'/me/appointments_count_by_status', 'query_string': b'status=requested'}
2026-07-23 23:03:37.295 | TRACE:    172.20.0.1:62082 - HTTP connection made
2026-07-23 23:03:37.295 | TRACE:    172.20.0.1:62084 - HTTP connection made
2026-07-23 23:03:37.295 | TRACE:    172.20.0.1:62082 - ASGI [5] Started scope={'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('172.20.0.6', 5000), 'client': ('172.20.0.1', 62082), 'scheme': 'http', 'root_path': '', 'headers': '<...>', 'state': {}, 'method': 'OPTIONS', 'path': '/me', 'raw_path': b'/me', 'query_string': b''}
2026-07-23 23:03:37.295 | TRACE:    172.20.0.1:62104 - HTTP connection made
2026-07-23 23:03:37.295 | TRACE:    172.20.0.1:62084 - ASGI [6] Started scope={'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('172.20.0.6', 5000), 'client': ('172.20.0.1', 62084), 'scheme': 'http', 'root_path': '', 'headers': '<...>', 'state': {}, 'method': 'OPTIONS', 'path': '/me/appointments', 'raw_path': b'/me/appointments', 'query_string': b'page=1&per_page=50'}
2026-07-23 23:03:37.296 | TRACE:    172.20.0.1:62114 - HTTP connection made
2026-07-23 23:03:37.296 | TRACE:    172.20.0.1:62104 - ASGI [7] Started scope={'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('172.20.0.6', 5000), 'client': ('172.20.0.1', 62104), 'scheme': 'http', 'root_path': '', 'headers': '<...>', 'state': {}, 'method': 'OPTIONS', 'path': '/schedule/', 'raw_path': b'/schedule/', 'query_string': b''}
2026-07-23 23:03:37.297 | TRACE:    172.20.0.1:62114 - ASGI [8] Started scope={'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('172.20.0.6', 5000), 'client': ('172.20.0.1', 62114), 'scheme': 'http', 'root_path': '', 'headers': '<...>', 'state': {}, 'method': 'OPTIONS', 'path': '/me/calendars', 'raw_path': b'/me/calendars', 'query_string': b'only_connected=false'}
2026-07-23 23:03:37.297 | TRACE:    172.20.0.1:62066 - ASGI [4] Send {'type': 'http.response.start', 'status': 200, 'headers': '<...>'}
2026-07-23 23:03:37.297 | INFO:     172.20.0.1:62066 - "OPTIONS /me/appointments_count_by_status?status=requested HTTP/1.1" 200 OK
2026-07-23 23:03:37.297 | TRACE:    172.20.0.1:62066 - ASGI [4] Send {'type': 'http.response.body', 'body': '<2 bytes>', 'more_body': True}
2026-07-23 23:03:37.297 | TRACE:    172.20.0.1:62082 - ASGI [5] Send {'type': 'http.response.start', 'status': 200, 'headers': '<...>'}
2026-07-23 23:03:37.297 | INFO:     172.20.0.1:62082 - "OPTIONS /me HTTP/1.1" 200 OK
2026-07-23 23:03:37.297 | TRACE:    172.20.0.1:62066 - ASGI [4] Send {'type': 'http.response.body', 'body': '<0 bytes>', 'more_body': False}
2026-07-23 23:03:37.298 | TRACE:    172.20.0.1:62084 - ASGI [6] Send {'type': 'http.response.start', 'status': 200, 'headers': '<...>'}
2026-07-23 23:03:37.298 | INFO:     172.20.0.1:62084 - "OPTIONS /me/appointments?page=1&per_page=50 HTTP/1.1" 200 OK
2026-07-23 23:03:37.298 | TRACE:    172.20.0.1:62082 - ASGI [5] Send {'type': 'http.response.body', 'body': '<2 bytes>', 'more_body': True}
2026-07-23 23:03:37.298 | TRACE:    172.20.0.1:62104 - ASGI [7] Send {'type': 'http.response.start', 'status': 200, 'headers': '<...>'}
2026-07-23 23:03:37.298 | INFO:     172.20.0.1:62104 - "OPTIONS /schedule/ HTTP/1.1" 200 OK
2026-07-23 23:03:37.298 | TRACE:    172.20.0.1:62082 - ASGI [5] Send {'type': 'http.response.body', 'body': '<0 bytes>', 'more_body': False}
2026-07-23 23:03:37.298 | TRACE:    172.20.0.1:62084 - ASGI [6] Send {'type': 'http.response.body', 'body': '<2 bytes>', 'more_body': True}
2026-07-23 23:03:37.298 | TRACE:    172.20.0.1:62114 - ASGI [8] Send {'type': 'http.response.start', 'status': 200, 'headers': '<...>'}
2026-07-23 23:03:37.298 | INFO:     172.20.0.1:62114 - "OPTIONS /me/calendars?only_connected=false HTTP/1.1" 200 OK
2026-07-23 23:03:37.299 | TRACE:    172.20.0.1:62084 - ASGI [6] Send {'type': 'http.response.body', 'body': '<0 bytes>', 'more_body': False}
2026-07-23 23:03:37.299 | TRACE:    172.20.0.1:62104 - ASGI [7] Send {'type': 'http.response.body', 'body': '<2 bytes>', 'more_body': True}
2026-07-23 23:03:37.299 | TRACE:    172.20.0.1:62066 - ASGI [4] Completed
2026-07-23 23:03:37.299 | TRACE:    172.20.0.1:62104 - ASGI [7] Send {'type': 'http.response.body', 'body': '<0 bytes>', 'more_body': False}
2026-07-23 23:03:37.299 | TRACE:    172.20.0.1:62114 - ASGI [8] Send {'type': 'http.response.body', 'body': '<2 bytes>', 'more_body': True}
2026-07-23 23:03:37.299 | TRACE:    172.20.0.1:62114 - ASGI [8] Send {'type': 'http.response.body', 'body': '<0 bytes>', 'more_body': False}
2026-07-23 23:03:37.299 | TRACE:    172.20.0.1:62082 - ASGI [5] Completed
2026-07-23 23:03:37.299 | TRACE:    172.20.0.1:62084 - ASGI [6] Completed
2026-07-23 23:03:37.299 | TRACE:    172.20.0.1:62104 - ASGI [7] Completed
2026-07-23 23:03:37.299 | TRACE:    172.20.0.1:62114 - ASGI [8] Completed
2026-07-23 23:03:37.311 | TRACE:    172.20.0.1:62076 - ASGI [9] Started scope={'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('172.20.0.6', 5000), 'client': ('172.20.0.1', 62076), 'scheme': 'http', 'root_path': '', 'headers': '<...>', 'state': {}, 'method': 'GET', 'path': '/me/appointments_count_by_status', 'raw_path': b'/me/appointments_count_by_status', 'query_string': b'status=requested'}
2026-07-23 23:03:37.311 | TRACE:    172.20.0.1:62126 - HTTP connection made
2026-07-23 23:03:37.311 | TRACE:    172.20.0.1:62132 - HTTP connection made
2026-07-23 23:03:37.312 | TRACE:    172.20.0.1:62126 - ASGI [10] Started scope={'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('172.20.0.6', 5000), 'client': ('172.20.0.1', 62126), 'scheme': 'http', 'root_path': '', 'headers': '<...>', 'state': {}, 'method': 'GET', 'path': '/me', 'raw_path': b'/me', 'query_string': b''}
2026-07-23 23:03:37.313 | TRACE:    172.20.0.1:62140 - HTTP connection made
2026-07-23 23:03:37.313 | TRACE:    172.20.0.1:62132 - ASGI [11] Started scope={'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('172.20.0.6', 5000), 'client': ('172.20.0.1', 62132), 'scheme': 'http', 'root_path': '', 'headers': '<...>', 'state': {}, 'method': 'GET', 'path': '/schedule/', 'raw_path': b'/schedule/', 'query_string': b''}
2026-07-23 23:03:37.313 | TRACE:    172.20.0.1:62146 - HTTP connection made
2026-07-23 23:03:37.313 | TRACE:    172.20.0.1:62140 - ASGI [12] Started scope={'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('172.20.0.6', 5000), 'client': ('172.20.0.1', 62140), 'scheme': 'http', 'root_path': '', 'headers': '<...>', 'state': {}, 'method': 'GET', 'path': '/me/appointments', 'raw_path': b'/me/appointments', 'query_string': b'page=1&per_page=50'}
2026-07-23 23:03:37.316 | TRACE:    172.20.0.1:62146 - ASGI [13] Started scope={'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('172.20.0.6', 5000), 'client': ('172.20.0.1', 62146), 'scheme': 'http', 'root_path': '', 'headers': '<...>', 'state': {}, 'method': 'GET', 'path': '/me/calendars', 'raw_path': b'/me/calendars', 'query_string': b'only_connected=false'}
2026-07-23 23:03:37.388 | /usr/local/lib/python3.12/site-packages/jwt/api_jwt.py:368: InsecureKeyLengthWarning: The HMAC key is 24 bytes long, which is below the minimum recommended length of 32 bytes for SHA256. See RFC 7518 Section 3.2.
2026-07-23 23:03:37.388 |   decoded = self.decode_complete(
2026-07-23 23:03:37.503 | TRACE:    172.20.0.1:62146 - ASGI [13] Send {'type': 'http.response.start', 'status': 200, 'headers': '<...>'}
2026-07-23 23:03:37.504 | INFO:     172.20.0.1:62146 - "GET /me/calendars?only_connected=false HTTP/1.1" 200 OK
2026-07-23 23:03:37.505 | TRACE:    172.20.0.1:62132 - ASGI [11] Send {'type': 'http.response.start', 'status': 200, 'headers': '<...>'}
2026-07-23 23:03:37.505 | INFO:     172.20.0.1:62132 - "GET /schedule/ HTTP/1.1" 200 OK
2026-07-23 23:03:37.505 | TRACE:    172.20.0.1:62126 - ASGI [10] Send {'type': 'http.response.start', 'status': 200, 'headers': '<...>'}
2026-07-23 23:03:37.505 | INFO:     172.20.0.1:62126 - "GET /me HTTP/1.1" 200 OK
2026-07-23 23:03:37.505 | TRACE:    172.20.0.1:62146 - ASGI [13] Send {'type': 'http.response.body', 'body': '<871 bytes>', 'more_body': True}
2026-07-23 23:03:37.505 | TRACE:    172.20.0.1:62132 - ASGI [11] Send {'type': 'http.response.body', 'body': '<1759 bytes>', 'more_body': True}
2026-07-23 23:03:37.505 | TRACE:    172.20.0.1:62126 - ASGI [10] Send {'type': 'http.response.body', 'body': '<447 bytes>', 'more_body': True}
2026-07-23 23:03:37.506 | TRACE:    172.20.0.1:62146 - ASGI [13] Send {'type': 'http.response.body', 'body': '<0 bytes>', 'more_body': False}
2026-07-23 23:03:37.506 | TRACE:    172.20.0.1:62132 - ASGI [11] Send {'type': 'http.response.body', 'body': '<0 bytes>', 'more_body': False}
2026-07-23 23:03:37.506 | TRACE:    172.20.0.1:62126 - ASGI [10] Send {'type': 'http.response.body', 'body': '<0 bytes>', 'more_body': False}
2026-07-23 23:03:37.513 | TRACE:    172.20.0.1:62126 - ASGI [10] Completed
2026-07-23 23:03:37.513 | TRACE:    172.20.0.1:62146 - ASGI [13] Completed
2026-07-23 23:03:37.513 | TRACE:    172.20.0.1:62132 - ASGI [11] Completed
2026-07-23 23:03:37.520 | TRACE:    172.20.0.1:62076 - ASGI [9] Send {'type': 'http.response.start', 'status': 200, 'headers': '<...>'}
2026-07-23 23:03:37.520 | INFO:     172.20.0.1:62076 - "GET /me/appointments_count_by_status?status=requested HTTP/1.1" 200 OK
2026-07-23 23:03:37.521 | TRACE:    172.20.0.1:62076 - ASGI [9] Send {'type': 'http.response.body', 'body': '<11 bytes>', 'more_body': True}
2026-07-23 23:03:37.521 | TRACE:    172.20.0.1:62076 - ASGI [9] Send {'type': 'http.response.body', 'body': '<0 bytes>', 'more_body': False}
2026-07-23 23:03:37.524 | TRACE:    172.20.0.1:62140 - ASGI [12] Send {'type': 'http.response.start', 'status': 200, 'headers': '<...>'}
2026-07-23 23:03:37.524 | INFO:     172.20.0.1:62140 - "GET /me/appointments?page=1&per_page=50 HTTP/1.1" 200 OK
2026-07-23 23:03:37.524 | TRACE:    172.20.0.1:62140 - ASGI [12] Send {'type': 'http.response.body', 'body': '<1982 bytes>', 'more_body': True}
2026-07-23 23:03:37.525 | TRACE:    172.20.0.1:62140 - ASGI [12] Send {'type': 'http.response.body', 'body': '<0 bytes>', 'more_body': False}
2026-07-23 23:03:37.525 | TRACE:    172.20.0.1:62076 - ASGI [9] Completed
2026-07-23 23:03:37.526 | TRACE:    172.20.0.1:62140 - ASGI [12] Completed
2026-07-23 23:03:37.552 | TRACE:    172.20.0.1:62140 - ASGI [14] Started scope={'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('172.20.0.6', 5000), 'client': ('172.20.0.1', 62140), 'scheme': 'http', 'root_path': '', 'headers': '<...>', 'state': {}, 'method': 'GET', 'path': '/me/signature', 'raw_path': b'/me/signature', 'query_string': b''}
2026-07-23 23:03:37.573 | TRACE:    172.20.0.1:62140 - ASGI [14] Send {'type': 'http.response.start', 'status': 200, 'headers': '<...>'}
2026-07-23 23:03:37.573 | INFO:     172.20.0.1:62140 - "GET /me/signature HTTP/1.1" 200 OK
2026-07-23 23:03:37.573 | TRACE:    172.20.0.1:62140 - ASGI [14] Send {'type': 'http.response.body', 'body': '<117 bytes>', 'more_body': True}
2026-07-23 23:03:37.573 | TRACE:    172.20.0.1:62140 - ASGI [14] Send {'type': 'http.response.body', 'body': '<0 bytes>', 'more_body': False}
2026-07-23 23:03:37.574 | TRACE:    172.20.0.1:62140 - ASGI [14] Completed
2026-07-23 23:03:37.585 | TRACE:    172.20.0.1:62132 - ASGI [15] Started scope={'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('172.20.0.6', 5000), 'client': ('172.20.0.1', 62132), 'scheme': 'http', 'root_path': '', 'headers': '<...>', 'state': {}, 'method': 'GET', 'path': '/rmt/cal/1/2026-07-01/2026-08-01', 'raw_path': b'/rmt/cal/1/2026-07-01/2026-08-01', 'query_string': b'force_refresh=true'}
2026-07-23 23:03:37.586 | TRACE:    172.20.0.1:62140 - ASGI [16] Started scope={'type': 'http', 'asgi': {'version': '3.0', 'spec_version': '2.3'}, 'http_version': '1.1', 'server': ('172.20.0.6', 5000), 'client': ('172.20.0.1', 62140), 'scheme': 'http', 'root_path': '', 'headers': '<...>', 'state': {}, 'method': 'GET', 'path': '/rmt/cal/4/2026-07-01/2026-08-01', 'raw_path': b'/rmt/cal/4/2026-07-01/2026-08-01', 'query_string': b'force_refresh=true'}
2026-07-23 23:03:37.640 | TRACE:    172.20.0.1:62132 - ASGI [15] Send {'type': 'http.response.start', 'status': 200, 'headers': '<...>'}
2026-07-23 23:03:37.640 | INFO:     172.20.0.1:62132 - "GET /rmt/cal/1/2026-07-01/2026-08-01?force_refresh=true HTTP/1.1" 200 OK
2026-07-23 23:03:37.640 | TRACE:    172.20.0.1:62132 - ASGI [15] Send {'type': 'http.response.body', 'body': '<1983 bytes>', 'more_body': True}
2026-07-23 23:03:37.640 | TRACE:    172.20.0.1:62132 - ASGI [15] Send {'type': 'http.response.body', 'body': '<0 bytes>', 'more_body': False}
2026-07-23 23:03:37.641 | TRACE:    172.20.0.1:62140 - ASGI [16] Send {'type': 'http.response.start', 'status': 200, 'headers': '<...>'}
2026-07-23 23:03:37.641 | INFO:     172.20.0.1:62140 - "GET /rmt/cal/4/2026-07-01/2026-08-01?force_refresh=true HTTP/1.1" 200 OK
2026-07-23 23:03:37.642 | TRACE:    172.20.0.1:62140 - ASGI [16] Send {'type': 'http.response.body', 'body': '<6149 bytes>', 'more_body': True}
2026-07-23 23:03:37.642 | TRACE:    172.20.0.1:62140 - ASGI [16] Send {'type': 'http.response.body', 'body': '<0 bytes>', 'more_body': False}
2026-07-23 23:03:37.642 | TRACE:    172.20.0.1:62132 - ASGI [15] Completed
2026-07-23 23:03:37.643 | TRACE:    172.20.0.1:62140 - ASGI [16] Completed
2026-07-23 23:03:42.299 | TRACE:    172.20.0.1:62066 - HTTP connection lost
2026-07-23 23:03:42.299 | TRACE:    172.20.0.1:62082 - HTTP connection lost
2026-07-23 23:03:42.299 | TRACE:    172.20.0.1:62084 - HTTP connection lost
2026-07-23 23:03:42.299 | TRACE:    172.20.0.1:62104 - HTTP connection lost
2026-07-23 23:03:42.299 | TRACE:    172.20.0.1:62114 - HTTP connection lost
2026-07-23 23:03:42.506 | TRACE:    172.20.0.1:62146 - HTTP connection lost
2026-07-23 23:03:42.506 | TRACE:    172.20.0.1:62126 - HTTP connection lost
2026-07-23 23:03:42.521 | TRACE:    172.20.0.1:62076 - HTTP connection lost
2026-07-23 23:03:42.640 | TRACE:    172.20.0.1:62132 - HTTP connection lost
2026-07-23 23:03:42.642 | TRACE:    172.20.0.1:62140 - HTTP connection lost</pre>
</details> 

**After**, on startup:

<img width="1005" height="205" alt="image" src="https://github.com/user-attachments/assets/65b990e8-029f-4426-9331-3e24b66f16c0" />

<details><summary>After: the same (!) page load of the dashboard</summary>
<pre>INFO:     172.20.0.1:57738 - "GET /me/calendars?only_connected=false HTTP/1.1" 200 OK
INFO:     172.20.0.1:57734 - "GET /me/appointments_count_by_status?status=requested HTTP/1.1" 200 OK
INFO:     172.20.0.1:57736 - "GET /me HTTP/1.1" 200 OK
INFO:     172.20.0.1:57740 - "GET /schedule/ HTTP/1.1" 200 OK
INFO:     172.20.0.1:57718 - "GET /me/appointments?page=1&per_page=50 HTTP/1.1" 200 OK
INFO:     172.20.0.1:57718 - "GET /me/signature HTTP/1.1" 200 OK
INFO:     172.20.0.1:57718 - "GET /rmt/cal/4/2026-07-01/2026-08-01?force_refresh=true HTTP/1.1" 200 OK
INFO:     172.20.0.1:57740 - "GET /rmt/cal/1/2026-07-01/2026-08-01?force_refresh=true HTTP/1.1" 200 OK

2026-07-23 20:33:22 INFO:     172.20.0.1:62912 - "GET /me/calendars?only_connected=false HTTP/1.1" 200 OK
2026-07-23 20:33:22 INFO:     172.20.0.1:62860 - "OPTIONS /me/signature HTTP/1.1" 200 OK
2026-07-23 20:33:22 INFO:     172.20.0.1:62872 - "GET /me/appointments?page=1&per_page=50 HTTP/1.1" 200 OK
2026-07-23 20:33:22 INFO:     172.20.0.1:62922 - "GET /schedule/ HTTP/1.1" 200 OK
2026-07-23 20:33:22 INFO:     172.20.0.1:62912 - "GET /me/signature HTTP/1.1" 200 OK
2026-07-23 20:33:22 INFO:     172.20.0.1:62874 - "OPTIONS /rmt/cal/1/2026-07-01/2026-08-01?force_refresh=true HTTP/1.1" 200 OK
2026-07-23 20:33:22 INFO:     172.20.0.1:62882 - "OPTIONS /rmt/cal/4/2026-07-01/2026-08-01?force_refresh=true HTTP/1.1" 200 OK
2026-07-23 20:33:22 INFO:     172.20.0.1:62922 - "GET /rmt/cal/4/2026-07-01/2026-08-01?force_refresh=true HTTP/1.1" 200 OK
2026-07-23 20:33:22 INFO:     172.20.0.1:62872 - "GET /rmt/cal/1/2026-07-01/2026-08-01?force_refresh=true HTTP/1.1" 200 OK</pre>
</details> 
