### PR TITLE
ci(backend): block non-additive Alembic migrations pre-merge

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -88,11 +88,14 @@ jobs:
           cd ./backend && ruff format
 
   migration-additivity:
-    # Appointment deploys blue-green: for a window the OLD and NEW replicas run
-    # against the SAME database, and a schema change cannot be undone by aborting
-    # the deploy. So a migration must only ADD ("expand"); removals ship a release
-    # later ("contract"). Checked pre-merge -- the last point at which the migration
-    # has not yet run anywhere.
+    # For a window during every deploy the OLD and NEW replicas run against the SAME
+    # database, and a schema change cannot be undone by aborting the deploy. So a
+    # migration must only ADD ("expand"); removals ship a release later ("contract").
+    # That window is short and incidental on the current ECS rolling deploy; it is
+    # long and deliberate on the Argo Rollouts blue-green deploy being stood up on
+    # EKS tb-dev / tb-prod (thunderbird/platform-infrastructure#781), which this
+    # check is groundwork for. Checked pre-merge -- the last point at which the
+    # migration has not yet run anywhere.
     #
     # Its own job on purpose: the check is stdlib-only and takes ~100ms, so it should
     # not sit behind pip install + the full pytest suite. A migration author should
@@ -109,9 +112,13 @@ jobs:
 
       - name: Check new migrations are additive
         working-directory: ./backend
+        # Interpolate the branch name through env rather than into the script body,
+        # so a ref name can never be spliced into the shell command.
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
-          BASE="origin/${{ github.event.repository.default_branch }}"
+          BASE="origin/${DEFAULT_BRANCH}"
           # AMR + --no-renames: a migration can be made destructive by EDITING or
           # RENAMING one, not only by adding one.
           CHANGED=$(git diff --name-only --diff-filter=AMR --no-renames --relative \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -54,10 +54,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          # Full history so the migration-additivity check can diff against main
-          # to find the migrations this branch ADDS.
-          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -91,25 +87,42 @@ jobs:
         run: |
           cd ./backend && ruff format
 
-      # Appointment deploys blue-green: for a window, the OLD and NEW replicas run
-      # against the SAME database, and a schema change cannot be undone by aborting
-      # the deploy. So a migration must only ADD ("expand"); removals ship a release
-      # later ("contract"). Checked here, pre-merge, because that is the last point
-      # at which the migration has not yet run anywhere.
-      # Scoped to migrations this branch ADDS -- historical ones predate the gate.
-      - name: Migration additivity check (expand/contract)
+  migration-additivity:
+    # Appointment deploys blue-green: for a window the OLD and NEW replicas run
+    # against the SAME database, and a schema change cannot be undone by aborting
+    # the deploy. So a migration must only ADD ("expand"); removals ship a release
+    # later ("contract"). Checked pre-merge -- the last point at which the migration
+    # has not yet run anywhere.
+    #
+    # Its own job on purpose: the check is stdlib-only and takes ~100ms, so it should
+    # not sit behind pip install + the full pytest suite. A migration author should
+    # not have to fix unrelated test failures to learn their schema change is unsafe.
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    if: needs.detect-changes.outputs.validate-backend == 'true'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Needed to diff against the default branch.
+          fetch-depth: 0
+
+      - name: Check new migrations are additive
         working-directory: ./backend
         run: |
-          git fetch --no-tags origin main
-          ADDED=$(git diff --name-only --diff-filter=A --relative \
-                    origin/main...HEAD -- src/appointment/migrations/versions/)
-          if [ -z "$ADDED" ]; then
-            echo "No new migrations in this branch - nothing to check."
+          set -euo pipefail
+          BASE="origin/${{ github.event.repository.default_branch }}"
+          # AMR + --no-renames: a migration can be made destructive by EDITING or
+          # RENAMING one, not only by adding one.
+          CHANGED=$(git diff --name-only --diff-filter=AMR --no-renames --relative \
+                      "$BASE"...HEAD -- src/appointment/migrations/versions/)
+          if [ -z "$CHANGED" ]; then
+            echo "No added/changed migrations in this branch - nothing to check."
             exit 0
           fi
-          echo "New migrations:"; echo "$ADDED" | sed 's/^/  /'
+          echo "Migrations to check:"; echo "$CHANGED" | sed 's/^/  /'
           # shellcheck disable=SC2086
-          python scripts/check_migration_additivity.py $ADDED
+          python3 scripts/check_migration_additivity.py $CHANGED
 
   validate-frontend:
     needs: detect-changes

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -54,6 +54,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so the migration-additivity check can diff against main
+          # to find the migrations this branch ADDS.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -86,6 +90,26 @@ jobs:
       - name: Backend formatting check
         run: |
           cd ./backend && ruff format
+
+      # Appointment deploys blue-green: for a window, the OLD and NEW replicas run
+      # against the SAME database, and a schema change cannot be undone by aborting
+      # the deploy. So a migration must only ADD ("expand"); removals ship a release
+      # later ("contract"). Checked here, pre-merge, because that is the last point
+      # at which the migration has not yet run anywhere.
+      # Scoped to migrations this branch ADDS -- historical ones predate the gate.
+      - name: Migration additivity check (expand/contract)
+        working-directory: ./backend
+        run: |
+          git fetch --no-tags origin main
+          ADDED=$(git diff --name-only --diff-filter=A --relative \
+                    origin/main...HEAD -- src/appointment/migrations/versions/)
+          if [ -z "$ADDED" ]; then
+            echo "No new migrations in this branch - nothing to check."
+            exit 0
+          fi
+          echo "New migrations:"; echo "$ADDED" | sed 's/^/  /'
+          # shellcheck disable=SC2086
+          python scripts/check_migration_additivity.py $ADDED
 
   validate-frontend:
     needs: detect-changes

--- a/backend/scripts/check_migration_additivity.py
+++ b/backend/scripts/check_migration_additivity.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Fail CI when a new Alembic migration is not additive (expand/contract safe).
+
+WHY
+---
+Appointment is deployed with a blue-green rollout: for a window during every
+deploy, the OLD and NEW replicas run against the SAME database. A migration that
+removes or narrows something the old replicas still use breaks them the moment it
+lands -- and a schema change cannot be rolled back by aborting the deploy. So a
+migration must only ever ADD things ("expand"); removals ("contract") ship in a
+LATER release, once no running replica references them.
+
+This check runs in CI on the migrations a PR ADDS, so the author finds out while
+it is still cheap to fix, and before the migration can ever execute anywhere.
+
+WHAT IS FLAGGED (in `upgrade()` only -- `downgrade()` is never run by the deploy)
+---------------------------------------------------------------------------
+  * op.drop_column / drop_table / drop_constraint / drop_index
+  * op.rename_table, and op.alter_column(new_column_name=...)   (renames)
+  * op.alter_column(nullable=False)                             (narrowing)
+  * op.add_column(... nullable=False) with NO server_default    (old replicas'
+    INSERTs omit the column, so they start failing)
+  * op.create_index(unique=True) / op.create_unique_constraint  (fails outright
+    if existing rows collide, leaving a half-applied release)
+  * op.batch_alter_table(...)                                   (recreates the
+    table; never additive under blue-green)
+  * op.execute("...") containing destructive SQL
+
+WHAT IS NOT FLAGGED (deliberately -- these are additive)
+--------------------------------------------------------
+  * anything inside `downgrade()`
+  * `nullable=False` on a column of a brand-new `op.create_table(...)` -- old
+    replicas do not know the table exists
+  * `existing_nullable=False` -- a descriptor of current state, not a change
+  * `op.add_column(... nullable=False, server_default=...)` -- the default
+    backfills for old replicas
+
+ESCAPE HATCH
+------------
+A genuinely-needed contract migration ships by declaring it in the migration
+itself, so the reviewer of the schema change sees the justification in the diff:
+
+    # additivity-exempt: https://github.com/thunderbird/appointment/issues/1234
+    #   invites table removal; no replica has referenced it since v1.9.
+
+The marker must carry a URL. Prefer splitting into expand/contract over exempting.
+
+USAGE
+-----
+    check_migration_additivity.py <file.py> [<file.py> ...]
+    check_migration_additivity.py --all      # scan every migration (audit)
+
+Exit 0 = additive (or exempt), 1 = non-additive found, 2 = usage/parse error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import pathlib
+import re
+import sys
+
+VERSIONS_DIR = pathlib.Path(__file__).resolve().parents[1] / 'src/appointment/migrations/versions'
+
+# op.<name>(...) calls that remove or rename something an old replica may use.
+DESTRUCTIVE_OPS = {
+    'drop_column': 'drops a column the old replicas may still SELECT',
+    'drop_table': 'drops a table the old replicas may still query',
+    'drop_constraint': 'drops a constraint the old replicas rely on',
+    'drop_index': 'drops an index; old replicas lose the query plan mid-rollout',
+    'rename_table': 'renames a table; old replicas still use the old name',
+}
+
+# Raw SQL that is destructive regardless of how it is spelled.
+DESTRUCTIVE_SQL = re.compile(
+    r'\b(?:'
+    r'DROP\s+(?:COLUMN|TABLE|CONSTRAINT|INDEX)'
+    r'|ALTER\s+TABLE\b[\s\S]*?\b(?:DROP|MODIFY|CHANGE)\b'
+    r'|RENAME\s+(?:TO|COLUMN)'
+    r'|TRUNCATE\b'
+    r'|DELETE\s+FROM\b'
+    r'|NOT\s+NULL'
+    r')',
+    re.IGNORECASE,
+)
+
+EXEMPT_RE = re.compile(r'#\s*additivity-exempt:\s*(\S+)(.*)', re.IGNORECASE)
+
+
+class Finding:
+    def __init__(self, line: int, rule: str, detail: str, fix: str):
+        self.line, self.rule, self.detail, self.fix = line, rule, detail, fix
+
+
+def _kwarg(call: ast.Call, name: str) -> ast.expr | None:
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+    return None
+
+
+def _is_true(node: ast.expr | None) -> bool:
+    return isinstance(node, ast.Constant) and node.value is True
+
+
+def _is_false(node: ast.expr | None) -> bool:
+    return isinstance(node, ast.Constant) and node.value is False
+
+
+def _op_name(call: ast.Call) -> str | None:
+    """Return the method name for `op.<name>(...)` / `batch_op.<name>(...)`."""
+    func = call.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _receiver(call: ast.Call) -> str | None:
+    func = call.func
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+        return func.value.id
+    return None
+
+
+def _columns_in(call: ast.Call) -> list[ast.Call]:
+    """sa.Column(...) calls appearing anywhere inside this call's arguments."""
+    out = []
+    for node in ast.walk(call):
+        if isinstance(node, ast.Call) and _op_name(node) == 'Column':
+            out.append(node)
+    return out
+
+
+def check_upgrade(tree: ast.Module) -> list[Finding]:
+    upgrade = next(
+        (n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name.startswith('upgrade')),
+        None,
+    )
+    if upgrade is None:
+        return []
+
+    findings: list[Finding] = []
+
+    # NOTE: `op.create_table(...)` is never inspected below -- a brand-new table's
+    # NOT NULL columns are additive (no running replica knows the table exists), so
+    # create_table is exempt by construction rather than by an explicit filter.
+    for node in ast.walk(upgrade):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _op_name(node)
+        if name is None:
+            continue
+
+        if name in DESTRUCTIVE_OPS:
+            findings.append(
+                Finding(node.lineno, f'op.{name}', DESTRUCTIVE_OPS[name],
+                        'Remove it here; ship the removal in a LATER release (contract phase).')
+            )
+            continue
+
+        if name == 'batch_alter_table':
+            findings.append(
+                Finding(node.lineno, 'op.batch_alter_table',
+                        'batch mode recreates the table, which is never additive',
+                        'Use direct op.* calls for the additive parts.')
+            )
+            continue
+
+        if name == 'alter_column':
+            if _kwarg(node, 'new_column_name') is not None:
+                findings.append(
+                    Finding(node.lineno, 'op.alter_column(new_column_name=...)',
+                            'renames a column; old replicas still SELECT the old name',
+                            'Add the new column, dual-write, backfill, drop the old one in a later release.')
+                )
+            if _is_false(_kwarg(node, 'nullable')):
+                findings.append(
+                    Finding(node.lineno, 'op.alter_column(nullable=False)',
+                            "narrows a column; old replicas' NULL-omitting INSERTs start failing",
+                            'Backfill first, then enforce NOT NULL in a later release.')
+                )
+            continue
+
+        if name == 'add_column':
+            for col in _columns_in(node):
+                if _is_false(_kwarg(col, 'nullable')) and _kwarg(col, 'server_default') is None:
+                    findings.append(
+                        Finding(col.lineno, 'op.add_column(nullable=False) without server_default',
+                                "old replicas' INSERTs omit the column, so they fail",
+                                "Add server_default=... (note: SQLAlchemy's default= is client-side "
+                                'and emits no DDL default, so it does not help here).')
+                    )
+            continue
+
+        if name == 'create_index' and _is_true(_kwarg(node, 'unique')):
+            findings.append(
+                Finding(node.lineno, 'op.create_index(unique=True)',
+                        'fails outright if existing rows collide, leaving a half-applied release',
+                        'De-duplicate in a prior release, then add the unique index.')
+            )
+            continue
+
+        if name == 'create_unique_constraint':
+            findings.append(
+                Finding(node.lineno, 'op.create_unique_constraint',
+                        'fails outright if existing rows collide',
+                        'De-duplicate in a prior release, then add the constraint.')
+            )
+            continue
+
+        if name == 'execute' and _receiver(node) == 'op':
+            for arg in ast.walk(node):
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                    m = DESTRUCTIVE_SQL.search(arg.value)
+                    if m:
+                        findings.append(
+                            Finding(node.lineno, 'op.execute(<destructive SQL>)',
+                                    f'raw SQL contains {m.group(0).strip()!r}',
+                                    'Express the additive part in SQL; defer the destructive part a release.')
+                        )
+                        break
+
+    return findings
+
+
+def check_file(path: pathlib.Path) -> tuple[list[Finding], str | None]:
+    """Return (findings, exemption_reason)."""
+    src = path.read_text(encoding='utf-8')
+    m = EXEMPT_RE.search(src)
+    if m:
+        url, rest = m.group(1), m.group(2).strip()
+        if not url.startswith(('http://', 'https://')):
+            return (
+                [Finding(0, 'additivity-exempt without a URL',
+                         f'marker points at {url!r}',
+                         'Use: # additivity-exempt: <issue-url> <reason>')],
+                None,
+            )
+        return [], f'{url} {rest}'.strip()
+
+    try:
+        tree = ast.parse(src, filename=str(path))
+    except SyntaxError as exc:  # pragma: no cover
+        return [Finding(exc.lineno or 0, 'syntax error', str(exc), 'Fix the migration file.')], None
+    return check_upgrade(tree), None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('files', nargs='*', help='migration files to check')
+    ap.add_argument('--all', action='store_true', help='check every migration (audit mode)')
+    args = ap.parse_args()
+
+    if args.all:
+        paths = sorted(VERSIONS_DIR.glob('*.py'))
+    else:
+        paths = [pathlib.Path(f) for f in args.files]
+        paths = [p for p in paths if p.suffix == '.py' and p.name != '__init__.py' and p.exists()]
+
+    if not paths:
+        print('migration-additivity: no migration files to check.')
+        return 0
+
+    failed = False
+    for path in paths:
+        findings, exempt = check_file(path)
+        if exempt:
+            print(f'\N{WARNING SIGN}  {path.name}: EXEMPT -- {exempt}')
+            continue
+        if not findings:
+            print(f'\N{CHECK MARK}  {path.name}: additive')
+            continue
+        failed = True
+        print(f'\N{CROSS MARK}  {path.name}: NOT additive')
+        for f in findings:
+            print(f'      line {f.line}: {f.rule}')
+            print(f'        why: {f.detail}')
+            print(f'        fix: {f.fix}')
+
+    if failed:
+        print(
+            '\nA blue-green deploy runs the OLD and NEW replicas against the same database,\n'
+            'and a schema change cannot be undone by aborting the deploy. Split the change:\n'
+            '  release N   : add the new thing (and backfill / dual-write)\n'
+            '  release N+1 : remove the old thing, once nothing references it\n\n'
+            'If the removal is genuinely safe now, declare it in the migration:\n'
+            '  # additivity-exempt: <issue-url> <why it is safe>\n'
+        )
+    return 1 if failed else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/backend/scripts/check_migration_additivity.py
+++ b/backend/scripts/check_migration_additivity.py
@@ -119,6 +119,7 @@ class Finding:
 
 # --- small AST helpers -------------------------------------------------------------
 
+
 def _attr_name(call: ast.Call) -> str | None:
     """`x.foo(...)` -> 'foo'."""
     return call.func.attr if isinstance(call.func, ast.Attribute) else None
@@ -194,11 +195,10 @@ def _literal_sql(call: ast.Call) -> tuple[str, bool]:
 
 # --- scan scope: upgrade() plus the helpers it calls --------------------------------
 
+
 def _scanned_functions(tree: ast.Module) -> tuple[list[ast.AST], list[str]]:
     """Return (functions to scan, names of upgrade entrypoints found)."""
-    funcs: dict[str, ast.AST] = {
-        n.name: n for n in tree.body if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
-    }
+    funcs: dict[str, ast.AST] = {n.name: n for n in tree.body if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}
     entry = [name for name in funcs if UPGRADE_RE.match(name)]
     if not entry:
         return [], []
@@ -222,12 +222,18 @@ def _scanned_functions(tree: ast.Module) -> tuple[list[ast.AST], list[str]]:
 
 # --- the rules ---------------------------------------------------------------------
 
+
 def check_upgrade(tree: ast.Module) -> list[Finding]:
     scoped, entry = _scanned_functions(tree)
     if not entry:
-        return [Finding(0, 'no upgrade() found',
-                        'the file defines no top-level upgrade()/upgrade_<engine>()',
-                        'A migration must define upgrade(); the check cannot verify this file.')]
+        return [
+            Finding(
+                0,
+                'no upgrade() found',
+                'the file defines no top-level upgrade()/upgrade_<engine>()',
+                'A migration must define upgrade(); the check cannot verify this file.',
+            )
+        ]
 
     calls = [n for f in scoped for n in ast.walk(f) if isinstance(n, ast.Call)]
 
@@ -238,7 +244,9 @@ def check_upgrade(tree: ast.Module) -> list[Finding]:
     # `with op.batch_alter_table(...) as batch_op:` binds an alias we must trust.
     batch_aliases = {
         item.optional_vars.id
-        for f in scoped for n in ast.walk(f) if isinstance(n, ast.With)
+        for f in scoped
+        for n in ast.walk(f)
+        if isinstance(n, ast.With)
         for item in n.items
         if isinstance(item.context_expr, ast.Call)
         and _attr_name(item.context_expr) == 'batch_alter_table'
@@ -262,17 +270,34 @@ def check_upgrade(tree: ast.Module) -> list[Finding]:
                 # An enum MODIFY is ambiguous: appending a value is additive, removing
                 # one is not, and the member list is usually interpolated so it cannot
                 # be compared statically. Surface it; do not block on it.
-                findings.append(Finding(node.lineno, 'execute(<enum change>)',
-                                        'alters an enum; additive only if values are ADDED, never removed',
-                                        'Reviewer must confirm no enum value was removed.', blocking=False))
+                findings.append(
+                    Finding(
+                        node.lineno,
+                        'execute(<enum change>)',
+                        'alters an enum; additive only if values are ADDED, never removed',
+                        'Reviewer must confirm no enum value was removed.',
+                        blocking=False,
+                    )
+                )
             elif hit:
-                findings.append(Finding(node.lineno, 'execute(<destructive SQL>)',
-                                        f'raw SQL contains {hit.group(0).strip()!r}',
-                                        'Defer the destructive statement to a later release.'))
+                findings.append(
+                    Finding(
+                        node.lineno,
+                        'execute(<destructive SQL>)',
+                        f'raw SQL contains {hit.group(0).strip()!r}',
+                        'Defer the destructive statement to a later release.',
+                    )
+                )
             elif not static and sql.strip():
-                findings.append(Finding(node.lineno, 'execute(<dynamic SQL>)',
-                                        'SQL is built at runtime, so it cannot be verified statically',
-                                        'Reviewer must confirm this is additive.', blocking=False))
+                findings.append(
+                    Finding(
+                        node.lineno,
+                        'execute(<dynamic SQL>)',
+                        'SQL is built at runtime, so it cannot be verified statically',
+                        'Reviewer must confirm this is additive.',
+                        blocking=False,
+                    )
+                )
             continue
 
         # Everything below is a DDL op and must actually be on op/batch_op.
@@ -280,8 +305,14 @@ def check_upgrade(tree: ast.Module) -> list[Finding]:
             continue
 
         if name in DESTRUCTIVE_OPS:
-            findings.append(Finding(node.lineno, f'op.{name}', DESTRUCTIVE_OPS[name],
-                                    'Ship the removal in a LATER release (contract phase).'))
+            findings.append(
+                Finding(
+                    node.lineno,
+                    f'op.{name}',
+                    DESTRUCTIVE_OPS[name],
+                    'Ship the removal in a LATER release (contract phase).',
+                )
+            )
             continue
 
         if name == 'drop_index':
@@ -290,46 +321,86 @@ def check_upgrade(tree: ast.Module) -> list[Finding]:
             )
             if table in reindexed:
                 continue  # index swap: dropped and recreated in the same migration
-            findings.append(Finding(node.lineno, 'op.drop_index',
-                                    'removes an index the old replicas depend on for query plans',
-                                    'Recreate it here, or drop it in a later release.'))
+            findings.append(
+                Finding(
+                    node.lineno,
+                    'op.drop_index',
+                    'removes an index the old replicas depend on for query plans',
+                    'Recreate it here, or drop it in a later release.',
+                )
+            )
             continue
 
         if name == 'batch_alter_table':
             table = _str_arg(node, 0)
-            parent = next((w for f in scoped for w in ast.walk(f)
-                           if isinstance(w, ast.With)
-                           and any(i.context_expr is node for i in w.items)), None)
+            parent = next(
+                (
+                    w
+                    for f in scoped
+                    for w in ast.walk(f)
+                    if isinstance(w, ast.With) and any(i.context_expr is node for i in w.items)
+                ),
+                None,
+            )
             destructive = parent is not None and any(
-                _attr_name(c) in (DESTRUCTIVE_OPS | {'drop_index': ''}) for c in ast.walk(parent)
+                _attr_name(c) in (DESTRUCTIVE_OPS | {'drop_index': ''})
+                for c in ast.walk(parent)
                 if isinstance(c, ast.Call)
             )
             if destructive and table not in new_tables:
-                findings.append(Finding(node.lineno, 'op.batch_alter_table(<destructive>)',
-                                        'batch mode recreates the table, and the body removes something',
-                                        'Defer the removal to a later release.'))
+                findings.append(
+                    Finding(
+                        node.lineno,
+                        'op.batch_alter_table(<destructive>)',
+                        'batch mode recreates the table, and the body removes something',
+                        'Defer the removal to a later release.',
+                    )
+                )
             continue
 
         if name == 'alter_column':
             table = _str_arg(node, 0)
             if _kwarg(node, 'new_column_name') is not None:
-                findings.append(Finding(node.lineno, 'op.alter_column(new_column_name=...)',
-                                        'renames a column; old replicas still SELECT the old name',
-                                        'Add the new column, dual-write, backfill, drop the old one later.'))
+                findings.append(
+                    Finding(
+                        node.lineno,
+                        'op.alter_column(new_column_name=...)',
+                        'renames a column; old replicas still SELECT the old name',
+                        'Add the new column, dual-write, backfill, drop the old one later.',
+                    )
+                )
             if _is(_kwarg(node, 'nullable'), False) and table not in new_tables:
-                findings.append(Finding(node.lineno, 'op.alter_column(nullable=False)',
-                                        "narrows a column; old replicas' NULL-omitting INSERTs start failing",
-                                        'Backfill first, then enforce NOT NULL in a later release.'))
-            if _has_kwarg(node, 'server_default') and _is(_kwarg(node, 'server_default'), None) \
-                    and _has_kwarg(node, 'existing_server_default'):
-                findings.append(Finding(node.lineno, 'op.alter_column(server_default=None)',
-                                        "removes a default the old replicas' INSERTs rely on",
-                                        'Remove the default in a later release.'))
+                findings.append(
+                    Finding(
+                        node.lineno,
+                        'op.alter_column(nullable=False)',
+                        "narrows a column; old replicas' NULL-omitting INSERTs start failing",
+                        'Backfill first, then enforce NOT NULL in a later release.',
+                    )
+                )
+            if (
+                _has_kwarg(node, 'server_default')
+                and _is(_kwarg(node, 'server_default'), None)
+                and _has_kwarg(node, 'existing_server_default')
+            ):
+                findings.append(
+                    Finding(
+                        node.lineno,
+                        'op.alter_column(server_default=None)',
+                        "removes a default the old replicas' INSERTs rely on",
+                        'Remove the default in a later release.',
+                    )
+                )
             new_t, old_t = _type_length(_kwarg(node, 'type_')), _type_length(_kwarg(node, 'existing_type'))
             if new_t and old_t and new_t[0] == old_t[0] and new_t[1] < old_t[1]:
-                findings.append(Finding(node.lineno, 'op.alter_column(<narrowing type>)',
-                                        f'{old_t[0]}({old_t[1]}) -> {new_t[0]}({new_t[1]}) truncates existing data',
-                                        'Widen instead, or narrow in a later release after backfilling.'))
+                findings.append(
+                    Finding(
+                        node.lineno,
+                        'op.alter_column(<narrowing type>)',
+                        f'{old_t[0]}({old_t[1]}) -> {new_t[0]}({new_t[1]}) truncates existing data',
+                        'Widen instead, or narrow in a later release after backfilling.',
+                    )
+                )
             continue
 
         if name == 'add_column':
@@ -341,24 +412,34 @@ def check_upgrade(tree: ast.Module) -> list[Finding]:
             for col in _sa_columns(node):
                 default = _kwarg(col, 'server_default')
                 if _is(_kwarg(col, 'nullable'), False) and (default is None or _is(default, None)):
-                    findings.append(Finding(
-                        col.lineno, 'op.add_column(nullable=False) without server_default',
-                        "old replicas' INSERTs omit the column, so they fail",
-                        "Add server_default=... (SQLAlchemy's default= is client-side and emits no DDL default)."))
+                    findings.append(
+                        Finding(
+                            col.lineno,
+                            'op.add_column(nullable=False) without server_default',
+                            "old replicas' INSERTs omit the column, so they fail",
+                            "Add server_default=... (SQLAlchemy's default= is client-side and emits no DDL default).",
+                        )
+                    )
             continue
 
         if (name == 'create_index' and _is(_kwarg(node, 'unique'), True)) or name == 'create_unique_constraint':
             table = _str_arg(node, 1)
             if table in new_tables:
                 continue
-            findings.append(Finding(node.lineno, f'op.{name} (unique)',
-                                    'aborts the migration if existing rows collide',
-                                    'De-duplicate in a prior release, then add the constraint.'))
+            findings.append(
+                Finding(
+                    node.lineno,
+                    f'op.{name} (unique)',
+                    'aborts the migration if existing rows collide',
+                    'De-duplicate in a prior release, then add the constraint.',
+                )
+            )
 
     return findings
 
 
 # --- exemptions (real comments only) -----------------------------------------------
+
 
 def _exemptions(src: str) -> list[tuple[int, str, str]]:
     """Markers found in genuine COMMENT tokens -- not docstrings or SQL strings."""
@@ -393,16 +474,20 @@ def check_file(path: pathlib.Path) -> tuple[list[Finding], str | None]:
     bad = [(ln, url) for ln, url, reason in markers if not EXEMPT_URL_RE.match(url) or len(reason) < 10]
     if bad:
         ln, url = bad[0]
-        return findings + [Finding(
-            ln, 'invalid additivity-exempt marker',
-            f'{url!r} is not a Thunderbird issue/PR URL followed by a reason',
-            'Use: # additivity-exempt: https://github.com/thunderbird/<repo>/issues/<n> <why it is safe>',
-        )], None
+        return findings + [
+            Finding(
+                ln,
+                'invalid additivity-exempt marker',
+                f'{url!r} is not a Thunderbird issue/PR URL followed by a reason',
+                'Use: # additivity-exempt: https://github.com/thunderbird/<repo>/issues/<n> <why it is safe>',
+            )
+        ], None
 
     return findings, '; '.join(f'{url} {reason}' for _, url, reason in markers)
 
 
 # --- output ------------------------------------------------------------------------
+
 
 def _annotate(path: pathlib.Path, f: Finding) -> None:
     if os.environ.get('GITHUB_ACTIONS') and f.line:

--- a/backend/scripts/check_migration_additivity.py
+++ b/backend/scripts/check_migration_additivity.py
@@ -10,87 +10,118 @@ lands -- and a schema change cannot be rolled back by aborting the deploy. So a
 migration must only ever ADD things ("expand"); removals ("contract") ship in a
 LATER release, once no running replica references them.
 
-This check runs in CI on the migrations a PR ADDS, so the author finds out while
-it is still cheap to fix, and before the migration can ever execute anywhere.
+This runs in CI on the migrations a PR adds or edits, so the author finds out
+while it is still cheap to fix, and before the migration can execute anywhere.
 
-WHAT IS FLAGGED (in `upgrade()` only -- `downgrade()` is never run by the deploy)
----------------------------------------------------------------------------
-  * op.drop_column / drop_table / drop_constraint / drop_index
-  * op.rename_table, and op.alter_column(new_column_name=...)   (renames)
-  * op.alter_column(nullable=False)                             (narrowing)
-  * op.add_column(... nullable=False) with NO server_default    (old replicas'
-    INSERTs omit the column, so they start failing)
-  * op.create_index(unique=True) / op.create_unique_constraint  (fails outright
-    if existing rows collide, leaving a half-applied release)
-  * op.batch_alter_table(...)                                   (recreates the
-    table; never additive under blue-green)
-  * op.execute("...") containing destructive SQL
+SCOPE OF THE SCAN
+-----------------
+Every top-level `upgrade` / `upgrade_<engine>` function, PLUS every module-level
+helper transitively called from them -- factoring a drop into a helper is the
+house style here, and must not hide it. `downgrade()` and anything reachable only
+from it is ignored: the deploy never runs it, and Alembic autogenerates a
+destructive downgrade for every additive upgrade.
 
-WHAT IS NOT FLAGGED (deliberately -- these are additive)
---------------------------------------------------------
-  * anything inside `downgrade()`
-  * `nullable=False` on a column of a brand-new `op.create_table(...)` -- old
-    replicas do not know the table exists
-  * `existing_nullable=False` -- a descriptor of current state, not a change
-  * `op.add_column(... nullable=False, server_default=...)` -- the default
-    backfills for old replicas
+WHAT IS FLAGGED
+---------------
+  * op.drop_column / drop_table / drop_constraint / rename_table
+  * op.drop_index                       (unless the same table is re-indexed here)
+  * op.alter_column(new_column_name=)   (rename)
+  * op.alter_column(nullable=False)     (narrowing)
+  * op.alter_column(type_=) that shrinks a length
+  * op.alter_column(server_default=None) over an existing default
+  * op.add_column(nullable=False) with no server_default
+  * unique constraints/indexes on a PRE-EXISTING table (they abort on duplicates)
+  * op.batch_alter_table(...) whose body is destructive (batch recreates the table)
+  * .execute() -- on ANY receiver -- carrying destructive SQL
+
+NOT FLAGGED (these are additive)
+--------------------------------
+  * anything reachable only from `downgrade()`
+  * NOT NULL / unique on a table created in the same migration
+  * `existing_nullable=` / `existing_server_default=` (they describe current state)
+  * op.add_column(nullable=False, server_default=...)
 
 ESCAPE HATCH
 ------------
-A genuinely-needed contract migration ships by declaring it in the migration
-itself, so the reviewer of the schema change sees the justification in the diff:
+A genuinely-safe contract migration declares itself, in a real comment, so the
+justification sits in the diff the schema reviewer reads:
 
     # additivity-exempt: https://github.com/thunderbird/appointment/issues/1234
-    #   invites table removal; no replica has referenced it since v1.9.
+    #   invites table; nothing has referenced it since v1.9
 
-The marker must carry a URL. Prefer splitting into expand/contract over exempting.
+The URL must be a Thunderbird issue/PR and a reason is required. Exempt files are
+still scanned, and everything waived is printed, so the waiver is auditable.
 
 USAGE
 -----
     check_migration_additivity.py <file.py> [<file.py> ...]
-    check_migration_additivity.py --all      # scan every migration (audit)
+    check_migration_additivity.py --all      # audit every migration
 
-Exit 0 = additive (or exempt), 1 = non-additive found, 2 = usage/parse error.
+Exit 0 = additive (or waived), 1 = non-additive found, 2 = tool/usage error.
 """
 
 from __future__ import annotations
 
 import argparse
 import ast
+import io
+import os
 import pathlib
 import re
 import sys
+import tokenize
 
 VERSIONS_DIR = pathlib.Path(__file__).resolve().parents[1] / 'src/appointment/migrations/versions'
 
-# op.<name>(...) calls that remove or rename something an old replica may use.
+UPGRADE_RE = re.compile(r'^upgrade(_\w+)?$')
+
+# Removals/renames: an old replica still referencing the thing breaks immediately.
 DESTRUCTIVE_OPS = {
     'drop_column': 'drops a column the old replicas may still SELECT',
     'drop_table': 'drops a table the old replicas may still query',
     'drop_constraint': 'drops a constraint the old replicas rely on',
-    'drop_index': 'drops an index; old replicas lose the query plan mid-rollout',
     'rename_table': 'renames a table; old replicas still use the old name',
 }
 
-# Raw SQL that is destructive regardless of how it is spelled.
+# Destructive SQL. Anchored to DDL verbs so a bare "NOT NULL" in a CREATE TABLE,
+# or the word DELETE inside a string value, does not trip it.
 DESTRUCTIVE_SQL = re.compile(
     r'\b(?:'
     r'DROP\s+(?:COLUMN|TABLE|CONSTRAINT|INDEX)'
-    r'|ALTER\s+TABLE\b[\s\S]*?\b(?:DROP|MODIFY|CHANGE)\b'
+    r'|ALTER\s+TABLE\b[\s\S]{0,200}?\b(?:DROP|MODIFY|CHANGE)\b'
     r'|RENAME\s+(?:TO|COLUMN)'
-    r'|TRUNCATE\b'
-    r'|DELETE\s+FROM\b'
-    r'|NOT\s+NULL'
+    r'|TRUNCATE\s+TABLE'
     r')',
     re.IGNORECASE,
 )
 
-EXEMPT_RE = re.compile(r'#\s*additivity-exempt:\s*(\S+)(.*)', re.IGNORECASE)
+# Only a real Thunderbird issue/PR justifies a waiver.
+EXEMPT_URL_RE = re.compile(r'^https://github\.com/thunderbird/[\w.-]+/(?:issues|pull)/\d+/?$')
+EXEMPT_MARKER_RE = re.compile(r'#\s*additivity-exempt:\s*(\S+)\s*(.*)', re.IGNORECASE)
+
+
+class ToolError(Exception):
+    """Something prevented the check from running; never a silent pass."""
 
 
 class Finding:
-    def __init__(self, line: int, rule: str, detail: str, fix: str):
-        self.line, self.rule, self.detail, self.fix = line, rule, detail, fix
+    def __init__(self, line: int, rule: str, detail: str, fix: str, blocking: bool = True):
+        self.line, self.rule, self.detail, self.fix, self.blocking = line, rule, detail, fix, blocking
+
+
+# --- small AST helpers -------------------------------------------------------------
+
+def _attr_name(call: ast.Call) -> str | None:
+    """`x.foo(...)` -> 'foo'."""
+    return call.func.attr if isinstance(call.func, ast.Attribute) else None
+
+
+def _receiver(call: ast.Call) -> str | None:
+    """`op.foo(...)` -> 'op'. Returns None for chained calls like op.get_bind().foo()."""
+    func = call.func
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+        return func.value.id
+    return None
 
 
 def _kwarg(call: ast.Call, name: str) -> ast.expr | None:
@@ -100,163 +131,297 @@ def _kwarg(call: ast.Call, name: str) -> ast.expr | None:
     return None
 
 
-def _is_true(node: ast.expr | None) -> bool:
-    return isinstance(node, ast.Constant) and node.value is True
+def _has_kwarg(call: ast.Call, name: str) -> bool:
+    return any(kw.arg == name for kw in call.keywords)
 
 
-def _is_false(node: ast.expr | None) -> bool:
-    return isinstance(node, ast.Constant) and node.value is False
+def _is(node: ast.expr | None, value) -> bool:
+    return isinstance(node, ast.Constant) and node.value is value
 
 
-def _op_name(call: ast.Call) -> str | None:
-    """Return the method name for `op.<name>(...)` / `batch_op.<name>(...)`."""
-    func = call.func
-    if isinstance(func, ast.Attribute):
-        return func.attr
+def _str_arg(call: ast.Call, index: int) -> str | None:
+    if len(call.args) > index and isinstance(call.args[index], ast.Constant):
+        v = call.args[index].value
+        return v if isinstance(v, str) else None
     return None
 
 
-def _receiver(call: ast.Call) -> str | None:
-    func = call.func
-    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
-        return func.value.id
+def _sa_columns(call: ast.Call) -> list[ast.Call]:
+    return [n for n in ast.walk(call) if isinstance(n, ast.Call) and _attr_name(n) == 'Column']
+
+
+def _type_length(node: ast.expr | None) -> tuple[str, int] | None:
+    """`sa.String(50)` -> ('String', 50). Only literal lengths are comparable."""
+    if not isinstance(node, ast.Call):
+        return None
+    name = _attr_name(node) or (node.func.id if isinstance(node.func, ast.Name) else None)
+    if not name or not node.args:
+        return None
+    first = node.args[0]
+    length = _kwarg(node, 'length')
+    for candidate in (first, length):
+        if isinstance(candidate, ast.Constant) and isinstance(candidate.value, int):
+            return name, candidate.value
     return None
 
 
-def _columns_in(call: ast.Call) -> list[ast.Call]:
-    """sa.Column(...) calls appearing anywhere inside this call's arguments."""
-    out = []
+def _literal_sql(call: ast.Call) -> tuple[str, bool]:
+    """Best-effort SQL text inside a call. Returns (text, fully_static)."""
+    parts: list[str] = []
+    static = True
     for node in ast.walk(call):
-        if isinstance(node, ast.Call) and _op_name(node) == 'Column':
-            out.append(node)
-    return out
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            parts.append(node.value)
+        elif isinstance(node, ast.JoinedStr):
+            for v in node.values:
+                if isinstance(v, ast.Constant) and isinstance(v.value, str):
+                    parts.append(v.value)
+                else:
+                    static = False
+                    parts.append(' ? ')
+        elif isinstance(node, ast.Name):
+            static = False
+    return ' '.join(parts), static
 
+
+# --- scan scope: upgrade() plus the helpers it calls --------------------------------
+
+def _scanned_functions(tree: ast.Module) -> tuple[list[ast.AST], list[str]]:
+    """Return (functions to scan, names of upgrade entrypoints found)."""
+    funcs: dict[str, ast.AST] = {
+        n.name: n for n in tree.body if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    entry = [name for name in funcs if UPGRADE_RE.match(name)]
+    if not entry:
+        return [], []
+
+    # Transitively pull in module-level helpers called from the upgrade path, so a
+    # destructive op factored into a helper cannot hide. `downgrade` and anything
+    # only it calls are never added.
+    selected: dict[str, ast.AST] = {name: funcs[name] for name in entry}
+    queue = list(entry)
+    while queue:
+        node = funcs[queue.pop()]
+        for call in ast.walk(node):
+            if not isinstance(call, ast.Call):
+                continue
+            callee = call.func.id if isinstance(call.func, ast.Name) else None
+            if callee and callee in funcs and callee not in selected and not callee.startswith('downgrade'):
+                selected[callee] = funcs[callee]
+                queue.append(callee)
+    return list(selected.values()), entry
+
+
+# --- the rules ---------------------------------------------------------------------
 
 def check_upgrade(tree: ast.Module) -> list[Finding]:
-    upgrade = next(
-        (n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name.startswith('upgrade')),
-        None,
-    )
-    if upgrade is None:
-        return []
+    scoped, entry = _scanned_functions(tree)
+    if not entry:
+        return [Finding(0, 'no upgrade() found',
+                        'the file defines no top-level upgrade()/upgrade_<engine>()',
+                        'A migration must define upgrade(); the check cannot verify this file.')]
+
+    calls = [n for f in scoped for n in ast.walk(f) if isinstance(n, ast.Call)]
+
+    # Tables created here are additive wholesale: no running replica knows them.
+    new_tables = {t for c in calls if _attr_name(c) == 'create_table' and (t := _str_arg(c, 0))}
+    # A drop_index paired with a create_index on the same table is an index swap.
+    reindexed = {t for c in calls if _attr_name(c) == 'create_index' and (t := _str_arg(c, 1))}
+    # `with op.batch_alter_table(...) as batch_op:` binds an alias we must trust.
+    batch_aliases = {
+        item.optional_vars.id
+        for f in scoped for n in ast.walk(f) if isinstance(n, ast.With)
+        for item in n.items
+        if isinstance(item.context_expr, ast.Call)
+        and _attr_name(item.context_expr) == 'batch_alter_table'
+        and isinstance(item.optional_vars, ast.Name)
+    }
+    ddl_receivers = {'op'} | batch_aliases
 
     findings: list[Finding] = []
-
-    # NOTE: `op.create_table(...)` is never inspected below -- a brand-new table's
-    # NOT NULL columns are additive (no running replica knows the table exists), so
-    # create_table is exempt by construction rather than by an explicit filter.
-    for node in ast.walk(upgrade):
-        if not isinstance(node, ast.Call):
-            continue
-        name = _op_name(node)
+    for node in calls:
+        name = _attr_name(node)
         if name is None:
+            continue
+        recv = _receiver(node)
+
+        # `.execute()` is checked on ANY receiver: op.execute, session.execute,
+        # connection.execute and op.get_bind().execute are all used in this repo.
+        if name == 'execute':
+            sql, static = _literal_sql(node)
+            hit = DESTRUCTIVE_SQL.search(sql)
+            if hit and re.search(r'\benum\s*\(', sql, re.IGNORECASE):
+                # An enum MODIFY is ambiguous: appending a value is additive, removing
+                # one is not, and the member list is usually interpolated so it cannot
+                # be compared statically. Surface it; do not block on it.
+                findings.append(Finding(node.lineno, 'execute(<enum change>)',
+                                        'alters an enum; additive only if values are ADDED, never removed',
+                                        'Reviewer must confirm no enum value was removed.', blocking=False))
+            elif hit:
+                findings.append(Finding(node.lineno, 'execute(<destructive SQL>)',
+                                        f'raw SQL contains {hit.group(0).strip()!r}',
+                                        'Defer the destructive statement to a later release.'))
+            elif not static and sql.strip():
+                findings.append(Finding(node.lineno, 'execute(<dynamic SQL>)',
+                                        'SQL is built at runtime, so it cannot be verified statically',
+                                        'Reviewer must confirm this is additive.', blocking=False))
+            continue
+
+        # Everything below is a DDL op and must actually be on op/batch_op.
+        if recv not in ddl_receivers and name not in ('add_column',):
             continue
 
         if name in DESTRUCTIVE_OPS:
-            findings.append(
-                Finding(node.lineno, f'op.{name}', DESTRUCTIVE_OPS[name],
-                        'Remove it here; ship the removal in a LATER release (contract phase).')
+            findings.append(Finding(node.lineno, f'op.{name}', DESTRUCTIVE_OPS[name],
+                                    'Ship the removal in a LATER release (contract phase).'))
+            continue
+
+        if name == 'drop_index':
+            table = _str_arg(node, 1) or (
+                k.value if isinstance(k := _kwarg(node, 'table_name'), ast.Constant) else None
             )
+            if table in reindexed:
+                continue  # index swap: dropped and recreated in the same migration
+            findings.append(Finding(node.lineno, 'op.drop_index',
+                                    'removes an index the old replicas depend on for query plans',
+                                    'Recreate it here, or drop it in a later release.'))
             continue
 
         if name == 'batch_alter_table':
-            findings.append(
-                Finding(node.lineno, 'op.batch_alter_table',
-                        'batch mode recreates the table, which is never additive',
-                        'Use direct op.* calls for the additive parts.')
+            table = _str_arg(node, 0)
+            parent = next((w for f in scoped for w in ast.walk(f)
+                           if isinstance(w, ast.With)
+                           and any(i.context_expr is node for i in w.items)), None)
+            destructive = parent is not None and any(
+                _attr_name(c) in (DESTRUCTIVE_OPS | {'drop_index': ''}) for c in ast.walk(parent)
+                if isinstance(c, ast.Call)
             )
+            if destructive and table not in new_tables:
+                findings.append(Finding(node.lineno, 'op.batch_alter_table(<destructive>)',
+                                        'batch mode recreates the table, and the body removes something',
+                                        'Defer the removal to a later release.'))
             continue
 
         if name == 'alter_column':
+            table = _str_arg(node, 0)
             if _kwarg(node, 'new_column_name') is not None:
-                findings.append(
-                    Finding(node.lineno, 'op.alter_column(new_column_name=...)',
-                            'renames a column; old replicas still SELECT the old name',
-                            'Add the new column, dual-write, backfill, drop the old one in a later release.')
-                )
-            if _is_false(_kwarg(node, 'nullable')):
-                findings.append(
-                    Finding(node.lineno, 'op.alter_column(nullable=False)',
-                            "narrows a column; old replicas' NULL-omitting INSERTs start failing",
-                            'Backfill first, then enforce NOT NULL in a later release.')
-                )
+                findings.append(Finding(node.lineno, 'op.alter_column(new_column_name=...)',
+                                        'renames a column; old replicas still SELECT the old name',
+                                        'Add the new column, dual-write, backfill, drop the old one later.'))
+            if _is(_kwarg(node, 'nullable'), False) and table not in new_tables:
+                findings.append(Finding(node.lineno, 'op.alter_column(nullable=False)',
+                                        "narrows a column; old replicas' NULL-omitting INSERTs start failing",
+                                        'Backfill first, then enforce NOT NULL in a later release.'))
+            if _has_kwarg(node, 'server_default') and _is(_kwarg(node, 'server_default'), None) \
+                    and _has_kwarg(node, 'existing_server_default'):
+                findings.append(Finding(node.lineno, 'op.alter_column(server_default=None)',
+                                        "removes a default the old replicas' INSERTs rely on",
+                                        'Remove the default in a later release.'))
+            new_t, old_t = _type_length(_kwarg(node, 'type_')), _type_length(_kwarg(node, 'existing_type'))
+            if new_t and old_t and new_t[0] == old_t[0] and new_t[1] < old_t[1]:
+                findings.append(Finding(node.lineno, 'op.alter_column(<narrowing type>)',
+                                        f'{old_t[0]}({old_t[1]}) -> {new_t[0]}({new_t[1]}) truncates existing data',
+                                        'Widen instead, or narrow in a later release after backfilling.'))
             continue
 
         if name == 'add_column':
-            for col in _columns_in(node):
-                if _is_false(_kwarg(col, 'nullable')) and _kwarg(col, 'server_default') is None:
-                    findings.append(
-                        Finding(col.lineno, 'op.add_column(nullable=False) without server_default',
-                                "old replicas' INSERTs omit the column, so they fail",
-                                "Add server_default=... (note: SQLAlchemy's default= is client-side "
-                                'and emits no DDL default, so it does not help here).')
-                    )
+            if recv not in ddl_receivers:
+                continue
+            table = _str_arg(node, 0)
+            if table in new_tables:
+                continue
+            for col in _sa_columns(node):
+                default = _kwarg(col, 'server_default')
+                if _is(_kwarg(col, 'nullable'), False) and (default is None or _is(default, None)):
+                    findings.append(Finding(
+                        col.lineno, 'op.add_column(nullable=False) without server_default',
+                        "old replicas' INSERTs omit the column, so they fail",
+                        "Add server_default=... (SQLAlchemy's default= is client-side and emits no DDL default)."))
             continue
 
-        if name == 'create_index' and _is_true(_kwarg(node, 'unique')):
-            findings.append(
-                Finding(node.lineno, 'op.create_index(unique=True)',
-                        'fails outright if existing rows collide, leaving a half-applied release',
-                        'De-duplicate in a prior release, then add the unique index.')
-            )
-            continue
-
-        if name == 'create_unique_constraint':
-            findings.append(
-                Finding(node.lineno, 'op.create_unique_constraint',
-                        'fails outright if existing rows collide',
-                        'De-duplicate in a prior release, then add the constraint.')
-            )
-            continue
-
-        if name == 'execute' and _receiver(node) == 'op':
-            for arg in ast.walk(node):
-                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
-                    m = DESTRUCTIVE_SQL.search(arg.value)
-                    if m:
-                        findings.append(
-                            Finding(node.lineno, 'op.execute(<destructive SQL>)',
-                                    f'raw SQL contains {m.group(0).strip()!r}',
-                                    'Express the additive part in SQL; defer the destructive part a release.')
-                        )
-                        break
+        if (name == 'create_index' and _is(_kwarg(node, 'unique'), True)) or name == 'create_unique_constraint':
+            table = _str_arg(node, 1)
+            if table in new_tables:
+                continue
+            findings.append(Finding(node.lineno, f'op.{name} (unique)',
+                                    'aborts the migration if existing rows collide',
+                                    'De-duplicate in a prior release, then add the constraint.'))
 
     return findings
 
 
+# --- exemptions (real comments only) -----------------------------------------------
+
+def _exemptions(src: str) -> list[tuple[int, str, str]]:
+    """Markers found in genuine COMMENT tokens -- not docstrings or SQL strings."""
+    out = []
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(src).readline):
+            if tok.type == tokenize.COMMENT and (m := EXEMPT_MARKER_RE.search(tok.string)):
+                out.append((tok.start[0], m.group(1), m.group(2).strip()))
+    except (tokenize.TokenError, IndentationError):
+        pass
+    return out
+
+
 def check_file(path: pathlib.Path) -> tuple[list[Finding], str | None]:
-    """Return (findings, exemption_reason)."""
-    src = path.read_text(encoding='utf-8')
-    m = EXEMPT_RE.search(src)
-    if m:
-        url, rest = m.group(1), m.group(2).strip()
-        if not url.startswith(('http://', 'https://')):
-            return (
-                [Finding(0, 'additivity-exempt without a URL',
-                         f'marker points at {url!r}',
-                         'Use: # additivity-exempt: <issue-url> <reason>')],
-                None,
-            )
-        return [], f'{url} {rest}'.strip()
+    """Return (findings, waiver). A waiver never skips the scan."""
+    try:
+        src = path.read_text(encoding='utf-8')
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ToolError(f'{path}: cannot read ({exc})') from exc
 
     try:
         tree = ast.parse(src, filename=str(path))
-    except SyntaxError as exc:  # pragma: no cover
-        return [Finding(exc.lineno or 0, 'syntax error', str(exc), 'Fix the migration file.')], None
-    return check_upgrade(tree), None
+    except SyntaxError as exc:
+        raise ToolError(f'{path}: syntax error at line {exc.lineno} ({exc.msg})') from exc
+
+    findings = check_upgrade(tree)
+
+    markers = _exemptions(src)
+    if not markers:
+        return findings, None
+
+    bad = [(ln, url) for ln, url, reason in markers if not EXEMPT_URL_RE.match(url) or len(reason) < 10]
+    if bad:
+        ln, url = bad[0]
+        return findings + [Finding(
+            ln, 'invalid additivity-exempt marker',
+            f'{url!r} is not a Thunderbird issue/PR URL followed by a reason',
+            'Use: # additivity-exempt: https://github.com/thunderbird/<repo>/issues/<n> <why it is safe>',
+        )], None
+
+    return findings, '; '.join(f'{url} {reason}' for _, url, reason in markers)
+
+
+# --- output ------------------------------------------------------------------------
+
+def _annotate(path: pathlib.Path, f: Finding) -> None:
+    if os.environ.get('GITHUB_ACTIONS') and f.line:
+        print(f'::error file={path},line={f.line},title=Non-additive migration::{f.rule} -- {f.detail}')
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument('files', nargs='*', help='migration files to check')
-    ap.add_argument('--all', action='store_true', help='check every migration (audit mode)')
+    ap.add_argument('--all', action='store_true', help='audit every migration')
     args = ap.parse_args()
 
     if args.all:
-        paths = sorted(VERSIONS_DIR.glob('*.py'))
+        if not VERSIONS_DIR.is_dir():
+            print(f'error: migrations directory not found: {VERSIONS_DIR}', file=sys.stderr)
+            return 2
+        paths = [p for p in sorted(VERSIONS_DIR.glob('*.py')) if p.name != '__init__.py']
     else:
-        paths = [pathlib.Path(f) for f in args.files]
-        paths = [p for p in paths if p.suffix == '.py' and p.name != '__init__.py' and p.exists()]
+        paths = []
+        for f in args.files:
+            p = pathlib.Path(f)
+            # A path we were asked to check but cannot must never be a silent pass.
+            if not p.is_file() or p.suffix != '.py':
+                print(f'error: not a migration file: {f}', file=sys.stderr)
+                return 2
+            if p.name != '__init__.py':
+                paths.append(p)
 
     if not paths:
         print('migration-additivity: no migration files to check.')
@@ -264,31 +429,49 @@ def main() -> int:
 
     failed = False
     for path in paths:
-        findings, exempt = check_file(path)
-        if exempt:
-            print(f'\N{WARNING SIGN}  {path.name}: EXEMPT -- {exempt}')
+        try:
+            findings, waiver = check_file(path)
+        except ToolError as exc:
+            print(f'ERROR  {exc}', file=sys.stderr)
+            return 2
+
+        blocking = [f for f in findings if f.blocking]
+        if waiver:
+            print(f'WAIVED {path.name}: {waiver}')
+            for f in findings:
+                print(f'         line {f.line}: {f.rule} -- {f.detail}')
             continue
-        if not findings:
-            print(f'\N{CHECK MARK}  {path.name}: additive')
+        if not blocking:
+            print(f'PASS   {path.name}: additive')
+            for f in findings:
+                print(f'         note line {f.line}: {f.rule} -- {f.detail}')
             continue
+
         failed = True
-        print(f'\N{CROSS MARK}  {path.name}: NOT additive')
+        print(f'FAIL   {path.name}: not additive')
         for f in findings:
-            print(f'      line {f.line}: {f.rule}')
-            print(f'        why: {f.detail}')
-            print(f'        fix: {f.fix}')
+            print(f'         line {f.line}: {f.rule}')
+            print(f'           why: {f.detail}')
+            print(f'           fix: {f.fix}')
+            if f.blocking:
+                _annotate(path, f)
 
     if failed:
         print(
             '\nA blue-green deploy runs the OLD and NEW replicas against the same database,\n'
             'and a schema change cannot be undone by aborting the deploy. Split the change:\n'
-            '  release N   : add the new thing (and backfill / dual-write)\n'
-            '  release N+1 : remove the old thing, once nothing references it\n\n'
-            'If the removal is genuinely safe now, declare it in the migration:\n'
-            '  # additivity-exempt: <issue-url> <why it is safe>\n'
+            '  release N   : add the new thing, and dual-write/backfill it in the app\n'
+            '  release N+1 : remove the old thing, once no running replica references it\n'
+            '\nA rename is add -> dual-write -> backfill -> drop, i.e. more than two releases.\n'
+            '\nIf the removal is genuinely safe now, declare it in the migration:\n'
+            '  # additivity-exempt: https://github.com/thunderbird/<repo>/issues/<n> <why it is safe>\n'
         )
     return 1 if failed else 0
 
 
 if __name__ == '__main__':
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except ToolError as exc:  # pragma: no cover
+        print(f'ERROR  {exc}', file=sys.stderr)
+        sys.exit(2)

--- a/backend/scripts/check_migration_additivity.py
+++ b/backend/scripts/check_migration_additivity.py
@@ -3,12 +3,20 @@
 
 WHY
 ---
-Appointment is deployed with a blue-green rollout: for a window during every
-deploy, the OLD and NEW replicas run against the SAME database. A migration that
-removes or narrows something the old replicas still use breaks them the moment it
-lands -- and a schema change cannot be rolled back by aborting the deploy. So a
-migration must only ever ADD things ("expand"); removals ("contract") ship in a
-LATER release, once no running replica references them.
+For a window during every deploy, the OLD and NEW replicas run against the SAME
+database. A migration that removes or narrows something the old replicas still
+use breaks them the moment it lands -- and a schema change cannot be rolled back
+by aborting the deploy. So a migration must only ever ADD things ("expand");
+removals ("contract") ship in a LATER release, once no running replica
+references them.
+
+That window already exists in the current ECS Fargate rolling deploy (AWS
+default min 100% / max 200%), where it is short and incidental. This check is
+groundwork for the Argo Rollouts BLUE-GREEN deploy on the new EKS tb-dev /
+tb-prod clusters (thunderbird/platform-infrastructure#781), which holds both
+versions up on purpose -- for the length of prePromotionAnalysis plus
+scaleDownDelaySeconds -- and offers an abort path that looks like a rollback but
+cannot undo DDL.
 
 This runs in CI on the migrations a PR adds or edits, so the author finds out
 while it is still cheap to fix, and before the migration can execute anywhere.
@@ -458,8 +466,9 @@ def main() -> int:
 
     if failed:
         print(
-            '\nA blue-green deploy runs the OLD and NEW replicas against the same database,\n'
-            'and a schema change cannot be undone by aborting the deploy. Split the change:\n'
+            '\nA deploy runs the OLD and NEW replicas against the same database (briefly on\n'
+            'ECS rolling; deliberately, for longer, on the EKS blue-green rollout), and a\n'
+            'schema change cannot be undone by aborting the deploy. Split the change:\n'
             '  release N   : add the new thing, and dual-write/backfill it in the app\n'
             '  release N+1 : remove the old thing, once no running replica references it\n'
             '\nA rename is add -> dual-write -> backfill -> drop, i.e. more than two releases.\n'

--- a/backend/test/unit/test_migration_additivity.py
+++ b/backend/test/unit/test_migration_additivity.py
@@ -37,6 +37,7 @@ def wrap(upgrade_body: str, downgrade_body: str = 'pass') -> str:
 
 # --- additive: must NOT be flagged -------------------------------------------------
 
+
 def test_add_nullable_column_is_additive():
     assert rules(wrap("op.add_column('t', sa.Column('c', sa.String, nullable=True))")) == []
 
@@ -52,8 +53,7 @@ def test_create_table_with_not_null_columns_is_additive():
 
 
 def test_unique_index_on_a_table_created_here_is_additive():
-    src = wrap("op.create_table('t', sa.Column('c', sa.String))\n    "
-               "op.create_index('i', 't', ['c'], unique=True)")
+    src = wrap("op.create_table('t', sa.Column('c', sa.String))\n    op.create_index('i', 't', ['c'], unique=True)")
     assert rules(src) == []
 
 
@@ -78,9 +78,11 @@ def test_destructive_ddl_in_downgrade_is_ignored():
 
 
 def test_helper_called_only_from_downgrade_is_ignored():
-    src = ('def _cleanup():\n    op.drop_table("t")\n\n\n'
-           'def upgrade():\n    op.add_column("t", sa.Column("c", sa.String))\n\n\n'
-           'def downgrade():\n    _cleanup()\n')
+    src = (
+        'def _cleanup():\n    op.drop_table("t")\n\n\n'
+        'def upgrade():\n    op.add_column("t", sa.Column("c", sa.String))\n\n\n'
+        'def downgrade():\n    _cleanup()\n'
+    )
     assert rules(src) == []
 
 
@@ -91,7 +93,7 @@ def test_index_swap_is_not_flagged():
 
 
 def test_non_destructive_execute_is_additive():
-    assert rules(wrap("op.execute(\"UPDATE t SET c = 'x' WHERE c IS NULL\")")) == []
+    assert rules(wrap('op.execute("UPDATE t SET c = \'x\' WHERE c IS NULL")')) == []
 
 
 def test_add_column_raw_sql_is_additive():
@@ -100,6 +102,7 @@ def test_add_column_raw_sql_is_additive():
 
 
 # --- non-additive: must be flagged -------------------------------------------------
+
 
 @pytest.mark.parametrize(
     'body,expected',
@@ -156,8 +159,7 @@ def test_destructive_batch_alter_is_flagged():
 
 
 def test_additive_batch_alter_is_not_flagged():
-    src = ('def upgrade():\n    with op.batch_alter_table("t") as b:\n'
-           '        b.add_column(sa.Column("c", sa.String))\n')
+    src = 'def upgrade():\n    with op.batch_alter_table("t") as b:\n        b.add_column(sa.Column("c", sa.String))\n'
     assert rules(src) == []
 
 
@@ -190,8 +192,10 @@ def test_raw_sql_on_any_receiver_is_flagged(stmt):
 
 def test_destructive_op_in_a_helper_is_flagged():
     """Factoring a drop into a helper is house style here; it must not hide it."""
-    src = ('def _cleanup(conn):\n    op.drop_index("i", "t")\n\n\n'
-           'def upgrade():\n    _cleanup(op.get_bind())\n\n\ndef downgrade():\n    pass\n')
+    src = (
+        'def _cleanup(conn):\n    op.drop_index("i", "t")\n\n\n'
+        'def upgrade():\n    _cleanup(op.get_bind())\n\n\ndef downgrade():\n    pass\n'
+    )
     assert 'op.drop_index' in rules(src)
 
 
@@ -202,6 +206,7 @@ def test_missing_upgrade_is_flagged_not_ignored():
 
 # --- non-blocking notes ------------------------------------------------------------
 
+
 def test_enum_change_is_a_note_not_a_block():
     """Appending an enum value is additive; removing one is not, and the member
     list is usually interpolated, so it cannot be decided statically."""
@@ -211,11 +216,12 @@ def test_enum_change_is_a_note_not_a_block():
 
 
 def test_dynamic_sql_is_a_note_not_a_block():
-    src = wrap("op.execute(some_statement)")
+    src = wrap('op.execute(some_statement)')
     assert rules(src) == []
 
 
 # --- exemption ---------------------------------------------------------------------
+
 
 def test_exemption_with_valid_url_and_reason_waives(tmp_path):
     p = tmp_path / 'm.py'
@@ -234,8 +240,8 @@ def test_exemption_with_valid_url_and_reason_waives(tmp_path):
 @pytest.mark.parametrize(
     'marker',
     [
-        '# additivity-exempt: trust-me a good reason here',           # not a URL
-        '# additivity-exempt: https:// a good reason here',           # bare scheme
+        '# additivity-exempt: trust-me a good reason here',  # not a URL
+        '# additivity-exempt: https:// a good reason here',  # bare scheme
         '# additivity-exempt: https://evil.example/1 a good reason',  # wrong host
         '# additivity-exempt: https://github.com/thunderbird/appointment/issues/1',  # no reason
     ],
@@ -266,27 +272,28 @@ def test_exemption_inside_a_docstring_does_not_count(tmp_path):
 # migrations must be additive or carry an exemption. Both directions are asserted
 # so that a checker which stops flagging anything FAILS rather than passing.
 
-GRANDFATHERED = frozenset({
-    '2023_07_27_1102-f9c5471478d0_modify_schedules_table.py',
-    '2024_03_13_1621-f92bae6c27da_update_subscribers_table_to_.py',
-    '2024_06_13_1525-f732d6e597fe_update_appointments_make_uuid_.py',
-    '2024_06_25_2133-156b3b0d77b9_add_ftue_level_to_subscribers.py',
-    '2024_12_20_1733-0c99f6a02f3b_make_subscribers_language_not_.py',
-    '2025_01_15_1340-4a15d01919b8_add_config_fields_to_subscribers_table.py',
-    '2025_04_04_1536-666158eab217_add_start_of_week_user_setting.py',
-    '2025_05_13_0837-ceecffbb5eb5_update_availabilities_table.py',
-    '2025_06_26_1629-88dbe32dc40d_switch_appointment_uuid_type.py',
-    '2026_02_19_0842-17792ef315c1_remove_invites_and_waiting_list_.py',
-    '2026_06_15_1200-d4e5f6a7b8c9_add_owner_id_scoped_schedule_slug.py',
-})
+GRANDFATHERED = frozenset(
+    {
+        '2023_07_27_1102-f9c5471478d0_modify_schedules_table.py',
+        '2024_03_13_1621-f92bae6c27da_update_subscribers_table_to_.py',
+        '2024_06_13_1525-f732d6e597fe_update_appointments_make_uuid_.py',
+        '2024_06_25_2133-156b3b0d77b9_add_ftue_level_to_subscribers.py',
+        '2024_12_20_1733-0c99f6a02f3b_make_subscribers_language_not_.py',
+        '2025_01_15_1340-4a15d01919b8_add_config_fields_to_subscribers_table.py',
+        '2025_04_04_1536-666158eab217_add_start_of_week_user_setting.py',
+        '2025_05_13_0837-ceecffbb5eb5_update_availabilities_table.py',
+        '2025_06_26_1629-88dbe32dc40d_switch_appointment_uuid_type.py',
+        '2026_02_19_0842-17792ef315c1_remove_invites_and_waiting_list_.py',
+        '2026_06_15_1200-d4e5f6a7b8c9_add_owner_id_scoped_schedule_slug.py',
+    }
+)
 
 
 def _blocking_flagged() -> set[str]:
     return {
         p.name
         for p in checker.VERSIONS_DIR.glob('*.py')
-        if p.name != '__init__.py'
-        and any(f.blocking for f in checker.check_file(p)[0])
+        if p.name != '__init__.py' and any(f.blocking for f in checker.check_file(p)[0])
     }
 
 

--- a/backend/test/unit/test_migration_additivity.py
+++ b/backend/test/unit/test_migration_additivity.py
@@ -1,24 +1,34 @@
 """Tests for scripts/check_migration_additivity.py (the CI expand/contract gate).
 
-The gate is only useful if it is well calibrated: a false positive on an ordinary
-additive migration teaches people to ignore it, and a false negative defeats the
-point. These tests pin both directions.
+A gate is only useful if it is well calibrated in BOTH directions: a false
+positive on an ordinary additive migration teaches people to ignore it, and a
+false negative defeats the point. These tests pin both, and are deliberately
+written so that a checker which silently stops working fails the suite rather
+than passing vacuously.
 """
 
 import ast
 import importlib.util
 import pathlib
+import sys
+from urllib.parse import urlparse
 
 import pytest
 
 _SCRIPT = pathlib.Path(__file__).resolve().parents[2] / 'scripts/check_migration_additivity.py'
+assert _SCRIPT.is_file(), f'checker script not found at {_SCRIPT}'
 _spec = importlib.util.spec_from_file_location('check_migration_additivity', _SCRIPT)
 checker = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = checker
 _spec.loader.exec_module(checker)
 
 
 def rules(source: str) -> list[str]:
-    return [f.rule for f in checker.check_upgrade(ast.parse(source))]
+    return [f.rule for f in checker.check_upgrade(ast.parse(source)) if f.blocking]
+
+
+def notes(source: str) -> list[str]:
+    return [f.rule for f in checker.check_upgrade(ast.parse(source)) if not f.blocking]
 
 
 def wrap(upgrade_body: str, downgrade_body: str = 'pass') -> str:
@@ -38,28 +48,55 @@ def test_add_not_null_column_with_server_default_is_additive():
 
 def test_create_table_with_not_null_columns_is_additive():
     """A brand-new table cannot break replicas that do not know it exists."""
-    src = wrap("op.create_table('t', sa.Column('c', sa.String, nullable=False))")
+    assert rules(wrap("op.create_table('t', sa.Column('c', sa.String, nullable=False))")) == []
+
+
+def test_unique_index_on_a_table_created_here_is_additive():
+    src = wrap("op.create_table('t', sa.Column('c', sa.String))\n    "
+               "op.create_index('i', 't', ['c'], unique=True)")
     assert rules(src) == []
 
 
 def test_existing_nullable_is_not_a_change():
     """`existing_nullable=` describes current state; it is not a narrowing."""
-    src = wrap("op.alter_column('t', 'c', type_=sa.String(64), existing_nullable=False)")
+    assert rules(wrap("op.alter_column('t', 'c', type_=sa.String(64), existing_nullable=False)")) == []
+
+
+def test_widening_a_type_is_additive():
+    src = wrap("op.alter_column('t', 'c', type_=sa.String(255), existing_type=sa.String(64))")
     assert rules(src) == []
 
 
 def test_destructive_ddl_in_downgrade_is_ignored():
     """Alembic autogenerates a mirror-image downgrade(); the deploy never runs it.
 
-    This is the single most important false-positive guard: without it, every
-    ordinary add_column migration would be flagged.
+    The single most important false-positive guard: without it, every ordinary
+    add_column migration would be flagged.
     """
     src = wrap("op.add_column('t', sa.Column('c', sa.String, nullable=True))", "op.drop_column('t', 'c')")
     assert rules(src) == []
 
 
+def test_helper_called_only_from_downgrade_is_ignored():
+    src = ('def _cleanup():\n    op.drop_table("t")\n\n\n'
+           'def upgrade():\n    op.add_column("t", sa.Column("c", sa.String))\n\n\n'
+           'def downgrade():\n    _cleanup()\n')
+    assert rules(src) == []
+
+
+def test_index_swap_is_not_flagged():
+    """drop_index + create_index on the same table is one logical operation."""
+    src = wrap("op.drop_index('i', 't')\n    op.create_index('i', 't', ['c'])")
+    assert 'op.drop_index' not in rules(src)
+
+
 def test_non_destructive_execute_is_additive():
     assert rules(wrap("op.execute(\"UPDATE t SET c = 'x' WHERE c IS NULL\")")) == []
+
+
+def test_add_column_raw_sql_is_additive():
+    """The expand-phase statement the gate itself recommends must not be flagged."""
+    assert rules(wrap("op.execute('ALTER TABLE t ADD COLUMN c INT NOT NULL DEFAULT 0')")) == []
 
 
 # --- non-additive: must be flagged -------------------------------------------------
@@ -72,7 +109,7 @@ def test_non_destructive_execute_is_additive():
         ("op.drop_constraint('c', 't')", 'op.drop_constraint'),
         ("op.drop_index('i', 't')", 'op.drop_index'),
         ("op.rename_table('a', 'b')", 'op.rename_table'),
-        ("op.create_unique_constraint('u', 't', ['c'])", 'op.create_unique_constraint'),
+        ("op.create_unique_constraint('u', 't', ['c'])", 'op.create_unique_constraint (unique)'),
     ],
 )
 def test_destructive_ops_are_flagged(body, expected):
@@ -81,6 +118,16 @@ def test_destructive_ops_are_flagged(body, expected):
 
 def test_narrowing_to_not_null_is_flagged():
     assert 'op.alter_column(nullable=False)' in rules(wrap("op.alter_column('t', 'c', nullable=False)"))
+
+
+def test_narrowing_a_type_is_flagged():
+    src = wrap("op.alter_column('t', 'c', type_=sa.String(50), existing_type=sa.String(255))")
+    assert 'op.alter_column(<narrowing type>)' in rules(src)
+
+
+def test_removing_a_server_default_is_flagged():
+    src = wrap("op.alter_column('t', 'c', server_default=None, existing_server_default='0')")
+    assert 'op.alter_column(server_default=None)' in rules(src)
 
 
 def test_column_rename_is_flagged():
@@ -94,24 +141,33 @@ def test_add_not_null_without_server_default_is_flagged():
     assert any('add_column' in r for r in rules(src))
 
 
-def test_unique_index_is_flagged():
-    src = wrap("op.create_index('i', 't', ['c'], unique=True)")
-    assert 'op.create_index(unique=True)' in rules(src)
+def test_explicit_server_default_none_does_not_satisfy_the_rule():
+    src = wrap("op.add_column('t', sa.Column('c', sa.Integer, nullable=False, server_default=None))")
+    assert any('add_column' in r for r in rules(src))
 
 
-def test_batch_alter_table_is_flagged():
-    """batch mode recreates the table, and also hides op.* calls from the scan."""
+def test_unique_index_on_existing_table_is_flagged():
+    assert 'op.create_index (unique)' in rules(wrap("op.create_index('i', 't', ['c'], unique=True)"))
+
+
+def test_destructive_batch_alter_is_flagged():
     src = 'def upgrade():\n    with op.batch_alter_table("t") as b:\n        b.drop_column("c")\n'
-    assert 'op.batch_alter_table' in rules(src)
+    assert 'op.batch_alter_table(<destructive>)' in rules(src)
+
+
+def test_additive_batch_alter_is_not_flagged():
+    src = ('def upgrade():\n    with op.batch_alter_table("t") as b:\n'
+           '        b.add_column(sa.Column("c", sa.String))\n')
+    assert rules(src) == []
 
 
 @pytest.mark.parametrize(
     'sql',
     [
         'ALTER TABLE `t` DROP COLUMN `c`',
-        'ALTER TABLE `t` MODIFY COLUMN `c` int NOT NULL',
         'DROP TABLE t',
-        'TRUNCATE t',
+        'TRUNCATE TABLE t',
+        'ALTER TABLE t RENAME COLUMN a TO b',
     ],
 )
 def test_destructive_raw_sql_is_flagged(sql):
@@ -119,47 +175,136 @@ def test_destructive_raw_sql_is_flagged(sql):
     assert any('execute' in r for r in rules(wrap(f'op.execute("{sql}")')))
 
 
+@pytest.mark.parametrize(
+    'stmt',
+    [
+        'op.get_bind().execute(sa.text("DROP TABLE t"))',
+        'session.execute(sa.text("DROP TABLE t"))',
+        'connection.execute("DROP TABLE t")',
+    ],
+)
+def test_raw_sql_on_any_receiver_is_flagged(stmt):
+    """op.get_bind()/Session is the most-used raw-SQL path in this repo."""
+    assert any('execute' in r for r in rules(wrap(stmt)))
+
+
+def test_destructive_op_in_a_helper_is_flagged():
+    """Factoring a drop into a helper is house style here; it must not hide it."""
+    src = ('def _cleanup(conn):\n    op.drop_index("i", "t")\n\n\n'
+           'def upgrade():\n    _cleanup(op.get_bind())\n\n\ndef downgrade():\n    pass\n')
+    assert 'op.drop_index' in rules(src)
+
+
+def test_missing_upgrade_is_flagged_not_ignored():
+    """A file the checker cannot understand must never be a silent pass."""
+    assert 'no upgrade() found' in rules('def upgade():\n    op.drop_table("t")\n')
+
+
+# --- non-blocking notes ------------------------------------------------------------
+
+def test_enum_change_is_a_note_not_a_block():
+    """Appending an enum value is additive; removing one is not, and the member
+    list is usually interpolated, so it cannot be decided statically."""
+    src = wrap("op.execute(f'ALTER TABLE `t` MODIFY COLUMN `c` enum({vals}) NOT NULL')")
+    assert rules(src) == []
+    assert 'execute(<enum change>)' in notes(src)
+
+
+def test_dynamic_sql_is_a_note_not_a_block():
+    src = wrap("op.execute(some_statement)")
+    assert rules(src) == []
+
+
 # --- exemption ---------------------------------------------------------------------
 
-def test_exemption_with_url_passes(tmp_path):
+def test_exemption_with_valid_url_and_reason_waives(tmp_path):
     p = tmp_path / 'm.py'
     p.write_text(
-        '# additivity-exempt: https://example.com/issues/1 unused since v1.9\n'
+        '# additivity-exempt: https://github.com/thunderbird/appointment/issues/1 unused since v1.9\n'
         + wrap("op.drop_table('t')")
     )
-    findings, exempt = checker.check_file(p)
-    assert findings == [] and exempt and 'example.com' in exempt
+    findings, waiver = checker.check_file(p)
+    assert waiver is not None
+    parsed = urlparse(waiver.split()[0])
+    assert parsed.scheme == 'https' and parsed.netloc == 'github.com'
+    # The waiver must still report what it is waiving, so it stays auditable.
+    assert any('drop_table' in f.rule for f in findings)
 
 
-def test_exemption_without_url_is_rejected(tmp_path):
+@pytest.mark.parametrize(
+    'marker',
+    [
+        '# additivity-exempt: trust-me a good reason here',           # not a URL
+        '# additivity-exempt: https:// a good reason here',           # bare scheme
+        '# additivity-exempt: https://evil.example/1 a good reason',  # wrong host
+        '# additivity-exempt: https://github.com/thunderbird/appointment/issues/1',  # no reason
+    ],
+)
+def test_invalid_exemptions_are_rejected(tmp_path, marker):
     p = tmp_path / 'm.py'
-    p.write_text('# additivity-exempt: trust-me\n' + wrap("op.drop_table('t')"))
-    findings, exempt = checker.check_file(p)
-    assert exempt is None
-    assert findings and 'URL' in findings[0].rule
+    p.write_text(marker + '\n' + wrap("op.drop_table('t')"))
+    findings, waiver = checker.check_file(p)
+    assert waiver is None
+    assert any('invalid additivity-exempt' in f.rule for f in findings)
+
+
+def test_exemption_inside_a_docstring_does_not_count(tmp_path):
+    """The marker must be a real comment, not text in a string."""
+    p = tmp_path / 'm.py'
+    p.write_text(
+        '"""docs\n# additivity-exempt: https://github.com/thunderbird/appointment/issues/1 reason here\n"""\n'
+        + wrap("op.drop_table('t')")
+    )
+    findings, waiver = checker.check_file(p)
+    assert waiver is None
+    assert any('drop_table' in f.rule for f in findings)
 
 
 # --- calibration against the real corpus -------------------------------------------
+#
+# Migrations that predate this gate and are non-additive in upgrade(). New
+# migrations must be additive or carry an exemption. Both directions are asserted
+# so that a checker which stops flagging anything FAILS rather than passing.
 
-def test_existing_migrations_are_stable():
-    """The committed migrations must not change verdict unexpectedly.
+GRANDFATHERED = frozenset({
+    '2023_07_27_1102-f9c5471478d0_modify_schedules_table.py',
+    '2024_03_13_1621-f92bae6c27da_update_subscribers_table_to_.py',
+    '2024_06_13_1525-f732d6e597fe_update_appointments_make_uuid_.py',
+    '2024_06_25_2133-156b3b0d77b9_add_ftue_level_to_subscribers.py',
+    '2024_12_20_1733-0c99f6a02f3b_make_subscribers_language_not_.py',
+    '2025_01_15_1340-4a15d01919b8_add_config_fields_to_subscribers_table.py',
+    '2025_04_04_1536-666158eab217_add_start_of_week_user_setting.py',
+    '2025_05_13_0837-ceecffbb5eb5_update_availabilities_table.py',
+    '2025_06_26_1629-88dbe32dc40d_switch_appointment_uuid_type.py',
+    '2026_02_19_0842-17792ef315c1_remove_invites_and_waiting_list_.py',
+    '2026_06_15_1200-d4e5f6a7b8c9_add_owner_id_scoped_schedule_slug.py',
+})
 
-    Guards the calibration: if a future ruleset change starts flagging the
-    historical additive migrations, this fails loudly instead of in someone's PR.
-    """
-    flagged = sorted(
-        p.name for p in checker.VERSIONS_DIR.glob('*.py')
-        if p.name != '__init__.py' and checker.check_file(p)[0]
-    )
-    # Historical migrations that are genuinely non-additive in upgrade(). They
-    # predate this gate; new migrations must be additive or carry an exemption.
-    assert all(
-        any(tok in name for tok in (
-            'f9c5471478d0', 'f92bae6c27da', '88dbe32dc40d', '17792ef315c1',  # drop_*
-            'f732d6e597fe',                                                   # drop_index + unique
-            '7f8b4f463f1d', '71cf5d3ee14b', 'a3fc3cc13f56', 'fb27de54e731',   # raw DDL
-            '156b3b0d77b9', '4a15d01919b8', '666158eab217',                   # NOT NULL, no default
-            '0c99f6a02f3b', 'ceecffbb5eb5', 'd4e5f6a7b8c9',                   # narrowing / unique
-        ))
-        for name in flagged
-    ), f'unexpected migration flagged: {flagged}'
+
+def _blocking_flagged() -> set[str]:
+    return {
+        p.name
+        for p in checker.VERSIONS_DIR.glob('*.py')
+        if p.name != '__init__.py'
+        and any(f.blocking for f in checker.check_file(p)[0])
+    }
+
+
+def test_corpus_is_non_empty():
+    """Guards against VERSIONS_DIR resolving somewhere wrong, which would make
+    every calibration assertion below pass over zero files."""
+    found = [p for p in checker.VERSIONS_DIR.glob('*.py') if p.name != '__init__.py']
+    assert len(found) >= 60, f'only {len(found)} migrations found; VERSIONS_DIR may be wrong'
+
+
+def test_no_new_non_additive_migrations():
+    """New migrations must be additive, or carry an exemption."""
+    unexpected = _blocking_flagged() - GRANDFATHERED
+    assert unexpected == set(), f'non-additive migration(s) added without an exemption: {sorted(unexpected)}'
+
+
+def test_grandfathered_migrations_are_still_detected():
+    """Non-vacuous regression guard: if a ruleset change stops catching the known
+    offenders, this fails -- unlike a subset assertion, which passes on an empty set."""
+    missed = {n for n in GRANDFATHERED if (checker.VERSIONS_DIR / n).is_file()} - _blocking_flagged()
+    assert missed == set(), f'ruleset regression -- no longer flagged: {sorted(missed)}'

--- a/backend/test/unit/test_migration_additivity.py
+++ b/backend/test/unit/test_migration_additivity.py
@@ -1,0 +1,165 @@
+"""Tests for scripts/check_migration_additivity.py (the CI expand/contract gate).
+
+The gate is only useful if it is well calibrated: a false positive on an ordinary
+additive migration teaches people to ignore it, and a false negative defeats the
+point. These tests pin both directions.
+"""
+
+import ast
+import importlib.util
+import pathlib
+
+import pytest
+
+_SCRIPT = pathlib.Path(__file__).resolve().parents[2] / 'scripts/check_migration_additivity.py'
+_spec = importlib.util.spec_from_file_location('check_migration_additivity', _SCRIPT)
+checker = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(checker)
+
+
+def rules(source: str) -> list[str]:
+    return [f.rule for f in checker.check_upgrade(ast.parse(source))]
+
+
+def wrap(upgrade_body: str, downgrade_body: str = 'pass') -> str:
+    return f'def upgrade():\n    {upgrade_body}\n\n\ndef downgrade():\n    {downgrade_body}\n'
+
+
+# --- additive: must NOT be flagged -------------------------------------------------
+
+def test_add_nullable_column_is_additive():
+    assert rules(wrap("op.add_column('t', sa.Column('c', sa.String, nullable=True))")) == []
+
+
+def test_add_not_null_column_with_server_default_is_additive():
+    src = wrap("op.add_column('t', sa.Column('c', sa.Boolean, nullable=False, server_default=false()))")
+    assert rules(src) == []
+
+
+def test_create_table_with_not_null_columns_is_additive():
+    """A brand-new table cannot break replicas that do not know it exists."""
+    src = wrap("op.create_table('t', sa.Column('c', sa.String, nullable=False))")
+    assert rules(src) == []
+
+
+def test_existing_nullable_is_not_a_change():
+    """`existing_nullable=` describes current state; it is not a narrowing."""
+    src = wrap("op.alter_column('t', 'c', type_=sa.String(64), existing_nullable=False)")
+    assert rules(src) == []
+
+
+def test_destructive_ddl_in_downgrade_is_ignored():
+    """Alembic autogenerates a mirror-image downgrade(); the deploy never runs it.
+
+    This is the single most important false-positive guard: without it, every
+    ordinary add_column migration would be flagged.
+    """
+    src = wrap("op.add_column('t', sa.Column('c', sa.String, nullable=True))", "op.drop_column('t', 'c')")
+    assert rules(src) == []
+
+
+def test_non_destructive_execute_is_additive():
+    assert rules(wrap("op.execute(\"UPDATE t SET c = 'x' WHERE c IS NULL\")")) == []
+
+
+# --- non-additive: must be flagged -------------------------------------------------
+
+@pytest.mark.parametrize(
+    'body,expected',
+    [
+        ("op.drop_column('t', 'c')", 'op.drop_column'),
+        ("op.drop_table('t')", 'op.drop_table'),
+        ("op.drop_constraint('c', 't')", 'op.drop_constraint'),
+        ("op.drop_index('i', 't')", 'op.drop_index'),
+        ("op.rename_table('a', 'b')", 'op.rename_table'),
+        ("op.create_unique_constraint('u', 't', ['c'])", 'op.create_unique_constraint'),
+    ],
+)
+def test_destructive_ops_are_flagged(body, expected):
+    assert expected in rules(wrap(body))
+
+
+def test_narrowing_to_not_null_is_flagged():
+    assert 'op.alter_column(nullable=False)' in rules(wrap("op.alter_column('t', 'c', nullable=False)"))
+
+
+def test_column_rename_is_flagged():
+    src = wrap("op.alter_column('t', 'old', new_column_name='new')")
+    assert 'op.alter_column(new_column_name=...)' in rules(src)
+
+
+def test_add_not_null_without_server_default_is_flagged():
+    """`default=` is SQLAlchemy client-side only and emits no DDL default."""
+    src = wrap("op.add_column('t', sa.Column('c', sa.Integer, default=0, nullable=False))")
+    assert any('add_column' in r for r in rules(src))
+
+
+def test_unique_index_is_flagged():
+    src = wrap("op.create_index('i', 't', ['c'], unique=True)")
+    assert 'op.create_index(unique=True)' in rules(src)
+
+
+def test_batch_alter_table_is_flagged():
+    """batch mode recreates the table, and also hides op.* calls from the scan."""
+    src = 'def upgrade():\n    with op.batch_alter_table("t") as b:\n        b.drop_column("c")\n'
+    assert 'op.batch_alter_table' in rules(src)
+
+
+@pytest.mark.parametrize(
+    'sql',
+    [
+        'ALTER TABLE `t` DROP COLUMN `c`',
+        'ALTER TABLE `t` MODIFY COLUMN `c` int NOT NULL',
+        'DROP TABLE t',
+        'TRUNCATE t',
+    ],
+)
+def test_destructive_raw_sql_is_flagged(sql):
+    """Raw SQL is the obvious way to sidestep an op.*-only ruleset."""
+    assert any('execute' in r for r in rules(wrap(f'op.execute("{sql}")')))
+
+
+# --- exemption ---------------------------------------------------------------------
+
+def test_exemption_with_url_passes(tmp_path):
+    p = tmp_path / 'm.py'
+    p.write_text(
+        '# additivity-exempt: https://example.com/issues/1 unused since v1.9\n'
+        + wrap("op.drop_table('t')")
+    )
+    findings, exempt = checker.check_file(p)
+    assert findings == [] and exempt and 'example.com' in exempt
+
+
+def test_exemption_without_url_is_rejected(tmp_path):
+    p = tmp_path / 'm.py'
+    p.write_text('# additivity-exempt: trust-me\n' + wrap("op.drop_table('t')"))
+    findings, exempt = checker.check_file(p)
+    assert exempt is None
+    assert findings and 'URL' in findings[0].rule
+
+
+# --- calibration against the real corpus -------------------------------------------
+
+def test_existing_migrations_are_stable():
+    """The committed migrations must not change verdict unexpectedly.
+
+    Guards the calibration: if a future ruleset change starts flagging the
+    historical additive migrations, this fails loudly instead of in someone's PR.
+    """
+    flagged = sorted(
+        p.name for p in checker.VERSIONS_DIR.glob('*.py')
+        if p.name != '__init__.py' and checker.check_file(p)[0]
+    )
+    # Historical migrations that are genuinely non-additive in upgrade(). They
+    # predate this gate; new migrations must be additive or carry an exemption.
+    assert all(
+        any(tok in name for tok in (
+            'f9c5471478d0', 'f92bae6c27da', '88dbe32dc40d', '17792ef315c1',  # drop_*
+            'f732d6e597fe',                                                   # drop_index + unique
+            '7f8b4f463f1d', '71cf5d3ee14b', 'a3fc3cc13f56', 'fb27de54e731',   # raw DDL
+            '156b3b0d77b9', '4a15d01919b8', '666158eab217',                   # NOT NULL, no default
+            '0c99f6a02f3b', 'ceecffbb5eb5', 'd4e5f6a7b8c9',                   # narrowing / unique
+        ))
+        for name in flagged
+    ), f'unexpected migration flagged: {flagged}'


### PR DESCRIPTION
**Draft — feedback welcome before this becomes a required check.**

Blocks a PR from adding an Alembic migration that isn't expand/contract safe.

### Why

For a window during every deploy, the OLD and NEW replicas run against the SAME database, and **a schema change cannot be undone by aborting the deploy**. So migrations must only ADD; removals ship a release later.

That window is short and incidental on today's ECS rolling deploy. It gets long and deliberate under the Argo Rollouts **blue-green** deploy going up on EKS tb-dev/tb-prod (thunderbird/platform-infrastructure#781) — which also adds an abort path that looks like a rollback but can't undo DDL. This is groundwork for that.

### Why pre-merge, not at deploy time

We built the deploy-time version first and **it can't work**: `backend/scripts/entry.sh` runs `alembic upgrade head` *before uvicorn binds*, and Rollouts only runs pre-promotion analysis once pods are **Ready**. The migration has already landed by then. Pre-merge is the last point at which it hasn't run anywhere.

### What's flagged

`upgrade()` only, following module-level helpers it calls (the repo's newest migration already hides a `drop_index` in one):

`drop_column` / `drop_table` / `drop_constraint` / `drop_index` / `rename_table` · `alter_column` rename, narrowing, or dropped default · `add_column(nullable=False)` with no `server_default` · unique index/constraint on an existing table · destructive `batch_alter_table` · `.execute()` with destructive raw SQL, on any receiver.

**Not flagged:** `NOT NULL`/unique on a table created in the same migration · `existing_nullable=` · `add_column(nullable=False, server_default=...)`. Enum widenings print as non-blocking notes.

### Calibration

**67 existing migrations: 56 pass, 11 blocking.** Existing migrations are untouched — CI only looks at what a branch changes. (A regex over whole files flags ~45; most are the autogenerated destructive `downgrade()` on an ordinary `add_column`. The AST scoping is what makes this usable.)

### Escape hatch

```python
# additivity-exempt: https://github.com/thunderbird/appointment/issues/1234
#   invites table; nothing has referenced it since v1.9
```
Thunderbird issue/PR URL + reason required, honoured only in a real comment token. Waived findings are still printed. Prefer splitting into expand/contract.

### Proof it fires

This PR adds no migrations, so its own run reports "nothing to check" — the checker invocation path never executes here. #1771 (throwaway, now closed) added one deliberately non-additive migration to exercise it.

**[`migration-additivity` — red in 7s](https://github.com/thunderbird/appointment/actions/runs/30303787275/job/90102983416)**

```
Migrations to check:
  src/appointment/migrations/versions/..._demo_non_additive.py
FAIL   not additive
  line 29: op.add_column(nullable=False) without server_default
     why: old replicas' INSERTs omit the column, so they fail
     fix: Add server_default=... (SQLAlchemy's default= is client-side, emits no DDL default)
  line 31: execute(<destructive SQL>)
     why: raw SQL contains 'ALTER TABLE subscribers DROP'
     fix: Defer the destructive statement to a later release.
  line 22: op.drop_column
     why: drops a column the old replicas may still SELECT
     fix: Ship the removal in a LATER release (contract phase).
```

<details><summary>the migration it was run against</summary>

```python
def _tidy_up():
    """Hidden in a helper on purpose: proves the scan follows call graphs."""
    op.drop_column('subscribers', 'ftue_level')

def upgrade() -> None:
    _tidy_up()                                              # 1. destructive, via helper
    op.add_column('subscribers',
                  sa.Column('demo_flag', sa.Boolean(), nullable=False))   # 2. NOT NULL, no default
    op.get_bind().execute(                                  # 3. raw DDL, non-`op` receiver
        sa.text('ALTER TABLE subscribers DROP COLUMN avatar_url'))

def downgrade() -> None:
    op.drop_column('subscribers', 'demo_flag')              # destructive, must NOT be flagged
```

</details>

The destructive `downgrade()` was correctly ignored. The corpus calibration test caught it independently too (`1 failed, 491 passed`), which shows that test isn't vacuous.

### Two things for the team

1. `main` has **no required status checks** — this is advisory until `migration-additivity` is added to branch protection.
2. `concurrency: group: validate` isn't ref-scoped, so a push on one branch cancels in-flight runs on another.

Context: thunderbird/platform-infrastructure#781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


