### PR TITLE
DEMO - DO NOT MERGE: prove the additivity gate goes red (#1770)

### DIFF
--- a/backend/src/appointment/migrations/versions/2026_07_27_1200-deadbeef0001_demo_non_additive.py
+++ b/backend/src/appointment/migrations/versions/2026_07_27_1200-deadbeef0001_demo_non_additive.py
@@ -1,0 +1,36 @@
+"""DEMO ONLY - deliberately non-additive. Do not merge.
+
+Exists to prove the `migration-additivity` CI job actually goes red.
+See thunderbird/appointment#1770.
+
+Revision ID: deadbeef0001
+Revises: d4e5f6a7b8c9
+Create Date: 2026-07-27 12:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = 'deadbeef0001'
+down_revision = 'd4e5f6a7b8c9'
+branch_labels = None
+depends_on = None
+
+
+def _tidy_up():
+    """Hidden in a helper on purpose: proves the scan follows call graphs."""
+    op.drop_column('subscribers', 'ftue_level')
+
+
+def upgrade() -> None:
+    # 1. destructive call reached only via a helper
+    _tidy_up()
+    # 2. NOT NULL with no server_default -> old replicas' INSERTs start failing
+    op.add_column('subscribers', sa.Column('demo_flag', sa.Boolean(), nullable=False))
+    # 3. raw DDL through a non-`op` receiver
+    op.get_bind().execute(sa.text('ALTER TABLE subscribers DROP COLUMN avatar_url'))
+
+
+def downgrade() -> None:
+    # Destructive, but never executed by a deploy -> must NOT be flagged.
+    op.drop_column('subscribers', 'demo_flag')


### PR DESCRIPTION
Throwaway. Will be closed and the branch deleted as soon as CI reports.

#1770 adds no migrations, so its own `migration-additivity` run says "nothing to check" and never exercises the checker invocation path. This branch adds one deliberately non-additive migration so the job actually fires.

Expected: **`migration-additivity` red** with three findings, and the destructive `downgrade()` **not** flagged.

Evidence for https://github.com/thunderbird/appointment/pull/1770.