### PR TITLE
fix(frontend): scope nginx root to server + add cache-control headers

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -120,6 +120,25 @@ jobs:
         run: |
           cd ./frontend && npm run test -- --run
 
+  # `nginx -t` is necessary but NOT sufficient: mis-scoping an add_header or
+  # breaking the /assets/ match is syntactically valid and only fails at request
+  # time. A *total* root mis-scope is not the gap -- that one fails closed, since
+  # / itself 404s and the rollout's readiness probe never goes green. The gap is
+  # breakage confined to /assets/, or a wrong or leaked Cache-Control value on a
+  # path that still returns 200: neither the readiness probe nor the synthetic
+  # analysis can see those, so they promote green. Runs the shipped conf in a stock
+  # nginx image over a synthetic dist tree: no npm build, no registry auth, no
+  # AWS creds.
+  validate-frontend-nginx:
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    if: needs.detect-changes.outputs.validate-frontend == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test nginx config behaviour
+        run: ./frontend/docker/test-nginx-config.sh
+
   validate-pulumi:
     needs: detect-changes
     runs-on: ubuntu-latest

--- a/frontend/docker/etc/nginx/conf.d/appointments.conf
+++ b/frontend/docker/etc/nginx/conf.d/appointments.conf
@@ -1,9 +1,64 @@
+# JSON access log. CloudFront sets X-Cache on egress, so the origin cannot log
+# it. X-Amz-Cf-Id is the ONLY CloudFront correlation header that reaches an
+# origin -- X-Amz-Cf-Pop is a viewer-response header and never arrives here, so
+# it is deliberately not a field below.
+#
+# CORRELATING A USER: today, read remote_addr. real_ip has already resolved it to
+# the address the ALB observed, and the ALB is the only proxy in front of this pod.
+# Do NOT read the LEFTMOST element of x_forwarded_for: that entry is whatever the
+# viewer sent, so it is the one hop in the chain an attacker fully controls.
+#
+# Once CloudFront fronts this origin, the trustworthy element becomes the
+# rightmost-but-one element of x_forwarded_for -- the hop CloudFront itself
+# appended -- or forward CloudFront-Viewer-Address and read that instead.
+# Everything to the LEFT of the last proxy-appended hop is viewer-supplied and
+# must never be used for attribution, rate limiting, or authorization.
+# x_forwarded_for is logged below as the raw claimed chain, not as an identity.
+#
+# Relatedly, user_agent reads literally "Amazon CloudFront" on any CDN behavior
+# that does not forward the viewer's User-Agent.
+log_format appointment_json escape=json
+    '{'
+    '"time":"$time_iso8601",'
+    '"remote_addr":"$remote_addr",'
+    '"x_forwarded_for":"$http_x_forwarded_for",'
+    '"cf_id":"$http_x_amz_cf_id",'
+    '"request":"$request",'
+    '"status":$status,'
+    '"body_bytes_sent":$body_bytes_sent,'
+    '"request_time":$request_time,'
+    '"upstream_response_time":"$upstream_response_time",'
+    '"user_agent":"$http_user_agent"'
+    '}';
+
+# $remote_addr is the private IP of whatever proxied the request -- an in-VPC ALB
+# in every environment -- so resolve the client from X-Forwarded-For.
+#
+# Trust RFC1918 10/8, NOT one environment's VPC CIDR: this single image is
+# promoted unchanged across five different /16s (EKS tb-dev 10.120, tb-prod
+# 10.130; ECS dev/stage/prod 10.22/10.21/10.20) and the entrypoint has no hook to
+# rewrite this value. A narrower literal silently no-ops in every environment but
+# one while `nginx -t` passes and every probe stays green. The trade is that any
+# in-VPC peer that reaches this pod directly can spoof X-Forwarded-For; these
+# fields are for correlation only -- never authorize or rate-limit on them.
+#
+# http scope, not server: the shortlink vhost at the bottom needs it too.
+set_real_ip_from 10.0.0.0/8;
+real_ip_header X-Forwarded-For;
+real_ip_recursive on;
+
 server {
     listen       80;
     listen  [::]:80;
     server_name  localhost;
 
-    #access_log  /var/log/nginx/host.access.log  main;
+    # MUST stay at server scope: declared inside `location /` it does not reach
+    # sibling locations, which then inherit the compiled-in default root
+    # (/etc/nginx/html, absent from nginx:stable) and 404 everything they serve
+    # -- while `nginx -t` still passes.
+    root   /usr/share/nginx/html;
+
+    access_log  /var/log/nginx/access.log  appointment_json;
 
     # Backend API proxy
     location ^~ /api/v1/ {
@@ -21,9 +76,51 @@ server {
         proxy_set_header Host $http_host;
         proxy_http_version 1.1;
     }
+    # NOTE: an add_header inside a location silently DROPS every parent-scope
+    # add_header. If HSTS/CSP are ever added at server scope they must be
+    # repeated in each location below, or they vanish on exactly the SPA shell
+    # and the bundle.
+
+    # Content-hashed Vite bundles. Short TTL for now; raised to
+    # `public, max-age=31536000, immutable` in a follow-up once this location
+    # matching has been verified against the running pod.
+    location ^~ /assets/ {
+        # Deliberately no `always`: the =404 below must not carry this header,
+        # or a missing asset gets cached for the full TTL.
+        add_header Cache-Control "public, max-age=300";
+        # 404 a missing asset instead of falling through to the SPA shell.
+        try_files $uri =404;
+
+        # MUST be nested: the ^~ above short-circuits top-level regex
+        # locations, so a sibling .map guard would never fire.
+        location ~ \.map$ {
+            return 404;
+        }
+    }
+
+    # The SPA shell is the deploy pointer -- never cache it. `no-store` over
+    # `no-cache` is deliberate: it is the only directive that also keeps the shell
+    # out of shared/CDN storage, and at ~1.6 KB the 304 revalidation it forfeits
+    # is not worth the risk of a stored pointer to a deleted bundle.
+    location = /index.html {
+        add_header Cache-Control "no-store";
+    }
+    # Runtime config, rewritten by docker-entrypoint.d on every boot.
+    location = /config.js {
+        add_header Cache-Control "no-store";
+    }
+    # Stock nginx:stable mime.types has no .webmanifest entry, so this would
+    # otherwise be served as application/octet-stream.
+    location = /site.webmanifest {
+        default_type application/manifest+json;
+        add_header Cache-Control "public, max-age=300";
+    }
     # Frontend Vue static files
     location / {
-        root   /usr/share/nginx/html;
+        # Unhashed root files (favicon*, apple-touch-icon, android-chrome-*,
+        # sitemap.txt) get a deliberate short TTL rather than inheriting
+        # CloudFront's 24h default.
+        add_header Cache-Control "public, max-age=300";
         try_files $uri $uri/ /index.html;
         #auth_basic "Restricted Content";
         #auth_basic_user_file /etc/nginx/.htpasswd;
@@ -45,6 +142,14 @@ server {
     listen 80;
     listen [::]:80;
     server_name stage.apmt.local stage.apt.mt;
+
+    # MUST be repeated per server: this file is included INSIDE http, where an
+    # access_log does not override nginx.conf's own -- it APPENDS, logging every
+    # request twice (verified). Without this line the vhost silently falls back to
+    # the inherited combined `main` format and puts non-JSON lines into the same
+    # stdout stream a JSON log decoder is reading.
+    access_log  /var/log/nginx/access.log  appointment_json;
+
     location / {
         # Transform stage.apt.mt/<everything here> to appointment-stage.tb.pro/user/<everything moved here>
         rewrite ^(.*)$ https://appointment-stage.tb.pro/user$1 redirect;

--- a/frontend/docker/test-nginx-config.sh
+++ b/frontend/docker/test-nginx-config.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# Behavioural test for docker/etc/nginx/conf.d/appointments.conf.
+#
+# WHY THIS EXISTS: `nginx -t` only proves the config parses. Every interesting way
+# to break this file -- declaring `root` inside `location /` so sibling locations
+# 404, a mis-scoped `add_header`, an `/assets/` rule that stops matching -- is
+# syntactically valid and passes `nginx -t`.
+#
+# A *total* root mis-scope is NOT the case this script is for: that one fails
+# closed on its own. Verified in a container -- with `root` back inside
+# `location /`, `/`, `/index.html`, `/config.js`, `/user/foo` AND `/assets/*` all
+# 404 (`open() "/etc/nginx/html/index.html" failed`), because the try_files
+# fallback re-runs location matching into `location = /index.html`, which has no
+# root. The rollout's readiness probe on `/` therefore never goes green and the
+# synthetic analysis fails its very first probe.
+#
+# What neither in-cluster gate can see is breakage CONFINED TO `/assets/`, or a
+# WRONG OR LEAKED `Cache-Control` value on a path that still returns 200. Those
+# promote green -- that is what this script exists to catch.
+#
+# Runs the shipped conf in a stock nginx image over a SYNTHETIC dist tree (no
+# npm build, no registry auth, no AWS creds -- ~20s). It tests location matching
+# and headers, not the real bundle.
+#
+# Usage: frontend/docker/test-nginx-config.sh
+# Env:   NGINX_IMAGE (default docker.io/library/nginx:stable), PORT (default 18150)
+
+set -euo pipefail
+
+NGINX_IMAGE="${NGINX_IMAGE:-docker.io/library/nginx:stable}"
+PORT="${PORT:-18150}"
+NAME="appt-nginx-conftest-$$"
+
+if command -v podman >/dev/null 2>&1; then ENGINE=podman; else ENGINE=docker; fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONF_SRC="${SCRIPT_DIR}/etc/nginx/conf.d/appointments.conf"
+[ -f "$CONF_SRC" ] || { echo "FATAL: conf not found at $CONF_SRC"; exit 1; }
+
+TMP="$(mktemp -d)"
+cleanup() {
+  "$ENGINE" rm -f "$NAME" >/dev/null 2>&1 || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+# Synthetic dist tree mirroring what `vite build` emits into /usr/share/nginx/html.
+# The .js.map is present ON DISK on purpose: the guard must beat try_files.
+#
+# FIXTURE SIZES ARE LOAD-BEARING, do not shrink them. The realistic way anyone
+# enables origin gzip is `gzip on;` plus a `gzip_min_length` (1000 is the value
+# everybody copies), and nginx's DEFAULT `gzip_types` is `text/html` alone. With a
+# tiny 83-byte shell and a 23-byte bundle, every such config leaves both responses
+# uncompressed and the compression assertions below pass vacuously (verified). So:
+#   - the SPA shell is padded past 1000 bytes, which is what catches `gzip on;`
+#     with or without a `gzip_min_length` (the real shell is ~1.6 KB anyway);
+#   - the bundle is ~64 KB, which is what catches a `gzip_types` list that adds
+#     application/javascript -- there the response comes back chunked with
+#     Content-Encoding: gzip and NO Content-Length.
+#
+# Both are generated with awk rather than `yes ... | head`: under `set -o pipefail`
+# that idiom kills the script, because `yes` exits 141 on SIGPIPE once head closes.
+mkdir -p "$TMP/html/assets" "$TMP/conf"
+cp "$CONF_SRC" "$TMP/conf/default.conf"
+awk 'BEGIN {
+  print "<!doctype html><html><head><title>appt</title>";
+  pad = ""; while (length(pad) < 40) pad = pad "a";
+  for (i = 1; i <= 30; i++) printf "<meta name=\"pad-%02d\" content=\"%s\">\n", i, pad;
+  print "</head><body>SPA SHELL</body></html>";
+}' > "$TMP/html/index.html"
+printf 'window.__APP_CONFIG__ = {"apiUrl":"http://localhost"};\n' > "$TMP/html/config.js"
+awk 'BEGIN { for (i = 0; i < 4000; i++) print "console.log(1);" }' \
+  > "$TMP/html/assets/index-abc123.js"
+printf '{"version":3,"sources":[]}\n' > "$TMP/html/assets/index-abc123.js.map"
+printf 'body{color:#000}\n' > "$TMP/html/assets/index-abc123.css"
+printf '<svg xmlns="http://www.w3.org/2000/svg"></svg>\n' > "$TMP/html/favicon.svg"
+printf '{"name":"appt"}\n' > "$TMP/html/site.webmanifest"
+printf 'https://example.invalid/\n' > "$TMP/html/sitemap.txt"
+
+# conf.d mounted rw: the stock entrypoint's 10-listen-on-ipv6 script edits it.
+# Mounting the whole dir also removes the stock default.conf, avoiding a
+# duplicate :80 default_server.
+"$ENGINE" run -d --name "$NAME" -p "127.0.0.1:${PORT}:80" \
+  -v "$TMP/conf:/etc/nginx/conf.d:z" \
+  -v "$TMP/html:/usr/share/nginx/html:ro,z" \
+  "$NGINX_IMAGE" >/dev/null
+
+echo "== nginx -t =="
+"$ENGINE" exec "$NAME" nginx -t
+
+for _ in $(seq 1 30); do
+  curl -fsS -o /dev/null "http://127.0.0.1:${PORT}/" && break
+  sleep 1
+done
+
+BASE="http://127.0.0.1:${PORT}"
+FAILED=0
+pass() { printf 'PASS  %s\n' "$1"; }
+fail() { printf 'FAIL  %s\n' "$1"; FAILED=$((FAILED + 1)); }
+
+# EVERY probe offers gzip/deflate/br. Folded in here rather than bolted onto one
+# call site so that no path can quietly start compressing: origin compression must
+# be off everywhere (see the Content-Encoding assertion below), not just on the
+# bundle that happened to get the header in a previous revision of this script.
+probe_ae='Accept-Encoding: gzip, deflate, br'
+
+# probe <label> <path> <expected-status> <expected-cache-control|-> [extra curl args...]
+probe() {
+  local label="$1" path="$2" want_status="$3" want_cc="$4"; shift 4
+  local hdrs status cc enc
+  hdrs="$(curl -sS -D - -o /dev/null -H "$probe_ae" "$@" "${BASE}${path}")"
+  status="$(printf '%s' "$hdrs" | awk 'NR==1{print $2}')"
+  cc="$(printf '%s' "$hdrs" | tr -d '\r' | awk -F': ' 'tolower($1)=="cache-control"{print $2}')"
+  enc="$(printf '%s' "$hdrs" | tr -d '\r' | awk -F': ' 'tolower($1)=="content-encoding"{print $2}')"
+  local n_cc
+  n_cc="$(printf '%s' "$hdrs" | tr -d '\r' | awk -F': ' 'tolower($1)=="cache-control"' | wc -l | tr -d ' ')"
+  [ "$want_cc" = "-" ] && want_cc=""
+  if [ "$status" = "$want_status" ] && [ "$cc" = "$want_cc" ] && [ "$n_cc" -le 1 ] && [ -z "$enc" ]; then
+    pass "$label -> $status cache-control='${cc}'"
+  else
+    fail "$label -> got status=$status cache-control='${cc}' (count=$n_cc) content-encoding='${enc}', want status=$want_status cache-control='${want_cc}' content-encoding=''"
+  fi
+}
+
+echo "== cache headers =="
+probe "hashed JS"            /assets/index-abc123.js      200 "public, max-age=300"
+probe "hashed CSS"           /assets/index-abc123.css     200 "public, max-age=300"
+probe "missing asset"        /assets/missing-000.js        404 -
+probe "sourcemap (on disk)"  /assets/index-abc123.js.map   404 -
+probe "sourcemap (absent)"   /assets/nope.js.map           404 -
+probe "root"                 /                             200 "no-store"
+probe "index.html"           /index.html                   200 "no-store"
+probe "deep SPA route"       /user/foo                     200 "no-store"
+probe "config.js"            /config.js                    200 "no-store"
+probe "favicon"              /favicon.svg                  200 "public, max-age=300"
+probe "sitemap"              /sitemap.txt                  200 "public, max-age=300"
+probe "webmanifest"          /site.webmanifest             200 "public, max-age=300"
+
+echo "== content types =="
+ct() { curl -sS -o /dev/null -w '%{content_type}' "${BASE}$1"; }
+case "$(ct /site.webmanifest)" in
+  application/manifest+json*) pass "webmanifest content-type" ;;
+  *) fail "webmanifest content-type -> $(ct /site.webmanifest), want application/manifest+json" ;;
+esac
+case "$(ct /sitemap.txt)" in
+  text/plain*) pass "sitemap content-type (mime map not clobbered)" ;;
+  *) fail "sitemap content-type -> $(ct /sitemap.txt), want text/plain" ;;
+esac
+
+echo "== SPA shell served on deep route =="
+if curl -sS "${BASE}/user/foo" | grep -q 'SPA SHELL'; then
+  pass "deep route body is the SPA shell"
+else
+  fail "deep route body is NOT the SPA shell"
+fi
+
+echo "== no origin compression (edge Brotli must win) =="
+# Content-Encoding absence is already asserted on EVERY probe above, so the extra
+# assertion here is the one that actually matters for the CDN: nginx gzip switches
+# the response to chunked and DROPS Content-Length, and AWS documents that a
+# missing Content-Length can make CloudFront cache a PARTIAL object (#814). It is
+# the loss of the header, not the value of Content-Encoding, that is the hazard.
+cl="$(curl -sS -D - -o /dev/null -H "$probe_ae" "${BASE}/assets/index-abc123.js" \
+       | tr -d '\r' | awk -F': ' 'tolower($1)=="content-length"{print $2}')"
+if [ -n "$cl" ]; then
+  pass "bundle keeps Content-Length (${cl} bytes, not chunked)"
+else
+  fail "bundle has NO Content-Length -- response is chunked, CloudFront may cache a partial object"
+fi
+
+echo "== access log: JSON, populated, real_ip resolved -- both vhosts =="
+# One probe per vhost, each carrying a known X-Forwarded-For so the real_ip
+# assertion has a deterministic expected value on both server blocks.
+XFF_PROBE=203.0.113.9
+curl -sS -o /dev/null -H "X-Forwarded-For: ${XFF_PROBE}" "${BASE}/logprobe-default" || true
+curl -sS -o /dev/null -H 'Host: stage.apt.mt' -H "X-Forwarded-For: ${XFF_PROBE}" \
+  "${BASE}/logprobe-shortlink" || true
+sleep 1
+
+# Select access-log lines by EXCLUDING the things we know are not access logs
+# (entrypoint chatter, `[notice]`/`[error]` lines). An include-filter anchored on
+# `^{` would silently match nothing the moment the log_format stops being JSON, and
+# "nothing matched" must never be indistinguishable from "everything passed" --
+# that is exactly how the earlier version of this check passed with `access_log
+# off;`, with a logfmt log_format, and with fields deleted (all verified).
+LOG_LINES="$("$ENGINE" logs "$NAME" 2>&1 \
+  | grep -vE '^([0-9]{4}/[0-9]{2}/[0-9]{2} |[^ ]*\.sh: |nginx: )' \
+  | grep -vE '^[[:space:]]*$' || true)"
+
+seen=0
+bad=0
+while IFS= read -r line; do
+  [ -n "$line" ] || continue
+  seen=$((seen + 1))
+  case "$line" in
+    '{'*) ;;
+    *) bad=$((bad + 1)); echo "  non-JSON log line: $line" ;;
+  esac
+done < <(printf '%s\n' "$LOG_LINES")
+
+if [ "$seen" -eq 0 ]; then
+  fail "NO access log lines captured at all -- access_log is off, misdirected, or the format changed"
+elif [ "$bad" -ne 0 ]; then
+  fail "$bad of $seen access log line(s) are not JSON"
+else
+  pass "$seen access log line(s) captured, all JSON-shaped"
+fi
+
+if command -v jq >/dev/null 2>&1; then
+  # Every line must actually parse, not just start with a brace.
+  invalid=0
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    printf '%s' "$line" | jq -e . >/dev/null 2>&1 || {
+      invalid=$((invalid + 1)); echo "  invalid JSON: $line"; }
+  done < <(printf '%s\n' "$LOG_LINES")
+  if [ "$seen" -eq 0 ]; then
+    fail "no access log lines to parse"
+  elif [ "$invalid" -eq 0 ]; then
+    pass "every access log line parses as JSON"
+  else
+    fail "$invalid invalid JSON access log line(s) (of $seen)"
+  fi
+
+  # Field presence + real_ip resolution, asserted separately on EACH vhost: the
+  # shortlink server block needs its own `access_log` line, and real_ip is at http
+  # scope precisely so it reaches both.
+  for vh in default shortlink; do
+    line="$(printf '%s\n' "$LOG_LINES" | grep -F "logprobe-${vh}" | grep '^{' | tail -1 || true)"
+    if [ -z "$line" ]; then
+      fail "${vh} vhost: no JSON access log line for /logprobe-${vh}"
+      continue
+    fi
+    if printf '%s' "$line" | jq -e 'has("x_forwarded_for") and has("cf_id")
+          and has("request_time") and has("upstream_response_time")
+          and has("user_agent")' >/dev/null 2>&1; then
+      pass "${vh} vhost: log line has x_forwarded_for, cf_id, request_time, upstream_response_time, user_agent"
+    else
+      fail "${vh} vhost: log line is missing a required field -> $line"
+    fi
+    ra="$(printf '%s' "$line" | jq -r '.remote_addr // ""' 2>/dev/null || true)"
+    if [ "$ra" = "$XFF_PROBE" ]; then
+      pass "${vh} vhost: real_ip resolved remote_addr to ${ra} from X-Forwarded-For"
+    else
+      fail "${vh} vhost: remote_addr='${ra}', want '${XFF_PROBE}' -- set_real_ip_from/real_ip_header not in effect"
+    fi
+  done
+elif [ -n "${CI:-}" ]; then
+  # jq ships on ubuntu-latest. If it is missing in CI the assertions above did not
+  # run, and a silently-skipped assertion is the failure mode this whole section
+  # was rewritten to remove.
+  fail "jq not found but CI is set -- the log field and real_ip assertions did not run"
+else
+  echo "SKIP  jq not installed; log field + real_ip assertions skipped"
+  echo "      (line-count and JSON-shape checks above still ran and still count)"
+fi
+
+echo
+if [ "$FAILED" -eq 0 ]; then
+  echo "ALL PROBES PASSED"
+else
+  echo "$FAILED PROBE(S) FAILED"
+  exit 1
+fi


### PR DESCRIPTION
## Scope: this does NOT affect the ECS + CloudFront + S3 deployment

**Production and staging are untouched by this PR.** They do not use nginx at all — the SPA is served from S3, not from a container. Traced end to end:

- `frontend/docker/etc/nginx/conf.d/appointments.conf` has **exactly one consumer**: `frontend/deploy.dockerfile:28`.
- `frontend/deploy.dockerfile` has **exactly one builder**: `.github/workflows/publish-images.yml:69`, which publishes the multi-arch GHCR frontend image — the EKS path only.
- `deploy-production.yml:41-42` deploys the frontend with `aws s3 sync ./dist "s3://$FRONTEND_BUCKET"` + `create-invalidation`. No image, no nginx.
- `deploy-staging.yml:46-47` does the same: `aws s3 sync frontend/dist s3://$FRONTEND_BUCKET`.
- The only container build in either deploy workflow is the **backend** (`docker build ./backend -f ./backend/Dockerfile`), a different Dockerfile this PR does not touch.
- The other Dockerfile, `frontend/Dockerfile`, is the local-dev vite server and never reads the nginx config.

The conf is also not an input to `vite build`, so **the bundle is byte-for-byte unaffected** — this is a `COPY` into the nginx image and nothing else.

The other two files are equally inert for prod: `frontend/docker/test-nginx-config.sh` runs only in CI, and the `validate.yml` addition is a new job in the **PR-validation** workflow — it does not touch `deploy-production.yml` or `deploy-staging.yml`.

This is deliberate: the ECS/CloudFront/S3 pipeline stays untouched until the EKS cutover (thunderbird/platform-infrastructure#707). To be precise about what that means: this change **is** active on the EKS tb-dev deployment — that is its purpose — and inert everywhere else.

## Why

`root` was declared **inside `location /`**, which meant it never reached sibling locations. Every new location in this change that serves from disk — `/assets/`, `/index.html`, `/config.js`, `/site.webmanifest` — would have inherited nginx's compiled-in default root (`/etc/nginx/html`, which does not exist in the `nginx:stable` image) and 404'd everything it serves, while **`nginx -t` still reports success**. `root` is hoisted to server scope, with a comment recording why it must stay there. Alongside it: real `Cache-Control` headers per content class, a JSON access log on both vhosts, X-Forwarded-For client resolution, and a CI job that probes actual requests.

To be precise about the blast radius rather than overselling it: a **total** root mis-scope **fails closed**. Reproduced in a container — with `root` back inside `location /`, `/`, `/index.html`, `/config.js`, `/user/foo` **and** `/assets/*` all 404 (`open() "/etc/nginx/html/index.html" failed`), because the `try_files` fallback re-runs location matching into `location = /index.html`, which has no root. So the rollout's readiness probe on `/` never goes green and `analysis-frontend-synthetic` fails its very first probe.

What neither in-cluster gate can see is breakage **confined to `/assets/`**, or a **wrong or leaked `Cache-Control` value** on a path that still returns 200. Those promote green — and that, not the total mis-scope, is the real reason the behavioural test below exists. (The upstream issue has been corrected to match; this PR now uses the same framing.)

## Evidence — probe matrix against the real image

`podman build -f frontend/deploy.dockerfile` (exit 0), nginx 1.30.4, real `dist/`:

| # | Probe | Status | `cache-control` | `content-type` | Bytes | Result |
|---|---|---|---|---|---|---|
| 1 | `/assets/index-D5xKgVJQ.js` | 200 | `public, max-age=300` | application/javascript | 999401 | PASS |
| 1b | `/assets/AvailabilityView-Dzsaous6.css` | 200 | `public, max-age=300` | text/css | 7744 | PASS |
| 2 | `/assets/missing-000.js` | 404 | *(none)* | text/html | 153 | PASS |
| 3 | `/assets/anything.js.map` | 404 | *(none)* | text/html | 153 | PASS |
| 3b | `/assets/AvailabilityView-vM6NC5iH.js.map` (on disk) | 404 | *(none)* | text/html | 153 | PASS |
| 4 | `/` | 200 | `no-store` | text/html | 1644 | PASS |
| 5 | `/index.html` | 200 | `no-store` | text/html | 1644 | PASS |
| 6 | `/user/foo` | 200 | `no-store` | text/html | 1644 | PASS |
| 6b | deep route body is the SPA shell | — | — | — | — | PASS |
| 7 | `/config.js` | 200 | `no-store` | application/javascript | 375 | PASS |
| 8 | `/favicon.svg` | 200 | `public, max-age=300` | image/svg+xml | 1651 | PASS |
| 9 | `/site.webmanifest` | 200 | `public, max-age=300` | application/manifest+json | 350 | PASS |
| 9b | `/sitemap.txt` (MIME map not clobbered) | 200 | `public, max-age=300` | text/plain | 25 | PASS |
| 10 | `Accept-Encoding: gzip, deflate, br` sent on **every** probe | 200 | `public, max-age=300` | application/javascript | 999401 | PASS |
| 10b | no `content-encoding` on any probed path, and bundle keeps `Content-Length` | — | — | — | — | PASS |
| 11 | `nginx -t` | — | — | — | — | PASS |
| 11b | `nginx -T` warn/emerg/duplicate lines = 0 | — | — | — | — | PASS |
| 12 | shortlink vhost `Host: stage.apt.mt` redirect | 302 | — | — | 145 | PASS |
| 13 | `/api/v1/health` → `error_page` (unchanged) | 502 | *(none)* | — | 59 | PASS |
| 14 | non-JSON access log lines (of 27) = 0 | — | — | — | — | PASS |
| 15 | `jq`-invalid access log lines = 0 | — | — | — | — | PASS |
| 16 | `cf_pop` field gone from log | — | — | — | — | PASS |
| 17 | realip: `"remote_addr":"203.0.113.9"` from XFF | — | — | — | — | PASS |
| 18 | realip fires on shortlink vhost too (`198.51.100.7`) | — | — | — | — | PASS |

**24/24 pass** — that is 24 data rows in the table above (an earlier revision of this body said "25/25", which was simply an arithmetic error). Separately, the CI script `frontend/docker/test-nginx-config.sh` asserts **22 checks** and additionally hard-fails on `nginx -t`; the two counts are not the same thing, because the matrix above is a manual run against the real `dist/` while the script runs against a synthetic tree.

**Probes 14/17/18 genuinely fail on `origin/main`** — its `access_log` is commented out, so lines come out in the inherited combined format (`10.0.0.74 - - [...] "GET /probe14 HTTP/1.1" 200`), and with no `set_real_ip_from` the `remote_addr` stays the peer's `10.0.0.74`.

**Probe 12 is not a regression check — it is a no-regression check.** An earlier revision of this body listed it alongside 14/17/18 as failing pre-edit. That was wrong: the shortlink `rewrite` is untouched by this PR, and the response is byte-identical on `origin/main` — 302, `Location: https://appointment-stage.tb.pro/user/abc`, `Content-Length: 145`. It is in the matrix to prove the second vhost still behaves exactly as it did, which is worth asserting given a `log_format` and three `real_ip` directives were added at **http** scope where they reach both server blocks.

Re-nesting `root` inside `location /` (the original blocker) still gives `nginx: syntax is ok` but **9 probe FAILs**, including `/assets/*` 404 and the deep route not serving the shell.

## New CI job

`validate-frontend-nginx` runs `frontend/docker/test-nginx-config.sh` under the existing `frontend/**` path filter: the shipped conf in a stock `nginx:stable` over a synthetic `dist/` tree. No npm build, no registry auth, no AWS creds, and no interpolation of untrusted `${{ github.event.* }}`.

Two of its assertions were originally able to pass vacuously and have been hardened. Both hardenings were mutation-verified — confirmed failing against each mutation and still passing against the real conf:

**Compression probe.** It offered `Accept-Encoding` at one call site and checked a 23-byte fixture, so it missed every realistic way of turning origin gzip on. `Accept-Encoding: gzip, deflate, br` is now folded into the shared `probe()` helper so **every** probe asserts no `Content-Encoding`; the SPA-shell fixture is padded past 1000 bytes and the bundle fixture is ~64 KB (both sizes are load-bearing against a `gzip_min_length`); and the bundle response must still carry a **`Content-Length`**, since it is the *loss* of that header under nginx's chunked gzip — not the value of `Content-Encoding` — that lets CloudFront cache a partial object (#814).

**JSON access-log check.** Its `bad` counter only incremented while reading a `grep`-filtered stream, so zero matched lines read as PASS. It now counts matched lines and requires `> 0`, selects log lines by *excluding* entrypoint/`[notice]` output rather than include-matching `^{` (so a non-JSON format is counted as bad instead of vanishing), asserts via `jq -e` that a captured line has `x_forwarded_for`, `cf_id`, `request_time`, `upstream_response_time` and `user_agent`, and probes each vhost with `X-Forwarded-For: 203.0.113.9` to assert the logged `remote_addr` resolves to it. The local `jq`-missing `SKIP` branch is kept but now hard-fails when `CI` is set, so a silently-skipped assertion cannot recur.

## Deliberate choices

**gzip is intentionally not enabled at the origin.** Compression belongs at CloudFront: nginx's `gzip` rewrites the body after `Content-Length` is set, which breaks range/partial-object requests and makes byte-level cache validation inconsistent — the edge does Brotli better and closer to the viewer. Probe 10b asserts no `Content-Encoding` comes back on any path even when the client offers `gzip, deflate, br`, and that the bundle keeps its `Content-Length`.

**The `/assets/` TTL is deliberately `max-age=300` for now.** Vite bundles are content-hashed, so `immutable, max-age=31536000` is correct in principle and is the follow-up — but only after curl parity is captured from the running pod, because `immutable` lands in **browser** caches, where a wrong value cannot be invalidated by any CloudFront invalidation and is unrecallable for a year.

**`no-store` (not `no-cache`) on the SPA shell** is deliberate: it is the only directive that also keeps the deploy pointer out of shared/CDN storage, and the 304 revalidation it forfeits is on a ~1.6 KB document.

**Read `$remote_addr`, never the leftmost `X-Forwarded-For` element.** The log-format comment previously said the opposite. `real_ip` has already resolved `$remote_addr` to the address the ALB observed; the leftmost XFF entry is whatever the viewer sent and is therefore the one hop an attacker fully controls. Verified from a 10/8 peer: `X-Forwarded-For: 1.2.3.4, 203.0.113.9` logs `remote_addr=203.0.113.9` while `1.2.3.4` is the forgery. Once CloudFront fronts this origin the trustworthy element is the rightmost-but-one — the hop CloudFront appended — or forward `CloudFront-Viewer-Address`.

## Deferred, tracked not lost

CloudFront origin-facing ranges in `set_real_ip_from`, `no-store` on `/api/v1/` and `/fxa`, and attaching `AllViewerExceptHostHeader` to the default + `/assets/*` behaviours all belong with the CDN work that owns the cache policies, not this file. One genuine pre-existing issue found and left alone as out of scope: the proxy blocks pass `$proxy_add_x_forwarded_for`, which lets a client seed the chain and bypass IP rate limiting — filing separately.

Part of thunderbird/platform-infrastructure#814

- https://github.com/thunderbird/platform-infrastructure/issues/814
- https://github.com/thunderbird/platform-infrastructure/issues/702

🤖 Generated with [Claude Code](https://claude.com/claude-code)

