### PR TITLE
Add logs for slug conflict + set a stable order for schedules

### DIFF
--- a/backend/src/appointment/database/repo/schedule.py
+++ b/backend/src/appointment/database/repo/schedule.py
@@ -30,6 +30,7 @@ def get_by_subscriber(db: Session, subscriber_id: int) -> list[models.Schedule]:
         db.query(models.Schedule)
         .join(models.Calendar, models.Schedule.calendar_id == models.Calendar.id)
         .filter(models.Calendar.owner_id == subscriber_id)
+        .order_by(models.Schedule.id)
         .all()
     )
 

--- a/backend/src/appointment/database/repo/schedule.py
+++ b/backend/src/appointment/database/repo/schedule.py
@@ -55,13 +55,13 @@ def slug_taken(db: Session, slug: str, owner_id: int) -> bool:
     )
 
 
-def slug_available_for_schedule(db: Session, slug: str, schedule_id: int) -> bool:
-    """True if this slug is unused or already belongs to the given schedule for the same owner."""
+def find_conflicting_schedule_id(db: Session, slug: str, schedule_id: int) -> int | None:
+    """Id of another schedule for the same owner that already uses this slug, if any."""
     schedule = get(db, schedule_id)
     if not schedule:
-        return False
+        return None
 
-    return (
+    conflicting = (
         db.query(models.Schedule)
         .filter(
             models.Schedule.slug == slug,
@@ -69,8 +69,16 @@ def slug_available_for_schedule(db: Session, slug: str, schedule_id: int) -> boo
             models.Schedule.owner_id == schedule.owner_id,
         )
         .first()
-        is None
     )
+    return conflicting.id if conflicting else None
+
+
+def slug_available_for_schedule(db: Session, slug: str, schedule_id: int) -> bool:
+    """True if this slug is unused or already belongs to the given schedule for the same owner."""
+    if not exists(db, schedule_id):
+        return False
+
+    return find_conflicting_schedule_id(db, slug, schedule_id) is None
 
 
 def get(db: Session, schedule_id: int):

--- a/backend/src/appointment/routes/schedule.py
+++ b/backend/src/appointment/routes/schedule.py
@@ -212,6 +212,7 @@ def update_schedule(
         raise validation.InvalidAvailabilityException()
 
     if schedule.slug and not repo.schedule.slug_available_for_schedule(db, schedule.slug, id):
+        _log_slug_conflict(db, subscriber.id, id, schedule.slug)
         raise validation.ScheduleSlugTakenException()
 
     result = repo.schedule.update(db=db, schedule=schedule, schedule_id=id)
@@ -220,6 +221,27 @@ def update_schedule(
         _sync_watch_channels(db, google_client, subscriber, schedule.calendar_id)
 
     return result
+
+
+def _log_slug_conflict(db: Session, owner_id: int, schedule_id: int, slug: str) -> None:
+    """Helped to log slug conflict to Sentry"""
+    if not os.getenv('SENTRY_DSN'):
+        return
+
+    schedules_for_owner = repo.schedule.get_by_subscriber(db, owner_id)
+
+    sentry_sdk.set_context(
+        'schedule_slug_conflict',
+        {
+            'schedule_id': schedule_id,
+            'owner_id': owner_id,
+            'conflicting_schedule_id': repo.schedule.find_conflicting_schedule_id(db, slug, schedule_id),
+            'schedule_count_for_owner': len(schedules_for_owner),
+            'schedule_ids_for_owner': [s.id for s in schedules_for_owner],
+            'slug_length': len(slug),
+        },
+    )
+    sentry_sdk.capture_message('Schedule update rejected: slug already taken', level='warning')
 
 
 def _sync_watch_channels(db: Session, google_client: GoogleClient, subscriber: Subscriber, default_calendar_id: int):

--- a/backend/test/unit/test_schedule_repo.py
+++ b/backend/test/unit/test_schedule_repo.py
@@ -58,6 +58,16 @@ class TestScheduleSlug:
         with with_db() as db:
             assert repo.schedule.slug_available_for_schedule(db, slug, other_schedule.id) is True
 
+    def test_get_by_subscriber_orders_schedules_by_id(self, with_db, make_schedule):
+        first = make_schedule()
+        second = make_schedule(calendar_id=first.calendar_id)
+        third = make_schedule(calendar_id=first.calendar_id)
+
+        with with_db() as db:
+            schedules = repo.schedule.get_by_subscriber(db, TEST_USER_ID)
+
+        assert [s.id for s in schedules] == sorted([first.id, second.id, third.id])
+
     def test_get_by_slug_is_scoped_to_owner(
         self, with_db, make_schedule, make_pro_subscriber, make_caldav_calendar
     ):

--- a/frontend/src/stores/user-store.ts
+++ b/frontend/src/stores/user-store.ts
@@ -86,12 +86,9 @@ export const useUserStore = defineStore('user', () => {
    */
   const mySlug = computed((): string | null => {
     const slugs = data?.value?.scheduleSlugs ?? {};
-    const slugKeys = Object.keys(slugs);
-    if (slugKeys.length == 0) {
-      return null;
-    }
+    const slugValues = Object.values(slugs);
 
-    return slugs[slugKeys[0]];
+    return slugValues.length > 0 ? (slugValues[0] as string) : null;
   });
 
   /**

--- a/frontend/test/stores/user-store.test.js
+++ b/frontend/test/stores/user-store.test.js
@@ -179,4 +179,18 @@ describe('User Store', () => {
     expect(user.data.settings.startOfWeek).toBeTruthy();
     expect(user.data.signedUrl).toBeTruthy();
   });
+
+  test('mySlug picks the first schedule slug', () => {
+    const user = useUserStore();
+    user.data.scheduleSlugs = { 12: 'second-schedule-slug', 3: 'first-schedule-slug' };
+
+    expect(user.mySlug).toBe('first-schedule-slug');
+  });
+
+  test('mySlug is null when there are no schedules', () => {
+    const user = useUserStore();
+    user.data.scheduleSlugs = {};
+
+    expect(user.mySlug).toBeNull();
+  });
 });


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- Added a Sentry call to log extra data for conflicting slugs preventing a schedule / availability to be saved
- Added ordering for schedules while getting the subscriber's schedule in get_by_subscriber

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

This really shouldn't happen so this is an attempt of solving a potential data inconsistency (a user with two schedules) but given that we only currently support a single schedule, a generated slug should never conflict. Alas, it seems to be happening so my assumption is that somehow there are two (or more) schedules for the affected user and the unstable ordering of the (supposedly single) schedule returned by the backend caused a slug clash.

Really unlikely but very curious case 🤔 

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->

We don't prevent the creation of two schedules in the backend at the moment as I believe there was a plan to support multiple schedules (ref https://github.com/thunderbird/appointment/issues/722). This is not tackled in this PR.

I can confirm this assumption if one would directly connect to the production DB and run: `SELECT owner_id, COUNT(*) FROM schedules GROUP BY owner_id HAVING COUNT(*) > 1;`

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Related with https://github.com/thunderbird/appointment/issues/1772
