### PR TITLE
Show a specific error for invalid booking links

### DIFF
--- a/frontend/src/views/BookerView/index.vue
+++ b/frontend/src/views/BookerView/index.vue
@@ -65,7 +65,7 @@ const handleError = (data: Exception) => {
 
   const errorDetail = data?.detail as ExceptionDetail;
 
-  if (errorDetail?.id === 'SCHEDULE_NOT_ACTIVE') {
+  if (errorDetail?.id === 'INVALID_LINK' || errorDetail?.id === 'SCHEDULE_NOT_ACTIVE') {
     errorHeading.value = '';
     errorBody.value = errorDetail.message;
   } else if (errorDetail?.id === 'RATE_LIMIT_EXCEEDED') {

--- a/frontend/test/components/BookerView.test.js
+++ b/frontend/test/components/BookerView.test.js
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+import { createPinia } from 'pinia';
+import { ref } from 'vue';
+import dayjs from 'dayjs';
+import i18ninstance from '@/composables/i18n';
+import { callKey, dayjsKey } from '@/keys';
+import BookerView from '@/views/BookerView/index.vue';
+
+describe('BookerView', () => {
+  let wrapper;
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('shows the backend message for an invalid booking link', async () => {
+    const response = {
+      data: ref({
+        detail: {
+          id: 'INVALID_LINK',
+          message: 'This link is no longer valid.',
+        },
+      }),
+      error: ref(true),
+    };
+    const json = vi.fn().mockResolvedValue(response);
+    const post = vi.fn().mockReturnValue({ json });
+    const call = vi.fn().mockReturnValue({ post });
+
+    wrapper = mount(BookerView, {
+      global: {
+        plugins: [createPinia(), i18ninstance],
+        provide: {
+          [callKey]: call,
+          [dayjsKey]: dayjs,
+        },
+      },
+    });
+
+    await flushPromises();
+
+    expect(call).toHaveBeenCalledWith('schedule/public/availability');
+    expect(post).toHaveBeenCalledWith({ url: window.location.href.split('#')[0] });
+    expect(wrapper.get('h1').text()).toBe('');
+    expect(wrapper.get('p').text()).toBe('This link is no longer valid.');
+  });
+});


### PR DESCRIPTION
## What changed?

Handle the existing `INVALID_LINK` API error in `BookerView` and display the backend’s localized message instead of the generic booking-page fallback. Added a component regression test that exercises the full request-to-render path.

Implemented with Codex agent assistance. I reviewed the issue scope, implementation, test coverage, and final diff.

## Why?

Invalid public booking URLs currently show “Something went wrong” even though the backend already identifies them precisely.

## Limitations and Notes

The generic fallback remains unchanged for unknown API errors.

Validation:
- `pnpm --dir frontend test -- --run test/components/BookerView.test.js` (14 files, 100 tests passed)
- `pnpm --dir frontend lint`
- `pnpm --dir frontend build`
- Prettier check on the changed files

## Applicable Issues

Closes #1780

## Screenshots

Not included; this only replaces the generic text with the localized message already returned by the backend.