### PR TITLE
Retry Thundermail CalDAV auto-connection if not account not provisioned yet + surface better errors

### DIFF
--- a/backend/src/appointment/defines.py
+++ b/backend/src/appointment/defines.py
@@ -31,6 +31,13 @@ DEFAULT_CALENDAR_COLOUR = '#c276c5'
 # List of Google CalDAV domains
 GOOGLE_CALDAV_DOMAINS = ['googleusercontent.com', 'google.com', 'gmail.com']
 
+# Code Accounts returns when a subscriber's Thundermail mailbox hasn't finished provisioning yet
+# (see thunderbird-accounts mail/views.py `appointment_caldav_setup`). It's a transient race, not
+# a permanent failure, so Appointment retries a few times with backoff before giving up.
+ACCOUNTS_MAIL_NOT_READY_CODE = 'mail_account_not_ready'
+ACCOUNTS_CALDAV_SETUP_MAX_ATTEMPTS = 3
+ACCOUNTS_CALDAV_SETUP_RETRY_DELAY_SECONDS = 2
+
 # Resolves to absolute appointment package path
 BASE_PATH = f'{sys.modules["appointment"].__path__[0]}'
 

--- a/backend/src/appointment/routes/caldav.py
+++ b/backend/src/appointment/routes/caldav.py
@@ -1,5 +1,6 @@
 import os
 import json
+import time
 import urllib
 from typing import Optional
 from urllib.parse import urlparse
@@ -25,9 +26,70 @@ from appointment.exceptions.validation import (
     RemoteCalendarAuthenticationException,
 )
 from appointment.l10n import l10n
-from appointment.defines import GOOGLE_CALDAV_DOMAINS
+from appointment.defines import (
+    GOOGLE_CALDAV_DOMAINS,
+    ACCOUNTS_MAIL_NOT_READY_CODE,
+    ACCOUNTS_CALDAV_SETUP_MAX_ATTEMPTS,
+    ACCOUNTS_CALDAV_SETUP_RETRY_DELAY_SECONDS,
+)
 
 router = APIRouter()
+
+
+def _request_appointment_app_password(token: str) -> str:
+    """Requests (or retrieves) the Appointment CalDAV app password from Thunderbird Accounts.
+
+    Retries with backoff when Accounts reports the mailbox is still being provisioned, and raises
+    a `RemoteCalendarConnectionError` carrying Accounts' own error message as `reason` for every
+    other failure.
+    """
+    tb_accounts_host = os.getenv('TB_ACCOUNTS_HOST')
+    appointment_caldav_secret = os.getenv('APPOINTMENT_CALDAV_SECRET')
+
+    if not tb_accounts_host or not appointment_caldav_secret:
+        raise RemoteCalendarConnectionError()
+
+    reason = None
+
+    for attempt in range(1, ACCOUNTS_CALDAV_SETUP_MAX_ATTEMPTS + 1):
+        try:
+            response = requests.post(
+                f'{tb_accounts_host}/appointment/caldav/setup/',
+                json={
+                    'appointment-secret': appointment_caldav_secret,
+                    'oidc-access-token': token,
+                },
+                timeout=10,
+            )
+        except requests.RequestException as ex:
+            sentry_sdk.capture_exception(ex)
+            raise RemoteCalendarConnectionError()
+
+        try:
+            result = response.json()
+        except ValueError:
+            result = {}
+
+        if response.ok and result.get('success'):
+            app_password = result.get('app_password')
+            if app_password:
+                return app_password
+            reason = None
+            break
+
+        reason = result.get('error')
+
+        if result.get('code') == ACCOUNTS_MAIL_NOT_READY_CODE and attempt < ACCOUNTS_CALDAV_SETUP_MAX_ATTEMPTS:
+            time.sleep(ACCOUNTS_CALDAV_SETUP_RETRY_DELAY_SECONDS * attempt)
+            continue
+
+        break
+
+    sentry_sdk.capture_message(
+        f'Appointment CalDAV auto-setup failed: {reason or "unknown error"}',
+        level='warning',
+    )
+    raise RemoteCalendarConnectionError(reason=reason)
 
 
 def _resolve_caldav_url(connection_url: str, redis_client: Redis) -> str:
@@ -163,13 +225,6 @@ def oidc_autodiscover_auth(
 
     connection_url = _resolve_caldav_url(os.getenv('TB_ACCOUNTS_CALDAV_URL'), redis_client)
 
-    # Request or retrieve an app password from Thunderbird Accounts for CalDAV authentication
-    tb_accounts_host = os.getenv('TB_ACCOUNTS_HOST')
-    appointment_caldav_secret = os.getenv('APPOINTMENT_CALDAV_SECRET')
-
-    if not tb_accounts_host or not appointment_caldav_secret:
-        raise RemoteCalendarConnectionError()
-
     # The CalDAV server authenticates against the account's OIDC login (`preferred_username`),
     # which can differ from `subscriber.email` (the standard OIDC `email` claim, used for
     # notifications). Introspect the token to recover the login identity for CalDAV auth.
@@ -178,29 +233,7 @@ def oidc_autodiscover_auth(
         raise RemoteCalendarConnectionError()
     caldav_user = token_data.get('preferred_username') or token_data.get('username') or subscriber.email
 
-    try:
-        response = requests.post(
-            f'{tb_accounts_host}/appointment/caldav/setup/',
-            json={
-                'appointment-secret': appointment_caldav_secret,
-                'oidc-access-token': token,
-            },
-            timeout=10,
-        )
-
-        response.raise_for_status()
-        result = response.json()
-
-        if not result.get('success'):
-            raise RemoteCalendarConnectionError()
-
-        app_password = result.get('app_password')
-
-        if not app_password:
-            raise RemoteCalendarConnectionError()
-    except requests.RequestException as ex:
-        sentry_sdk.capture_exception(ex)
-        raise RemoteCalendarConnectionError()
+    app_password = _request_appointment_app_password(token)
 
     con = CalDavConnector(
         db=db,

--- a/backend/test/integration/test_caldav_routes.py
+++ b/backend/test/integration/test_caldav_routes.py
@@ -6,6 +6,7 @@ import pytest
 
 from appointment.controller.calendar import CalDavConnector, Tools
 from appointment.database import models
+from appointment.defines import ACCOUNTS_MAIL_NOT_READY_CODE, ACCOUNTS_CALDAV_SETUP_MAX_ATTEMPTS
 from appointment.exceptions.calendar import TestConnectionFailed
 
 from sqlalchemy import select
@@ -195,6 +196,97 @@ class TestOidcAutodiscoverAuth:
 
         assert response.status_code == 400, response.text
         assert response.json()['detail']['id'] == 'REMOTE_CALENDAR_CONNECTION_ERROR'
+
+    def _mock_tb_accounts_not_ready(self):
+        mock_response = MagicMock()
+        mock_response.ok = False
+        mock_response.json.return_value = {
+            'success': False,
+            'error': 'Thundermail account setup is still in progress. Please try again shortly.',
+            'code': ACCOUNTS_MAIL_NOT_READY_CODE,
+        }
+        return mock_response
+
+    def test_oidc_auth_retries_when_mail_account_not_ready(self, with_client, with_db, monkeypatch):
+        """Should retry (with backoff) when TB Accounts reports the mailbox is still being
+        provisioned, and succeed once it becomes ready without surfacing an error to the user."""
+        monkeypatch.setenv('TB_ACCOUNTS_HOST', 'https://accounts.test.example')
+        monkeypatch.setenv('APPOINTMENT_CALDAV_SECRET', 'test-secret')
+        monkeypatch.setenv('TB_ACCOUNTS_CALDAV_URL', 'https://caldav.test.example')
+
+        monkeypatch.setattr(Tools, 'dns_caldav_lookup', lambda *a, **kw: (None, None))
+        monkeypatch.setattr(Tools, 'well_known_caldav_lookup', lambda *a, **kw: None)
+        monkeypatch.setattr('appointment.routes.caldav.time.sleep', lambda *a, **kw: None)
+
+        class MockCalDavConnector:
+            @staticmethod
+            def __init__(self, db, redis_instance, url, user, password, subscriber_id, calendar_id):
+                pass
+
+            @staticmethod
+            def test_connection(self):
+                return True
+
+            @staticmethod
+            def sync_calendars(self, external_connection_id=None):
+                pass
+
+        monkeypatch.setattr(CalDavConnector, '__init__', MockCalDavConnector.__init__)
+        monkeypatch.setattr(CalDavConnector, 'test_connection', MockCalDavConnector.test_connection)
+        monkeypatch.setattr(CalDavConnector, 'sync_calendars', MockCalDavConnector.sync_calendars)
+
+        with patch(
+            'appointment.routes.caldav.requests.post',
+            side_effect=[self._mock_tb_accounts_not_ready(), self._mock_tb_accounts_success()],
+        ) as mock_post:
+            response = with_client.post('/caldav/oidc/auth', headers=auth_headers)
+
+        assert response.status_code == 200, response.text
+        assert mock_post.call_count == 2
+
+    def test_oidc_auth_gives_up_after_max_attempts_when_still_not_ready(self, with_client, monkeypatch):
+        """Should stop retrying after the max attempt count and surface TB Accounts' own message
+        as `reason` instead of a generic error."""
+        monkeypatch.setenv('TB_ACCOUNTS_HOST', 'https://accounts.test.example')
+        monkeypatch.setenv('APPOINTMENT_CALDAV_SECRET', 'test-secret')
+        monkeypatch.setenv('TB_ACCOUNTS_CALDAV_URL', 'https://caldav.test.example')
+
+        monkeypatch.setattr(Tools, 'dns_caldav_lookup', lambda *a, **kw: (None, None))
+        monkeypatch.setattr(Tools, 'well_known_caldav_lookup', lambda *a, **kw: None)
+        monkeypatch.setattr('appointment.routes.caldav.time.sleep', lambda *a, **kw: None)
+
+        not_ready_response = self._mock_tb_accounts_not_ready()
+
+        with patch('appointment.routes.caldav.requests.post', return_value=not_ready_response) as mock_post:
+            response = with_client.post('/caldav/oidc/auth', headers=auth_headers)
+
+        assert response.status_code == 400, response.text
+        assert mock_post.call_count == ACCOUNTS_CALDAV_SETUP_MAX_ATTEMPTS
+        detail = response.json()['detail']
+        assert detail['id'] == 'REMOTE_CALENDAR_CONNECTION_ERROR'
+        assert detail['reason'] == not_ready_response.json.return_value['error']
+
+    def test_oidc_auth_surfaces_accounts_error_reason(self, with_client, monkeypatch):
+        """A non-retryable failure from TB Accounts should surface its own message as `reason`
+        instead of the generic connection error."""
+        monkeypatch.setenv('TB_ACCOUNTS_HOST', 'https://accounts.test.example')
+        monkeypatch.setenv('APPOINTMENT_CALDAV_SECRET', 'test-secret')
+        monkeypatch.setenv('TB_ACCOUNTS_CALDAV_URL', 'https://caldav.test.example')
+
+        monkeypatch.setattr(Tools, 'dns_caldav_lookup', lambda *a, **kw: (None, None))
+        monkeypatch.setattr(Tools, 'well_known_caldav_lookup', lambda *a, **kw: None)
+
+        failure_message = 'An error has occurred while setting up the Appointment CalDAV.'
+        failure_response = MagicMock()
+        failure_response.ok = False
+        failure_response.json.return_value = {'success': False, 'error': failure_message}
+
+        with patch('appointment.routes.caldav.requests.post', return_value=failure_response) as mock_post:
+            response = with_client.post('/caldav/oidc/auth', headers=auth_headers)
+
+        assert response.status_code == 400, response.text
+        assert mock_post.call_count == 1
+        assert response.json()['detail']['reason'] == failure_message
 
     def test_oidc_auth_connection_test_fails(self, with_client, monkeypatch):
         """Should raise RemoteCalendarConnectionError when CalDAV connection test fails."""

--- a/frontend/src/views/FTUEView/steps/ConnectYourCalendarStep.vue
+++ b/frontend/src/views/FTUEView/steps/ConnectYourCalendarStep.vue
@@ -33,7 +33,10 @@ const onContinueButtonClick = async () => {
         const { data, error } = await calendarStore.connectOIDCCalendar();
 
         if (data.value?.detail?.message) {
-          ftueStore.errorMessage = { title: data.value?.detail?.message };
+          ftueStore.errorMessage = {
+            title: data.value?.detail?.message,
+            details: data.value?.detail?.reason,
+          };
           return;
         }
 
@@ -66,6 +69,12 @@ const onContinueButtonClick = async () => {
 <template>
   <notice-bar :type="NoticeBarTypes.Critical" v-if="errorMessage" class="notice-bar">
     {{ errorMessage.title }}
+
+    <template v-if="errorMessage.details">
+      <br />
+      <br />
+    </template>
+    {{ errorMessage.details }}
   </notice-bar>
 
   <step-title :title="t('ftue.connectYourCalendar')" />


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- We are now actually surfacing the errors that are being sent from Accounts side while attempting to do the CalDAV auto-connection.
- In case there's a specific error where the account hasn't been provisioned yet in the Stalwart side, we do 3 retries before showing the error to give it a chance to work. After that we now show a specific error message about the account still being provisioned.

> [!NOTE]  
> To test this locally, you will need to run Accounts <-> Appointment in tandem

In the video attached I show how to reproduce the problem and the fix in action!

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

- We were swallowing the errors with the `response.raise_for_status()` and showing a generic error message which prevents us to further diagnose what exactly went wrong.
- There might be a race condition where the Stalwart account hasn't been provisioned yet while attempting to make the Thundermail CalDAV connection. In these cases, we should give a little bit of grace for retrying but ultimately showing a more meaningful error message.

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->

- This might not entirely solve the problem in the "Applicable Issues" section but at least would provide us with a bit more clarity on the error message. There's a hunch that the problem might be intermittent instability as well of attempting to do the Thundermail CalDAV connection while Accounts is still booting up from a deployment for example.
- The notice-bar design / message looks a bit odd but that's the wrapping done in the [component level itself in services-ui](https://thunderbird.github.io/services-ui/?path=/story/components-noticebar--type). To see it, shrink the window enough and the default text in it will wrap.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Related with https://github.com/thunderbird/appointment/issues/1766

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

https://github.com/user-attachments/assets/f8df75c5-c2ca-4e58-89f6-343624953cec

