### PR TITLE
Catch & reduce CalDAV XML parsing sentry errors

### DIFF
--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -425,8 +425,19 @@ class CalDavConnector(BaseConnector):
 
         perf_start = time.perf_counter_ns()
 
-        calendar = self.client.calendar(url=calendar_ids[0])
-        response = calendar.freebusy_request(time_min, time_max)
+        try:
+            calendar = self.client.calendar(url=calendar_ids[0])
+            response = calendar.freebusy_request(time_min, time_max)
+        except lxml.etree.XMLSyntaxError as ex:
+            # Server returned invalid XML (e.g. a JSON auth error body instead of a CalDAV response)
+            logging.warning(f'FreeBusy XML Error: {ex}')
+            raise TestConnectionFailed(reason=l10n('remote-calendar-reason-invalid-response'))
+        except caldav.lib.error.AuthorizationError as ex:
+            logging.warning(f'FreeBusy AuthorizationError: {ex}')
+            reason = ex.reason
+            if reason == 'Unauthorized' or reason == caldav.lib.error.DAVError.reason:
+                raise RemoteCalendarAuthenticationError(reason=l10n('remote-calendar-reason-unauthorized'))
+            raise TestConnectionFailed(reason=reason)
 
         perf_end = time.perf_counter_ns()
         print(f'CALDAV FreeBusy response: {(perf_end - perf_start) / 1000000000} seconds')
@@ -570,12 +581,23 @@ class CalDavConnector(BaseConnector):
         search_start = datetime.strptime(start, DATEFMT)
         search_end = datetime.strptime(end, DATEFMT)
 
-        result = calendar.search(
-            start=search_start,
-            end=search_end,
-            event=True,
-            expand=False,
-        )
+        try:
+            result = calendar.search(
+                start=search_start,
+                end=search_end,
+                event=True,
+                expand=False,
+            )
+        except lxml.etree.XMLSyntaxError as ex:
+            # Server returned invalid XML (e.g. a JSON auth error body instead of a CalDAV response)
+            logging.warning(f'List Events XML Error: {ex}')
+            raise TestConnectionFailed(reason=l10n('remote-calendar-reason-invalid-response'))
+        except caldav.lib.error.AuthorizationError as ex:
+            logging.warning(f'List Events AuthorizationError: {ex}')
+            reason = ex.reason
+            if reason == 'Unauthorized' or reason == caldav.lib.error.DAVError.reason:
+                raise RemoteCalendarAuthenticationError(reason=l10n('remote-calendar-reason-unauthorized'))
+            raise TestConnectionFailed(reason=reason)
 
         all_instances = []
 

--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -1220,12 +1220,20 @@ class Tools:
             except caldav.lib.error.ReportError:
                 logging.debug('[Tools.existing_events_for_schedule] CalDAV server does not support FreeBusy API.')
                 pass
+            except (TestConnectionFailed, RemoteCalendarAuthenticationError) as ex:
+                # Bad credentials or an unparsable response from this calendar's server.
+                # Skip it rather than crashing the whole availability lookup.
+                logging.warning(f'[Tools.existing_events_for_schedule] CalDAV calendar {calendar.id} unreachable: {ex}')
+                continue
 
             # Okay maybe this server doesn't support freebusy, try the old way
             try:
                 existing_events.extend(con.list_events(start.strftime(DATEFMT), end.strftime(DATEFMT)))
             except requests.exceptions.ConnectionError:
                 # Connection error with remote caldav calendar, don't crash this route.
+                pass
+            except (TestConnectionFailed, RemoteCalendarAuthenticationError) as ex:
+                logging.warning(f'[Tools.existing_events_for_schedule] CalDAV calendar {calendar.id} unreachable: {ex}')
                 pass
 
         # handle already requested time slots

--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -477,10 +477,10 @@ class CalDavConnector(BaseConnector):
                     break
         except IndexError as ex:
             # Library has an issue with top level urls, probably due to caldav spec?
-            logging.error(f'IE: Error testing connection {ex}')
+            logging.warning(f'IE: Error testing connection {ex}')
             raise TestConnectionFailed(reason=None)
         except KeyError as ex:
-            logging.error(f'KE: Error testing connection {ex}')
+            logging.warning(f'KE: Error testing connection {ex}')
             raise TestConnectionFailed(reason=None)
         except requests.exceptions.RequestException:
             raise TestConnectionFailed(reason=None)
@@ -489,11 +489,11 @@ class CalDavConnector(BaseConnector):
             raise TestConnectionFailed(reason=l10n('remote-calendar-reason-doesnt-support-auth'))
         except lxml.etree.XMLSyntaxError as ex:
             # Server returned invalid XML (e.g., an HTML error page like nginx 404)
-            logging.error(f'Test Connection XML Error: {ex}')
+            logging.warning(f'Test Connection XML Error: {ex}')
             raise TestConnectionFailed(reason=l10n('remote-calendar-reason-invalid-response'))
         except caldav.lib.error.NotFoundError as ex:
             # Good server, bad URL - 404 response
-            logging.error(f'Test Connection NotFoundError: {ex}')
+            logging.warning(f'Test Connection NotFoundError: {ex}')
             raise TestConnectionFailed(reason=l10n('remote-calendar-reason-not-found'))
         except (
             caldav.lib.error.PropfindError,
@@ -503,7 +503,7 @@ class CalDavConnector(BaseConnector):
             PropfindError: Some properties could not be retrieved.
             AuthorizationError: Credentials are not accepted.
             """
-            logging.error(f'Test Connection Error: {ex}')
+            logging.warning(f'Test Connection Error: {ex}')
 
             reason = ex.reason
             # Don't use the default "no reason" error message if we encounter it.

--- a/backend/src/appointment/main.py
+++ b/backend/src/appointment/main.py
@@ -43,6 +43,17 @@ from slowapi.errors import RateLimitExceeded
 import sentry_sdk
 
 
+class _SuppressCaldavXmlParseCritical(logging.Filter):
+    """The caldav library logs a full traceback at CRITICAL via the *root* logger
+    (bypassing its own 'caldav' logger) whenever a server response isn't valid XML,
+    e.g. a JSON auth-error body returned for an expired/invalid CalDAV credential.
+    See https://github.com/python-caldav/caldav/blob/master/caldav/davclient.py
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return 'Expected some valid XML from the server' not in record.getMessage()
+
+
 def _common_setup():
     # load any available .env into env
     if os.getenv('APP_ENV') != APP_ENV_TEST:
@@ -64,6 +75,10 @@ def _common_setup():
     # Adjust caldav
     caldav_logger = logging.getLogger('caldav')
     caldav_logger.setLevel(logging.CRITICAL)
+
+    # caldav's XML-parse-failure log bypasses the 'caldav' logger above (it calls the
+    # root logger directly), so it needs its own filter to keep it out of Sentry
+    logging.getLogger().addFilter(_SuppressCaldavXmlParseCritical())
 
     logging.debug('Logger started!')
 

--- a/backend/test/integration/test_calendar.py
+++ b/backend/test/integration/test_calendar.py
@@ -3,13 +3,17 @@ from datetime import date, datetime, timedelta
 from unittest.mock import MagicMock
 from zoneinfo import ZoneInfo
 
+import caldav.lib.error
 import icalendar
+import lxml.etree
 import pytest
 
 from appointment.database.models import CalendarProvider
 from appointment.controller.calendar import CalDavConnector, GoogleConnector
 from appointment.database import schemas, models, repo
 from appointment.defines import GOOGLE_CALDAV_DOMAINS
+from appointment.exceptions.calendar import TestConnectionFailed as CaldavTestConnectionFailed
+from appointment.exceptions.calendar import RemoteCalendarAuthenticationError
 
 from sqlalchemy import select
 
@@ -652,6 +656,81 @@ class TestCaldavListEvents:
         events = connector.list_events('2024-01-01', '2024-01-02')
 
         connector.put_cached_events.assert_called_once_with('2024-01-01_2024-01-02', events)
+
+
+class TestCaldavListEventsErrors:
+    """Tests for CalDavConnector.list_events() converting caldav/lxml errors into typed exceptions."""
+
+    def make_connector(self, search_side_effect):
+        connector = CalDavConnector(
+            db=None,
+            subscriber_id=1,
+            calendar_id=1,
+            redis_instance=None,
+            url='https://test.com/caldav',
+            user='test',
+            password='test',
+        )
+        calendar_mock = MagicMock()
+        calendar_mock.search.side_effect = search_side_effect
+        connector.client = MagicMock()
+        connector.client.calendar = MagicMock(return_value=calendar_mock)
+        connector.get_cached_events = MagicMock(return_value=None)
+        return connector
+
+    def test_list_events_xml_syntax_error_raises_test_connection_failed(self):
+        def raise_xml_syntax_error(*args, **kwargs):
+            # Trigger a real lxml.etree.XMLSyntaxError, as raised when the caldav
+            # library tries to parse a non-XML (e.g. JSON auth error) response body.
+            lxml.etree.fromstring(b'not xml')
+
+        connector = self.make_connector(raise_xml_syntax_error)
+
+        with pytest.raises(CaldavTestConnectionFailed):
+            connector.list_events('2024-01-01', '2024-01-02')
+
+    def test_list_events_authorization_error_raises_remote_calendar_authentication_error(self):
+        connector = self.make_connector(caldav.lib.error.AuthorizationError(reason='Unauthorized'))
+
+        with pytest.raises(RemoteCalendarAuthenticationError):
+            connector.list_events('2024-01-01', '2024-01-02')
+
+
+class TestCaldavGetBusyTime:
+    """Tests for CalDavConnector.get_busy_time() converting caldav/lxml errors into typed exceptions."""
+
+    def make_connector(self, freebusy_side_effect):
+        connector = CalDavConnector(
+            db=None,
+            subscriber_id=1,
+            calendar_id=1,
+            redis_instance=None,
+            url='https://test.com/caldav',
+            user='test',
+            password='test',
+        )
+        calendar_mock = MagicMock()
+        calendar_mock.freebusy_request.side_effect = freebusy_side_effect
+        connector.client = MagicMock()
+        connector.client.calendar = MagicMock(return_value=calendar_mock)
+        return connector
+
+    def test_get_busy_time_xml_syntax_error_raises_test_connection_failed(self):
+        def raise_xml_syntax_error(*args, **kwargs):
+            # Trigger a real lxml.etree.XMLSyntaxError, as raised when the caldav
+            # library tries to parse a non-XML (e.g. JSON auth error) response body.
+            lxml.etree.fromstring(b'not xml')
+
+        connector = self.make_connector(raise_xml_syntax_error)
+
+        with pytest.raises(CaldavTestConnectionFailed):
+            connector.get_busy_time(['https://test.com/caldav'], '2024-01-01', '2024-01-02')
+
+    def test_get_busy_time_authorization_error_raises_remote_calendar_authentication_error(self):
+        connector = self.make_connector(caldav.lib.error.AuthorizationError(reason='Unauthorized'))
+
+        with pytest.raises(RemoteCalendarAuthenticationError):
+            connector.get_busy_time(['https://test.com/caldav'], '2024-01-01', '2024-01-02')
 
 
 class TestCaldavListEventsMidnightSpanWorkaround:

--- a/backend/test/unit/test_calendar_tools.py
+++ b/backend/test/unit/test_calendar_tools.py
@@ -1,5 +1,6 @@
-from appointment.controller.calendar import Tools, GoogleConnector
+from appointment.controller.calendar import Tools, GoogleConnector, CalDavConnector
 from appointment.database import schemas, models
+from appointment.exceptions.calendar import RemoteCalendarAuthenticationError
 from datetime import datetime, timedelta, time, date, timezone
 from unittest.mock import Mock, MagicMock, PropertyMock
 from starlette_context import request_cycle_context
@@ -180,6 +181,43 @@ class TestTools:
             now + timedelta(minutes=60),  # requested slot
             now + timedelta(minutes=90),  # booked slot
         ]
+
+    def test_existing_events_for_schedule_skips_caldav_calendar_on_auth_failure(
+        self, monkeypatch, with_db, make_pro_subscriber, make_caldav_calendar, make_schedule
+    ):
+        """One CalDAV calendar with bad/expired credentials shouldn't prevent availability
+        from being computed for the subscriber's other calendars."""
+        subscriber = make_pro_subscriber()
+        bad_calendar = make_caldav_calendar(
+            subscriber_id=subscriber.id, connected=True, url='https://bad.example.com/caldav'
+        )
+        good_calendar = make_caldav_calendar(
+            subscriber_id=subscriber.id, connected=True, url='https://good.example.com/caldav'
+        )
+        schedule = make_schedule(calendar_id=good_calendar.id)
+
+        with with_db() as db:
+            db.add(schedule)
+            db.refresh(schedule)
+
+            def mock_get_busy_time(self, calendar_ids, start, end):
+                if self.url == bad_calendar.url:
+                    raise RemoteCalendarAuthenticationError(reason='Unauthorized')
+                return [{'start': datetime.now(), 'end': datetime.now() + timedelta(hours=1)}]
+
+            monkeypatch.setattr(CalDavConnector, 'get_busy_time', mock_get_busy_time)
+
+            events = Tools.existing_events_for_schedule(
+                schedule=schedule,
+                calendars=[bad_calendar, good_calendar],
+                subscriber=subscriber,
+                google_client=Mock(),
+                db=db,
+                redis=None,
+            )
+
+        # Only the healthy calendar's busy time should come through
+        assert len(events) == 1
 
 
 class TestVCreate:


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- Added try / except blocks for catching specific XML parsing errors from CalDAV server responses.
- Reduced the logging severity from error to warning from the paths of error handling that don't require code / engineering intervention.
- Added tests

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

There were 1000s of errors being triggered in Sentry that we really don't need to be alerted / act on from an engineering perspective. They just create noise and cost :(

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->

We might still promote specific errors as actual errors instead of warnings but happy to do this in a case by case basis instead of defaulting to logging as error everywhere.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Closes https://github.com/thunderbird/appointment/issues/1785
Closes https://github.com/thunderbird/appointment/issues/1051