### PR TITLE
Skip Google Calendar polling while a push channel is live (#1607)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -92,6 +92,16 @@ GOOGLE_AUTH_SECRET=
 GOOGLE_AUTH_PROJECT_ID=
 GOOGLE_AUTH_CALLBACK=http://localhost:5000/google/callback
 GOOGLE_CHANNEL_TTL_IN_SECONDS=604800 # 7 days
+# How often to renew watch channels. Renewal is a no-op for channels outside the
+# expiry threshold, so running it often is cheap and gives a failed run more
+# attempts before anything lapses.
+GOOGLE_CHANNEL_RENEW_INTERVAL_SECONDS=3600 # 1 hour
+# How stale a channel may get before the reconciliation sweep re-syncs it. Must
+# stay comfortably below MAX_SYNC_AGE (6h, in controller/google_watch.py) or
+# healthy channels flap out of trust between sweeps.
+GOOGLE_RECONCILE_INTERVAL_SECONDS=900 # 15 minutes
+# Window re-scanned in each direction after Google invalidates a sync token.
+GOOGLE_FULL_RESYNC_WINDOW_DAYS=90
 
 # -- Zoom API --
 ZOOM_API_ENABLED=False
@@ -133,6 +143,10 @@ CELERY_EAGER=False
 
 # In minutes, the time a cached remote event will expire at.
 REDIS_EVENT_EXPIRE_TIME=15
+# Cache TTL for remote calendar data covered by a live push channel. Push
+# invalidates on change; this only bounds how long a silently dropped
+# notification can go unnoticed.
+REDIS_EVENT_EXPIRE_SECONDS_PUSH=3600 # 1 hour
 
 TBA_PRIVACY_POLICY_LOCATION=../legal/services-privacy-policy.md
 TBA_TERMS_OF_USE_LOCATION=https://raw.githubusercontent.com/mozilla/legal-docs/main/{locale}/websites_tou.md

--- a/backend/.env.test
+++ b/backend/.env.test
@@ -54,6 +54,16 @@ GOOGLE_AUTH_SECRET=
 GOOGLE_AUTH_PROJECT_ID=
 GOOGLE_AUTH_CALLBACK=http://localhost:5000/google/callback
 GOOGLE_CHANNEL_TTL_IN_SECONDS=604800 # 7 days
+# How often to renew watch channels. Renewal is a no-op for channels outside the
+# expiry threshold, so running it often is cheap and gives a failed run more
+# attempts before anything lapses.
+GOOGLE_CHANNEL_RENEW_INTERVAL_SECONDS=3600 # 1 hour
+# How stale a channel may get before the reconciliation sweep re-syncs it. Must
+# stay comfortably below MAX_SYNC_AGE (6h, in controller/google_watch.py) or
+# healthy channels flap out of trust between sweeps.
+GOOGLE_RECONCILE_INTERVAL_SECONDS=900 # 15 minutes
+# Window re-scanned in each direction after Google invalidates a sync token.
+GOOGLE_FULL_RESYNC_WINDOW_DAYS=90
 
 # -- TB ACCOUNTS --
 TB_ACCOUNTS_CALDAV_URL=https://stage-thundermail.com
@@ -108,6 +118,10 @@ CELERY_EAGER=False
 
 # In minutes, the time a cached remote event will expire at.
 REDIS_EVENT_EXPIRE_TIME=15
+# Cache TTL for remote calendar data covered by a live push channel. Push
+# invalidates on change; this only bounds how long a silently dropped
+# notification can go unnoticed.
+REDIS_EVENT_EXPIRE_SECONDS_PUSH=3600 # 1 hour
 REDIS_OIDC_TOKEN_INTROSPECT_EXPIRE_SECONDS=300
 OIDC_EXP_GRACE_PERIOD=300
 OIDC_FALLBACK_MATCH_BY_EMAIL=

--- a/backend/src/appointment/celery_app.py
+++ b/backend/src/appointment/celery_app.py
@@ -3,7 +3,7 @@ import os
 import sentry_sdk
 from celery import Celery
 from dotenv import load_dotenv
-from appointment.defines import ONE_DAY_IN_SECONDS, SEVEN_DAYS_IN_SECONDS
+from appointment.defines import ONE_DAY_IN_SECONDS, ONE_HOUR_IN_SECONDS, SEVEN_DAYS_IN_SECONDS
 
 
 def _base_redis_url() -> str:
@@ -42,7 +42,14 @@ def create_celery_app() -> Celery:
     sentry_sdk.set_extra('CELERY_TASK_ALWAYS_EAGER', task_always_eager)
 
     google_channel_ttl = float(os.getenv('GOOGLE_CHANNEL_TTL_IN_SECONDS', SEVEN_DAYS_IN_SECONDS))
-    google_channel_renew_interval = google_channel_ttl - ONE_DAY_IN_SECONDS
+    # Run renewal well inside the channel lifetime so a failed run has several
+    # more attempts before anything expires. Capped at an hour because the task
+    # is a no-op for channels outside the renewal threshold.
+    google_channel_renew_interval = min(
+        float(os.getenv('GOOGLE_CHANNEL_RENEW_INTERVAL_SECONDS', ONE_HOUR_IN_SECONDS)),
+        max(google_channel_ttl - ONE_DAY_IN_SECONDS, 60.0),
+    )
+    google_reconcile_interval = float(os.getenv('GOOGLE_RECONCILE_INTERVAL_SECONDS', 900))
 
     app = Celery('appointment')
 
@@ -64,9 +71,18 @@ def create_celery_app() -> Celery:
                 'task': 'appointment.tasks.health.heartbeat',
                 'schedule': 60.0,
             },
+            # Renewal only acts on channels inside the expiry threshold, so
+            # running it often is cheap and makes it self-healing: at the old
+            # TTL-minus-a-day cadence a single failed run let channels lapse,
+            # with no second attempt before expiry.
             'renew-google-channels': {
                 'task': 'appointment.tasks.google.renew_google_channels',
                 'schedule': google_channel_renew_interval,
+            },
+            # Bounds how long a dropped push notification can go unnoticed.
+            'reconcile-google-channels': {
+                'task': 'appointment.tasks.google.reconcile_google_channels',
+                'schedule': google_reconcile_interval,
             },
         },
     })

--- a/backend/src/appointment/controller/apis/google_client.py
+++ b/backend/src/appointment/controller/apis/google_client.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import StrEnum
 
 import sentry_sdk
@@ -21,6 +21,30 @@ from ...exceptions.calendar import (
     FreeBusyTimeException
 )
 from ...exceptions.google_api import GoogleScopeChanged, GoogleInvalidCredentials
+
+
+def parse_rfc3339_utc(value: str) -> datetime:
+    """Parse an RFC-3339 UTC timestamp from the Calendar API into a naive UTC datetime.
+
+    Google documents these fields as RFC-3339, which permits fractional seconds.
+    The previous strict '%Y-%m-%dT%H:%M:%SZ' parse raised ValueError on any value
+    that carried them, taking down the whole availability lookup; that was
+    observed against a contract-accurate Calendar twin returning '...T17:52:58.000Z'.
+
+    Returns naive UTC to match what the rest of the busy-time pipeline and the
+    CalDAV connector produce.
+    """
+    try:
+        parsed = datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        # Fall back to the historical strict format so any shape that used to
+        # parse still parses identically.
+        parsed = datetime.strptime(value, DATETIMEFMT)
+
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+
+    return parsed
 
 
 class SendUpdates(StrEnum):
@@ -193,8 +217,8 @@ class GoogleClient:
                         # Transform to datetimes to match caldav's behaviour
                         items += [
                             {
-                                'start': datetime.strptime(entry.get('start'), DATETIMEFMT),
-                                'end': datetime.strptime(entry.get('end'), DATETIMEFMT),
+                                'start': parse_rfc3339_utc(entry.get('start')),
+                                'end': parse_rfc3339_utc(entry.get('end')),
                             }
                             for entry in busy
                         ]

--- a/backend/src/appointment/controller/apis/google_client.py
+++ b/backend/src/appointment/controller/apis/google_client.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import StrEnum
 
 import sentry_sdk
@@ -21,30 +21,6 @@ from ...exceptions.calendar import (
     FreeBusyTimeException
 )
 from ...exceptions.google_api import GoogleScopeChanged, GoogleInvalidCredentials
-
-
-def parse_rfc3339_utc(value: str) -> datetime:
-    """Parse an RFC-3339 UTC timestamp from the Calendar API into a naive UTC datetime.
-
-    Google documents these fields as RFC-3339, which permits fractional seconds.
-    The previous strict '%Y-%m-%dT%H:%M:%SZ' parse raised ValueError on any value
-    that carried them, taking down the whole availability lookup; that was
-    observed against a contract-accurate Calendar twin returning '...T17:52:58.000Z'.
-
-    Returns naive UTC to match what the rest of the busy-time pipeline and the
-    CalDAV connector produce.
-    """
-    try:
-        parsed = datetime.fromisoformat(value)
-    except (TypeError, ValueError):
-        # Fall back to the historical strict format so any shape that used to
-        # parse still parses identically.
-        parsed = datetime.strptime(value, DATETIMEFMT)
-
-    if parsed.tzinfo is not None:
-        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
-
-    return parsed
 
 
 class SendUpdates(StrEnum):
@@ -217,8 +193,8 @@ class GoogleClient:
                         # Transform to datetimes to match caldav's behaviour
                         items += [
                             {
-                                'start': parse_rfc3339_utc(entry.get('start')),
-                                'end': parse_rfc3339_utc(entry.get('end')),
+                                'start': datetime.strptime(entry.get('start'), DATETIMEFMT),
+                                'end': datetime.strptime(entry.get('end'), DATETIMEFMT),
                             }
                             for entry in busy
                         ]
@@ -425,10 +401,14 @@ class GoogleClient:
                     if e.status_code == 410:
                         logging.info('[google_client.list_events_sync] Sync token expired, full sync needed')
                         return None, None
+                    # Anything else must propagate. Returning the partial items
+                    # collected so far is indistinguishable from "nothing
+                    # changed", which lets the caller stamp the channel healthy
+                    # and stop polling on the strength of a failed sync.
                     logging.warning(
                         f'[google_client.list_events_sync] Request Error: {e.status_code}/{e.error_details}'
                     )
-                    break
+                    raise
 
         return items, next_sync_token
 

--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -31,6 +31,7 @@ from sqlalchemy.orm import Session
 from .. import utils
 from ..defines import REDIS_REMOTE_EVENTS_KEY, DATEFMT, DEFAULT_CALENDAR_COLOUR, FALLBACK_LOCALE, APP_ENV_DEV
 from .apis.google_client import EventStatus, GoogleClient, ResponseStatus, SendUpdates
+from . import google_watch
 from ..database.models import CalendarProvider, BookingStatus
 from ..database import schemas, models, repo
 from ..controller.mailer import Attachment
@@ -38,6 +39,19 @@ from ..exceptions.calendar import TestConnectionFailed, RemoteCalendarAuthentica
 from ..exceptions.validation import RemoteCalendarConnectionError
 from ..l10n import l10n
 from ..tasks.emails import send_invite_email, send_pending_email, send_rejection_email, send_cancel_email
+
+
+def push_cache_expiry() -> int:
+    """Cache TTL, in seconds, for data covered by a live push channel.
+
+    This is a safety net, not the primary refresh mechanism -- a push
+    notification busts the cache as soon as the calendar changes. It bounds how
+    long a *silently* dropped notification can go unnoticed, so it trades
+    staleness against API volume. Reads are the only consumer; the booking write
+    path re-validates against Google regardless (see routes.schedule), so a stale
+    read cannot produce a double booking.
+    """
+    return int(os.getenv('REDIS_EVENT_EXPIRE_SECONDS_PUSH', 3600))
 
 
 class RemoteEventState(Enum):
@@ -105,28 +119,89 @@ class BaseConnector:
 
         return True
 
-    def bust_cached_events(self, all_calendars=False):
-        """Delete cached events for a specific subscriber/calendar.
-        Optionally pass in all_calendars to remove all cached calendar events for a specific subscriber."""
+    def get_cached_busy_times(self, key_scope):
+        """Retrieve cached free/busy blocks, or None when unavailable/uncached.
+
+        Free/busy entries are plain {start, end} dicts of naive-UTC datetimes
+        rather than schemas.Event, but they share the remote-events key prefix so
+        a single bust clears both. Values round-trip back to datetimes so callers
+        cannot tell a cache hit from a fresh fetch.
+        """
+        if self.redis_instance is None:
+            return None
+
+        key_scope = self.obscure_key(key_scope)
+        encrypted = self.redis_instance.get(f'{REDIS_REMOTE_EVENTS_KEY}:{self.get_key_body()}:{key_scope}')
+        if encrypted is None:
+            return None
+
+        try:
+            return [
+                {'start': datetime.fromisoformat(entry['start']), 'end': datetime.fromisoformat(entry['end'])}
+                for entry in json.loads(encrypted)
+            ]
+        except (ValueError, TypeError, KeyError):
+            # A malformed entry must not take down availability; treat as a miss.
+            return None
+
+    def put_cached_busy_times(self, key_scope, busy_times: list[dict], expiry=None):
+        """Cache free/busy blocks. Returns False when redis isn't available."""
         if self.redis_instance is None:
             return False
 
-        timer_boot = time.perf_counter_ns()
+        if expiry is None:
+            expiry = os.getenv('REDIS_EVENT_EXPIRE_SECONDS', 900)
 
-        # Scan returns a tuple like: (Cursor start, [...keys found])
-        ret = self.redis_instance.scan(
-            0, f'{REDIS_REMOTE_EVENTS_KEY}:{self.get_key_body(only_subscriber=all_calendars)}:*'
-        )
-
-        if len(ret[1]) == 0:
+        try:
+            serialised = [
+                {'start': entry['start'].isoformat(), 'end': entry['end'].isoformat()}
+                for entry in busy_times
+            ]
+        except (AttributeError, KeyError, TypeError):
+            # Unexpected shape: skip caching rather than poison the cache.
+            logging.warning('[BaseConnector.put_cached_busy_times] Unexpected free/busy shape, not caching')
             return False
 
-        # Expand the list in position 1, which is a list of keys found from the scan
-        self.redis_instance.delete(*ret[1])
+        key_scope = self.obscure_key(key_scope)
+        self.redis_instance.set(
+            f'{REDIS_REMOTE_EVENTS_KEY}:{self.get_key_body()}:{key_scope}',
+            value=json.dumps(serialised),
+            ex=expiry,
+        )
+        return True
+
+    def bust_cached_events(self, all_calendars=False):
+        """Delete cached events for a specific subscriber/calendar.
+        Optionally pass in all_calendars to remove all cached calendar events for a specific subscriber.
+
+        Walks the whole keyspace with scan_iter. The previous implementation read
+        a single SCAN batch, which Redis does not guarantee to be complete, so a
+        bust could silently leave entries behind. Two callers depend on this being
+        exhaustive: the booking write path re-checks availability immediately
+        after busting, and push notifications use it to invalidate on change.
+
+        Returns the number of keys deleted.
+        """
+        if self.redis_instance is None:
+            return 0
+
+        timer_boot = time.perf_counter_ns()
+        match = f'{REDIS_REMOTE_EVENTS_KEY}:{self.get_key_body(only_subscriber=all_calendars)}:*'
+
+        deleted = 0
+        # Delete in batches; scan_iter keeps memory flat on large keyspaces.
+        batch = []
+        for key in self.redis_instance.scan_iter(match=match, count=500):
+            batch.append(key)
+            if len(batch) >= 500:
+                deleted += self.redis_instance.delete(*batch)
+                batch = []
+        if batch:
+            deleted += self.redis_instance.delete(*batch)
 
         sentry_sdk.set_measurement('redis_bust_time', time.perf_counter_ns() - timer_boot, 'nanosecond')
 
-        return True
+        return deleted
 
 
 class GoogleConnector(BaseConnector):
@@ -155,16 +230,65 @@ class GoogleConnector(BaseConnector):
         if google_tkn:
             self.google_token = Credentials.from_authorized_user_info(json.loads(google_tkn), self.google_client.SCOPES)
 
-    def get_busy_time(self, calendar_ids: list, start: str, end: str):
-        """Retrieve a list of { start, end } dicts that will indicate busy time for a user
-        Note: This does not use the remote_calendar_id from the class,
-        all calendars must be available under the google_token provided to the class"""
-        time_min = datetime.strptime(start, DATEFMT).isoformat() + 'Z'
-        time_max = datetime.strptime(end, DATEFMT).isoformat() + 'Z'
+    def _push_backed_remote_ids(self, calendar_ids: list) -> set:
+        """Which of `calendar_ids` currently have a live push channel.
 
+        Returns an empty set on any failure: not knowing means we poll, which is
+        the safe direction.
+        """
+        if self.db is None:
+            return set()
+
+        try:
+            calendars = repo.calendar.get_by_subscriber(self.db, self.subscriber_id, False)
+            wanted = set(calendar_ids)
+            relevant = [c for c in calendars if c.user in wanted]
+            return google_watch.push_backed_calendar_ids(self.db, relevant)
+        except Exception as ex:
+            logging.warning(f'[GoogleConnector._push_backed_remote_ids] Falling back to polling: {ex}')
+            return set()
+
+    def _fetch_free_busy(self, calendar_ids: list, time_min: str, time_max: str):
         results = []
         for calendars in utils.chunk_list(calendar_ids, chunk_by=5):
             results += self.google_client.get_free_busy(calendars, time_min, time_max, self.google_token)
+        return results
+
+    def get_busy_time(self, calendar_ids: list, start: str, end: str):
+        """Retrieve a list of { start, end } dicts that will indicate busy time for a user
+        Note: This does not use the remote_calendar_id from the class,
+        all calendars must be available under the google_token provided to the class
+
+        Calendars with a live push channel are served from cache when possible:
+        a push notification busts that cache, so the cached answer is refreshed on
+        change rather than on every request. Calendars without live push are
+        always fetched fresh, exactly as before.
+        """
+        time_min = datetime.strptime(start, DATEFMT).isoformat() + 'Z'
+        time_max = datetime.strptime(end, DATEFMT).isoformat() + 'Z'
+
+        push_backed = self._push_backed_remote_ids(calendar_ids)
+        # Preserve caller ordering so results stay stable between requests.
+        cacheable = [cid for cid in calendar_ids if cid in push_backed]
+        uncacheable = [cid for cid in calendar_ids if cid not in push_backed]
+
+        results = []
+
+        if cacheable:
+            # The key has to cover the exact calendar set, or a request for a
+            # subset would be served an answer computed for a superset.
+            scope = f'freebusy_{utils.stable_hash(sorted(cacheable))}_{start}_{end}'
+            cached = self.get_cached_busy_times(scope)
+            if cached is not None:
+                results += cached
+            else:
+                fetched = self._fetch_free_busy(cacheable, time_min, time_max)
+                self.put_cached_busy_times(scope, fetched, expiry=push_cache_expiry())
+                results += fetched
+
+        if uncacheable:
+            results += self._fetch_free_busy(uncacheable, time_min, time_max)
+
         return results
 
     def test_connection(self) -> bool:
@@ -261,7 +385,12 @@ class GoogleConnector(BaseConnector):
                 )
             )
 
-        self.put_cached_events(cache_scope, events)
+        # With a live push channel this cache is invalidated on change, so it can
+        # be held far longer than the blind time-based default.
+        if self.remote_calendar_id in self._push_backed_remote_ids([self.remote_calendar_id]):
+            self.put_cached_events(cache_scope, events, expiry=push_cache_expiry())
+        else:
+            self.put_cached_events(cache_scope, events)
 
         return events
 

--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -230,13 +230,22 @@ class GoogleConnector(BaseConnector):
         if google_tkn:
             self.google_token = Credentials.from_authorized_user_info(json.loads(google_tkn), self.google_client.SCOPES)
 
+    def _push_is_enabled(self) -> bool:
+        """Whether watch channels can exist at all.
+
+        routes.schedule only ever creates them under this flag, so with it off the
+        channel lookups below are guaranteed to come back empty -- and this runs on
+        the public availability path, so the queries are worth skipping outright.
+        """
+        return self.db is not None and os.getenv('GOOGLE_INVITE_ENABLED') == 'True'
+
     def _push_backed_remote_ids(self, calendar_ids: list) -> set:
         """Which of `calendar_ids` currently have a live push channel.
 
         Returns an empty set on any failure: not knowing means we poll, which is
         the safe direction.
         """
-        if self.db is None:
+        if not self._push_is_enabled():
             return set()
 
         try:
@@ -247,6 +256,18 @@ class GoogleConnector(BaseConnector):
         except Exception as ex:
             logging.warning(f'[GoogleConnector._push_backed_remote_ids] Falling back to polling: {ex}')
             return set()
+
+    def _push_backed_for_this_calendar(self) -> bool:
+        """Whether this connector's own calendar has a live push channel."""
+        if not self._push_is_enabled() or self.calendar_id is None:
+            return False
+
+        try:
+            channel = repo.google_calendar_channel.get_by_calendar_id(self.db, self.calendar_id)
+            return google_watch.is_push_active(channel)
+        except Exception as ex:
+            logging.warning(f'[GoogleConnector._push_backed_for_this_calendar] Falling back to polling: {ex}')
+            return False
 
     def _fetch_free_busy(self, calendar_ids: list, time_min: str, time_max: str):
         results = []
@@ -386,8 +407,10 @@ class GoogleConnector(BaseConnector):
             )
 
         # With a live push channel this cache is invalidated on change, so it can
-        # be held far longer than the blind time-based default.
-        if self.remote_calendar_id in self._push_backed_remote_ids([self.remote_calendar_id]):
+        # be held far longer than the blind time-based default. This connector is
+        # already scoped to one calendar, so ask about that channel directly
+        # rather than listing every calendar the subscriber owns.
+        if self._push_backed_for_this_calendar():
             self.put_cached_events(cache_scope, events, expiry=push_cache_expiry())
         else:
             self.put_cached_events(cache_scope, events)

--- a/backend/src/appointment/controller/google_watch.py
+++ b/backend/src/appointment/controller/google_watch.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from google.oauth2.credentials import Credentials
 from sqlalchemy.orm import Session
@@ -12,6 +12,83 @@ from sqlalchemy.orm import Session
 from .apis.google_client import GoogleClient
 from ..database import repo, models
 from ..tasks.google import stop_google_channel
+
+
+# How close to its expiration a channel may get before we stop trusting push
+# delivery. Google stops sending as soon as the channel lapses, so we need to
+# stop trusting it slightly *before* the recorded expiry rather than at it.
+CHANNEL_EXPIRY_MARGIN = timedelta(minutes=5)
+
+# The longest a channel may go without a successful sync before we stop trusting
+# it. Reconciliation (tasks.google.reconcile_google_channels) runs well inside
+# this window, so hitting it means push *and* reconciliation are both failing --
+# at which point we fall back to polling rather than serve unbounded staleness.
+MAX_SYNC_AGE = timedelta(hours=6)
+
+
+def _as_utc(value: datetime | None) -> datetime | None:
+    """Normalise a possibly naive DB datetime to an aware UTC one.
+
+    Columns are stored naive-UTC, but values that have just come off the wire are
+    aware. Comparing the two raises, so everything funnels through here.
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def is_push_active(channel: models.GoogleCalendarChannel | None, now: datetime | None = None) -> bool:
+    """Whether push delivery on this channel can be trusted in place of polling.
+
+    This is deliberately conservative: every uncertain case answers False, which
+    only costs a Google API call. Answering True when push is in fact dead is the
+    failure that shows users stale availability, so it has to be earned:
+
+      * the channel must exist and still be registered with Google,
+      * it must not be at or near its expiration,
+      * it must have completed an initial sync (so we hold a sync token), and
+      * that sync must be recent enough that a silently dead channel is caught.
+    """
+    if channel is None:
+        return False
+
+    now = now or datetime.now(tz=timezone.utc)
+
+    expiration = _as_utc(channel.expiration)
+    if expiration is None or expiration - CHANNEL_EXPIRY_MARGIN <= now:
+        return False
+
+    # No sync token means we have never established a delta chain for this
+    # calendar, so a notification could not tell us what changed.
+    if not channel.sync_token:
+        return False
+
+    last_synced_at = _as_utc(channel.last_synced_at)
+    if last_synced_at is None or now - last_synced_at > MAX_SYNC_AGE:
+        return False
+
+    return True
+
+
+def push_backed_calendar_ids(db: Session, calendars: list[models.Calendar]) -> set[str]:
+    """The remote (Google) calendar ids among `calendars` that have live push.
+
+    Returns remote ids -- i.e. `Calendar.user` -- because the freebusy call sites
+    work in Google's ids rather than ours.
+    """
+    now = datetime.now(tz=timezone.utc)
+    backed = set()
+
+    for calendar in calendars:
+        if calendar.provider != models.CalendarProvider.google:
+            continue
+        channel = repo.google_calendar_channel.get_by_calendar_id(db, calendar.id)
+        if is_push_active(channel, now):
+            backed.add(calendar.user)
+
+    return backed
 
 
 def get_webhook_url() -> str | None:
@@ -78,6 +155,10 @@ def setup_watch_channel(db: Session, google_client: GoogleClient, calendar: mode
                 expiration=expiration_dt,
                 state=state,
                 sync_token=sync_token,
+                # Only stamp the watermark if we actually got a token. Without
+                # one there is no delta chain, so the channel must not yet be
+                # trusted in place of polling.
+                last_synced_at=datetime.now(tz=timezone.utc) if sync_token else None,
             )
     except Exception as e:
         logging.warning(f'[google_watch] Failed to set up watch channel for calendar {calendar.id}: {e}')

--- a/backend/src/appointment/database/models.py
+++ b/backend/src/appointment/database/models.py
@@ -481,6 +481,15 @@ class GoogleCalendarChannel(Base):
     sync_token = Column(String, nullable=True)
     state = Column(encrypted_type(String, length=36), nullable=True)
 
+    # Push-health bookkeeping. These drive the decision to trust push delivery
+    # instead of polling Google on every request (see controller.google_watch).
+    # last_synced_at is the only one that gates trust: it is the watermark of the
+    # last *successful* incremental sync, so it advances on both push-triggered
+    # and reconciliation syncs.
+    last_synced_at = Column(DateTime, nullable=True)
+    last_notification_at = Column(DateTime, nullable=True)
+    last_message_number = Column(Integer, nullable=True)
+
     calendar: Mapped[Calendar] = relationship('Calendar', back_populates='google_channel')
 
     def __str__(self):

--- a/backend/src/appointment/database/models.py
+++ b/backend/src/appointment/database/models.py
@@ -481,14 +481,14 @@ class GoogleCalendarChannel(Base):
     sync_token = Column(String, nullable=True)
     state = Column(encrypted_type(String, length=36), nullable=True)
 
-    # Push-health bookkeeping. These drive the decision to trust push delivery
-    # instead of polling Google on every request (see controller.google_watch).
-    # last_synced_at is the only one that gates trust: it is the watermark of the
-    # last *successful* incremental sync, so it advances on both push-triggered
-    # and reconciliation syncs.
+    # Push-health bookkeeping. last_synced_at is the watermark of the last
+    # *successful* incremental sync (advancing on both push-triggered and
+    # reconciliation syncs) and is the only column that gates trust -- see
+    # controller.google_watch.is_push_active.
     last_synced_at = Column(DateTime, nullable=True)
+    # Observability only: when a notification was last received. Deliberately not
+    # a trust input, since a quiet channel and a broken one look identical here.
     last_notification_at = Column(DateTime, nullable=True)
-    last_message_number = Column(Integer, nullable=True)
 
     calendar: Mapped[Calendar] = relationship('Calendar', back_populates='google_channel')
 

--- a/backend/src/appointment/database/repo/google_calendar_channel.py
+++ b/backend/src/appointment/database/repo/google_calendar_channel.py
@@ -98,32 +98,20 @@ def record_sync(db: Session, channel: models.GoogleCalendarChannel, sync_token: 
 def record_notification(
     db: Session,
     channel: models.GoogleCalendarChannel,
-    message_number: int | None = None,
     expiration: datetime | None = None,
-) -> int | None:
+):
     """Record an inbound push notification.
-
-    Returns the previously-seen message number so the caller can spot gaps
-    (dropped deliveries) and replays (duplicate deliveries).
 
     Google re-states the channel expiration on every notification, so we take the
     opportunity to correct our stored copy for free.
     """
-    previous = channel.last_message_number
-
-    if message_number is not None:
-        # Never let a replayed or out-of-order delivery walk the high-water mark
-        # backwards.
-        if previous is None or message_number > previous:
-            channel.last_message_number = message_number
-
     if expiration is not None:
         channel.expiration = expiration.replace(tzinfo=None) if expiration.tzinfo else expiration
 
     channel.last_notification_at = datetime.now(tz=timezone.utc).replace(tzinfo=None)
     db.commit()
     db.refresh(channel)
-    return previous
+    return channel
 
 
 def update_expiration(

--- a/backend/src/appointment/database/repo/google_calendar_channel.py
+++ b/backend/src/appointment/database/repo/google_calendar_channel.py
@@ -3,7 +3,7 @@
 Repository providing CRUD functions for GoogleCalendarChannel database models.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
 from .. import models
@@ -33,6 +33,22 @@ def get_expiring(db: Session, before: datetime) -> list[models.GoogleCalendarCha
     )
 
 
+def get_stale(db: Session, synced_before: datetime) -> list[models.GoogleCalendarChannel]:
+    """Channels whose last successful sync is older than `synced_before`.
+
+    Channels that have never synced are included: they hold no delta chain, so
+    they are the staleest of all.
+    """
+    return (
+        db.query(models.GoogleCalendarChannel)
+        .filter(
+            (models.GoogleCalendarChannel.last_synced_at.is_(None))
+            | (models.GoogleCalendarChannel.last_synced_at < synced_before)
+        )
+        .all()
+    )
+
+
 def create(
     db: Session,
     calendar_id: int,
@@ -41,6 +57,7 @@ def create(
     expiration: datetime,
     state: str,
     sync_token: str | None = None,
+    last_synced_at: datetime | None = None,
 ) -> models.GoogleCalendarChannel:
     channel = models.GoogleCalendarChannel(
         calendar_id=calendar_id,
@@ -49,6 +66,7 @@ def create(
         expiration=expiration,
         sync_token=sync_token,
         state=state,
+        last_synced_at=last_synced_at,
     )
     db.add(channel)
     db.commit()
@@ -61,6 +79,51 @@ def update_sync_token(db: Session, channel: models.GoogleCalendarChannel, sync_t
     db.commit()
     db.refresh(channel)
     return channel
+
+
+def record_sync(db: Session, channel: models.GoogleCalendarChannel, sync_token: str | None = None):
+    """Stamp a successful sync, optionally advancing the sync token.
+
+    This is the watermark `is_push_active` trusts, so it must only be called
+    after Google has actually answered.
+    """
+    if sync_token:
+        channel.sync_token = sync_token
+    channel.last_synced_at = datetime.now(tz=timezone.utc).replace(tzinfo=None)
+    db.commit()
+    db.refresh(channel)
+    return channel
+
+
+def record_notification(
+    db: Session,
+    channel: models.GoogleCalendarChannel,
+    message_number: int | None = None,
+    expiration: datetime | None = None,
+) -> int | None:
+    """Record an inbound push notification.
+
+    Returns the previously-seen message number so the caller can spot gaps
+    (dropped deliveries) and replays (duplicate deliveries).
+
+    Google re-states the channel expiration on every notification, so we take the
+    opportunity to correct our stored copy for free.
+    """
+    previous = channel.last_message_number
+
+    if message_number is not None:
+        # Never let a replayed or out-of-order delivery walk the high-water mark
+        # backwards.
+        if previous is None or message_number > previous:
+            channel.last_message_number = message_number
+
+    if expiration is not None:
+        channel.expiration = expiration.replace(tzinfo=None) if expiration.tzinfo else expiration
+
+    channel.last_notification_at = datetime.now(tz=timezone.utc).replace(tzinfo=None)
+    db.commit()
+    db.refresh(channel)
+    return previous
 
 
 def update_expiration(

--- a/backend/src/appointment/database/repo/google_calendar_channel.py
+++ b/backend/src/appointment/database/repo/google_calendar_channel.py
@@ -95,19 +95,13 @@ def record_sync(db: Session, channel: models.GoogleCalendarChannel, sync_token: 
     return channel
 
 
-def record_notification(
-    db: Session,
-    channel: models.GoogleCalendarChannel,
-    expiration: datetime | None = None,
-):
-    """Record an inbound push notification.
+def record_notification(db: Session, channel: models.GoogleCalendarChannel):
+    """Record that a push notification arrived on this channel.
 
-    Google re-states the channel expiration on every notification, so we take the
-    opportunity to correct our stored copy for free.
+    Observability only. Paired with last_synced_at it separates "Google stopped
+    telling us" from "we heard, and failed to act on it", which is otherwise not
+    something we can tell apart after the fact.
     """
-    if expiration is not None:
-        channel.expiration = expiration.replace(tzinfo=None) if expiration.tzinfo else expiration
-
     channel.last_notification_at = datetime.now(tz=timezone.utc).replace(tzinfo=None)
     db.commit()
     db.refresh(channel)

--- a/backend/src/appointment/defines.py
+++ b/backend/src/appointment/defines.py
@@ -41,6 +41,7 @@ ACCOUNTS_CALDAV_SETUP_RETRY_DELAY_SECONDS = 2
 # Resolves to absolute appointment package path
 BASE_PATH = f'{sys.modules["appointment"].__path__[0]}'
 
+ONE_HOUR_IN_SECONDS = 3600
 ONE_DAY_IN_SECONDS = 86400
 SEVEN_DAYS_IN_SECONDS = 604800
 

--- a/backend/src/appointment/migrations/versions/2026_08_11_1200-e5f6a7b8c9d0_add_push_health_to_google_channels.py
+++ b/backend/src/appointment/migrations/versions/2026_08_11_1200-e5f6a7b8c9d0_add_push_health_to_google_channels.py
@@ -5,7 +5,6 @@ whether a channel can be trusted in place of polling:
 
   last_synced_at       - watermark of the last successful incremental sync
   last_notification_at - when a push notification was last received
-  last_message_number  - highest X-Goog-Message-Number seen on this channel
 
 Revision ID: e5f6a7b8c9d0
 Revises: d4e5f6a7b8c9
@@ -27,7 +26,6 @@ TABLE = 'google_calendar_channels'
 COLUMNS = (
     ('last_synced_at', sa.DateTime()),
     ('last_notification_at', sa.DateTime()),
-    ('last_message_number', sa.Integer()),
 )
 
 

--- a/backend/src/appointment/migrations/versions/2026_08_11_1200-e5f6a7b8c9d0_add_push_health_to_google_channels.py
+++ b/backend/src/appointment/migrations/versions/2026_08_11_1200-e5f6a7b8c9d0_add_push_health_to_google_channels.py
@@ -1,0 +1,50 @@
+"""add push-health columns to google_calendar_channels
+
+Adds the bookkeeping the push-driven cache invalidation relies on to decide
+whether a channel can be trusted in place of polling:
+
+  last_synced_at       - watermark of the last successful incremental sync
+  last_notification_at - when a push notification was last received
+  last_message_number  - highest X-Goog-Message-Number seen on this channel
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-08-11 12:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+# revision identifiers, used by Alembic.
+revision = 'e5f6a7b8c9d0'
+down_revision = 'd4e5f6a7b8c9'
+branch_labels = None
+depends_on = None
+
+TABLE = 'google_calendar_channels'
+COLUMNS = (
+    ('last_synced_at', sa.DateTime()),
+    ('last_notification_at', sa.DateTime()),
+    ('last_message_number', sa.Integer()),
+)
+
+
+def _column_exists(connection, table, column) -> bool:
+    insp = inspect(connection)
+    return column in [c['name'] for c in insp.get_columns(table)]
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    for name, type_ in COLUMNS:
+        if not _column_exists(connection, TABLE, name):
+            op.add_column(TABLE, sa.Column(name, type_, nullable=True))
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    for name, _ in reversed(COLUMNS):
+        if _column_exists(connection, TABLE, name):
+            op.drop_column(TABLE, name)

--- a/backend/src/appointment/routes/webhooks.py
+++ b/backend/src/appointment/routes/webhooks.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 
 import sentry_sdk
 from fastapi import APIRouter, Depends, Request, Response
@@ -80,49 +81,36 @@ def google_calendar_notification(
     # Google re-states the channel's expiration on every notification, so keep our
     # copy honest -- it is what is_push_active() trusts.
     expiration = _parse_expiration(request.headers.get('X-Goog-Channel-Expiration'))
-    message_number = _parse_message_number(request.headers.get('X-Goog-Message-Number'))
 
-    previous_message_number = repo.google_calendar_channel.record_notification(
-        db, channel, message_number=message_number, expiration=expiration
-    )
-
-    # Message numbers are per-channel and monotonic, so they tell us whether
-    # delivery has been lossy. Neither case changes what we do -- the sync is
-    # driven by the stored sync token, which is a watermark and therefore both
-    # gap-filling and replay-safe -- but both are worth surfacing.
-    if message_number is not None and previous_message_number is not None:
-        if message_number > previous_message_number + 1:
-            logging.warning(
-                f'[webhooks.google_calendar] Missed {message_number - previous_message_number - 1} '
-                f'notification(s) on channel {channel_id}; the sync token will cover the gap'
-            )
-        elif message_number <= previous_message_number:
-            logging.info(
-                f'[webhooks.google_calendar] Duplicate/out-of-order notification {message_number} '
-                f'on channel {channel_id} (already saw {previous_message_number}); syncing anyway'
-            )
+    repo.google_calendar_channel.record_notification(db, channel, expiration=expiration)
 
     sync_google_calendar_changes.delay(channel_id)
 
     return success_response
 
 
-def _parse_message_number(raw: str | None) -> int | None:
-    if not raw:
-        return None
-    try:
-        return int(raw)
-    except (TypeError, ValueError):
-        logging.warning(f'[webhooks.google_calendar] Unparsable X-Goog-Message-Number: {raw!r}')
-        return None
-
-
 def _parse_expiration(raw: str | None) -> datetime | None:
-    """Parse the X-Goog-Channel-Expiration header (Unix milliseconds, as a string)."""
+    """Parse the X-Goog-Channel-Expiration header into an aware UTC datetime.
+
+    The header is an RFC-1123 date string, e.g. 'Tue, 19 Nov 2013 01:13:52 GMT' --
+    *not* the epoch-milliseconds integer that the watch API response body uses for
+    the same value (see google_watch.setup_watch_channel, which parses that one).
+    Ref: https://developers.google.com/workspace/calendar/api/guides/push
+
+    A naive result is rejected rather than assumed to be UTC: record_notification
+    stores whatever it is given as naive-UTC, so an unzoned parse would write a
+    timestamp of unknown offset into the column is_push_active() trusts.
+    """
     if not raw:
         return None
     try:
-        return datetime.fromtimestamp(int(raw) / 1000, tz=timezone.utc)
-    except (TypeError, ValueError, OSError, OverflowError):
+        parsed = parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
         logging.warning(f'[webhooks.google_calendar] Unparsable X-Goog-Channel-Expiration: {raw!r}')
         return None
+
+    if parsed.tzinfo is None:
+        logging.warning(f'[webhooks.google_calendar] X-Goog-Channel-Expiration has no timezone: {raw!r}')
+        return None
+
+    return parsed.astimezone(timezone.utc)

--- a/backend/src/appointment/routes/webhooks.py
+++ b/backend/src/appointment/routes/webhooks.py
@@ -1,6 +1,4 @@
 import logging
-from datetime import datetime, timezone
-from email.utils import parsedate_to_datetime
 
 import sentry_sdk
 from fastapi import APIRouter, Depends, Request, Response
@@ -78,39 +76,8 @@ def google_calendar_notification(
         teardown_watch_channel(db, calendar)
         return success_response
 
-    # Google re-states the channel's expiration on every notification, so keep our
-    # copy honest -- it is what is_push_active() trusts.
-    expiration = _parse_expiration(request.headers.get('X-Goog-Channel-Expiration'))
-
-    repo.google_calendar_channel.record_notification(db, channel, expiration=expiration)
+    repo.google_calendar_channel.record_notification(db, channel)
 
     sync_google_calendar_changes.delay(channel_id)
 
     return success_response
-
-
-def _parse_expiration(raw: str | None) -> datetime | None:
-    """Parse the X-Goog-Channel-Expiration header into an aware UTC datetime.
-
-    The header is an RFC-1123 date string, e.g. 'Tue, 19 Nov 2013 01:13:52 GMT' --
-    *not* the epoch-milliseconds integer that the watch API response body uses for
-    the same value (see google_watch.setup_watch_channel, which parses that one).
-    Ref: https://developers.google.com/workspace/calendar/api/guides/push
-
-    A naive result is rejected rather than assumed to be UTC: record_notification
-    stores whatever it is given as naive-UTC, so an unzoned parse would write a
-    timestamp of unknown offset into the column is_push_active() trusts.
-    """
-    if not raw:
-        return None
-    try:
-        parsed = parsedate_to_datetime(raw)
-    except (TypeError, ValueError):
-        logging.warning(f'[webhooks.google_calendar] Unparsable X-Goog-Channel-Expiration: {raw!r}')
-        return None
-
-    if parsed.tzinfo is None:
-        logging.warning(f'[webhooks.google_calendar] X-Goog-Channel-Expiration has no timezone: {raw!r}')
-        return None
-
-    return parsed.astimezone(timezone.utc)

--- a/backend/src/appointment/routes/webhooks.py
+++ b/backend/src/appointment/routes/webhooks.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timezone
 
 import sentry_sdk
 from fastapi import APIRouter, Depends, Request, Response
@@ -76,6 +77,52 @@ def google_calendar_notification(
         teardown_watch_channel(db, calendar)
         return success_response
 
+    # Google re-states the channel's expiration on every notification, so keep our
+    # copy honest -- it is what is_push_active() trusts.
+    expiration = _parse_expiration(request.headers.get('X-Goog-Channel-Expiration'))
+    message_number = _parse_message_number(request.headers.get('X-Goog-Message-Number'))
+
+    previous_message_number = repo.google_calendar_channel.record_notification(
+        db, channel, message_number=message_number, expiration=expiration
+    )
+
+    # Message numbers are per-channel and monotonic, so they tell us whether
+    # delivery has been lossy. Neither case changes what we do -- the sync is
+    # driven by the stored sync token, which is a watermark and therefore both
+    # gap-filling and replay-safe -- but both are worth surfacing.
+    if message_number is not None and previous_message_number is not None:
+        if message_number > previous_message_number + 1:
+            logging.warning(
+                f'[webhooks.google_calendar] Missed {message_number - previous_message_number - 1} '
+                f'notification(s) on channel {channel_id}; the sync token will cover the gap'
+            )
+        elif message_number <= previous_message_number:
+            logging.info(
+                f'[webhooks.google_calendar] Duplicate/out-of-order notification {message_number} '
+                f'on channel {channel_id} (already saw {previous_message_number}); syncing anyway'
+            )
+
     sync_google_calendar_changes.delay(channel_id)
 
     return success_response
+
+
+def _parse_message_number(raw: str | None) -> int | None:
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        logging.warning(f'[webhooks.google_calendar] Unparsable X-Goog-Message-Number: {raw!r}')
+        return None
+
+
+def _parse_expiration(raw: str | None) -> datetime | None:
+    """Parse the X-Goog-Channel-Expiration header (Unix milliseconds, as a string)."""
+    if not raw:
+        return None
+    try:
+        return datetime.fromtimestamp(int(raw) / 1000, tz=timezone.utc)
+    except (TypeError, ValueError, OSError, OverflowError):
+        logging.warning(f'[webhooks.google_calendar] Unparsable X-Goog-Channel-Expiration: {raw!r}')
+        return None

--- a/backend/src/appointment/tasks/google.py
+++ b/backend/src/appointment/tasks/google.py
@@ -161,6 +161,15 @@ def sync_google_calendar_changes(self, channel_id: str):
             _recover_from_invalid_sync_token(db, channel, calendar, google_client, google_token)
             return
 
+        if not new_sync_token:
+            # A completed pagination always ends with a nextSyncToken. Without one
+            # there is no delta chain to continue, so treating this as a successful
+            # empty sync would stamp the channel healthy on an invalid response and
+            # silence the task's retry policy. Raise before touching any state.
+            raise RuntimeError(
+                f'[tasks.google] No sync token returned for channel {channel_id}; refusing to record sync'
+            )
+
         if changed_events:
             _process_changed_events(
                 db, calendar.id, changed_events, google_client, google_token, calendar.user
@@ -220,12 +229,22 @@ def _recover_from_invalid_sync_token(
     An invalidated sync token means we cannot know what changed. Recovery is:
       1. drop the cache, so reads stop trusting anything derived from the lost
          delta and fall back to Google,
-      2. re-scan a bounded forward window and re-apply RSVP/cancellation state,
-         so bookings that changed during the blackout are not missed,
-      3. establish a fresh token and re-stamp the watermark.
+      2. re-scan a bounded window and re-apply RSVP/cancellation state, so
+         bookings that changed during the blackout are not missed,
+      3. only then establish a fresh token and re-stamp the watermark.
 
-    If step 3 fails the watermark is left alone, so is_push_active() ages the
-    channel out and read paths return to polling -- stale, never silently wrong.
+    The ordering of 2 and 3 is the whole safety property. A fresh sync token
+    starts its delta chain *after* the blackout, so once it is stored the lost
+    changes are unrecoverable by any later sync -- reconciliation cannot help,
+    because nothing is left that knows they were missed. Step 2 failing is
+    therefore the dangerous case, and it must abort recovery rather than fall
+    through: we keep the old (invalid) token, so the next attempt re-enters
+    recovery instead of skipping past the gap.
+
+    The cache is busted *before* the scan on purpose. is_push_active() does not
+    go false here -- last_synced_at is untouched by a 410, so the gate keeps
+    trusting the channel for up to MAX_SYNC_AGE -- which means anything derived
+    from the lost delta would keep being served if we waited for success.
     """
     log.info(f'[tasks.google] Sync token invalidated for channel {channel.channel_id}, running full resync')
 
@@ -234,9 +253,12 @@ def _recover_from_invalid_sync_token(
     now = datetime.now(tz=timezone.utc)
     window_days = int(os.getenv('GOOGLE_FULL_RESYNC_WINDOW_DAYS', 90))
     try:
+        # Symmetric window: an event that started before now may still be running
+        # or have been modified during the blackout, and a forward-only scan
+        # would never see it.
         events = google_client.list_events(
             calendar.user,
-            now.isoformat(),
+            (now - timedelta(days=window_days)).isoformat(),
             (now + timedelta(days=window_days)).isoformat(),
             google_token,
         )
@@ -245,11 +267,13 @@ def _recover_from_invalid_sync_token(
                 db, calendar.id, events, google_client, google_token, calendar.user
             )
     except Exception as ex:
-        # Fall through to re-establish the token regardless; the reconciliation
-        # sweep will retry, and until it succeeds the stale watermark keeps read
-        # paths polling.
+        # Do not re-establish the token: that would trade a recoverable gap for
+        # a permanent one. Raising hands the retry to the task's own policy, and
+        # on exhaustion the untouched watermark ages the channel out of trust so
+        # reads fall back to polling.
         log.warning(f'[tasks.google] Full resync scan failed for channel {channel.channel_id}: {ex}')
         sentry_sdk.capture_exception(ex)
+        raise
 
     fresh_token = google_client.get_initial_sync_token(calendar.user, google_token)
     if fresh_token:

--- a/backend/src/appointment/tasks/google.py
+++ b/backend/src/appointment/tasks/google.py
@@ -1,5 +1,7 @@
 import json
 import logging
+import os
+from datetime import datetime, timedelta, timezone
 
 import sentry_sdk
 from google.oauth2.credentials import Credentials
@@ -11,7 +13,7 @@ from appointment.controller import zoom
 from appointment.database import repo, models, schemas
 from appointment.database.models import MeetingLinkProviderType
 from appointment.defines import FALLBACK_LOCALE
-from appointment.dependencies.database import get_engine_and_session
+from appointment.dependencies.database import get_engine_and_session, get_redis
 from appointment.dependencies.google import get_google_client
 from appointment.l10n import l10n
 
@@ -30,6 +32,62 @@ def renew_google_channels():
         sentry_sdk.capture_exception(e)
         raise
     log.info('Google Calendar channel renewal complete')
+
+
+@celery.task
+def reconcile_google_channels():
+    """Periodically sync channels that push has not refreshed recently.
+
+    Push delivery is best-effort: Google does not guarantee a notification for
+    every change, and a channel can go quiet because nothing happened or because
+    delivery is broken -- the two are indistinguishable from our side. This sweep
+    removes the need to tell them apart by syncing any channel that has not been
+    refreshed within the reconcile interval, which bounds how long a dropped
+    notification can go unnoticed.
+
+    If this sweep itself stops working, `last_synced_at` ages past MAX_SYNC_AGE
+    and is_push_active() turns false, so read paths return to polling Google.
+    """
+    from appointment.controller.google_watch import MAX_SYNC_AGE
+
+    _, SessionLocal = get_engine_and_session()
+    db = SessionLocal()
+
+    reconciled = 0
+    skipped = 0
+
+    try:
+        interval = timedelta(seconds=reconcile_interval_seconds())
+        synced_before = (datetime.now(tz=timezone.utc) - interval).replace(tzinfo=None)
+        channels = repo.google_calendar_channel.get_stale(db, synced_before=synced_before)
+
+        for channel in channels:
+            calendar = channel.calendar
+            if not calendar or not calendar.connected:
+                skipped += 1
+                continue
+
+            try:
+                sync_google_calendar_changes(channel.channel_id)
+                reconciled += 1
+            except Exception as ex:
+                # One bad channel must not stop the sweep for everyone else.
+                log.warning(f'[tasks.google] Reconcile failed for channel {channel.channel_id}: {ex}')
+                sentry_sdk.capture_exception(ex)
+                skipped += 1
+    finally:
+        db.close()
+
+    log.info(
+        f'[tasks.google] Reconciliation complete: {reconciled} synced, {skipped} skipped '
+        f'(channels unsynced for > {reconcile_interval_seconds()}s; '
+        f'push is distrusted entirely after {int(MAX_SYNC_AGE.total_seconds())}s)'
+    )
+
+
+def reconcile_interval_seconds() -> int:
+    """How stale a channel may get before the sweep re-syncs it."""
+    return int(os.getenv('GOOGLE_RECONCILE_INTERVAL_SECONDS', 900))
 
 
 @celery.task(
@@ -89,27 +147,118 @@ def sync_google_calendar_changes(self, channel_id: str):
         if not channel.sync_token:
             sync_token = google_client.get_initial_sync_token(calendar.user, google_token)
             if sync_token:
-                repo.google_calendar_channel.update_sync_token(db, channel, sync_token)
+                repo.google_calendar_channel.record_sync(db, channel, sync_token)
 
         changed_events, new_sync_token = google_client.list_events_sync(
             calendar.user, channel.sync_token, google_token
         )
 
         if changed_events is None:
-            fresh_token = google_client.get_initial_sync_token(calendar.user, google_token)
-            if fresh_token:
-                repo.google_calendar_channel.update_sync_token(db, channel, fresh_token)
+            # 410 Gone: Google invalidated our sync token, so the delta we would
+            # have received is unrecoverable. Re-establishing the token alone
+            # would silently swallow those changes, so do a bounded full resync
+            # to catch up before resuming incremental sync.
+            _recover_from_invalid_sync_token(db, channel, calendar, google_client, google_token)
             return
-
-        if new_sync_token:
-            repo.google_calendar_channel.update_sync_token(db, channel, new_sync_token)
 
         if changed_events:
             _process_changed_events(
                 db, calendar.id, changed_events, google_client, google_token, calendar.user
             )
+
+        # Stamp the watermark only after the changes have been applied: it is what
+        # is_push_active() trusts, so it must never run ahead of the local state.
+        repo.google_calendar_channel.record_sync(db, channel, new_sync_token)
+
+        if changed_events:
+            # The calendar moved, so any cached availability for this subscriber
+            # is now suspect. Busting is what lets read paths serve from cache
+            # between notifications instead of polling Google every request.
+            _bust_subscriber_cache(calendar)
     finally:
         db.close()
+
+
+def _bust_subscriber_cache(calendar: models.Calendar):
+    """Drop cached remote events/free-busy for the calendar's owner.
+
+    Deliberately busts every calendar of the subscriber rather than just this
+    one: free/busy entries are cached per *set* of calendars, so an entry
+    covering this calendar can be filed under another calendar's key.
+
+    Never raises -- a failed bust costs staleness until the TTL expires, but must
+    not fail the sync that has already been applied.
+    """
+    from appointment.controller.calendar import BaseConnector
+
+    try:
+        redis_instance = get_redis()
+        if redis_instance is None:
+            return
+
+        connector = BaseConnector(
+            subscriber_id=calendar.owner_id,
+            calendar_id=calendar.id,
+            redis_instance=redis_instance,
+        )
+        deleted = connector.bust_cached_events(all_calendars=True)
+        log.info(f'[tasks.google] Busted {deleted} cached entries for subscriber {calendar.owner_id}')
+    except Exception as ex:
+        log.warning(f'[tasks.google] Failed to bust cache for calendar {calendar.id}: {ex}')
+        sentry_sdk.capture_exception(ex)
+
+
+def _recover_from_invalid_sync_token(
+    db: Session,
+    channel: models.GoogleCalendarChannel,
+    calendar: models.Calendar,
+    google_client: GoogleClient,
+    google_token,
+):
+    """Recover after Google answers 410 fullSyncRequired.
+
+    An invalidated sync token means we cannot know what changed. Recovery is:
+      1. drop the cache, so reads stop trusting anything derived from the lost
+         delta and fall back to Google,
+      2. re-scan a bounded forward window and re-apply RSVP/cancellation state,
+         so bookings that changed during the blackout are not missed,
+      3. establish a fresh token and re-stamp the watermark.
+
+    If step 3 fails the watermark is left alone, so is_push_active() ages the
+    channel out and read paths return to polling -- stale, never silently wrong.
+    """
+    log.info(f'[tasks.google] Sync token invalidated for channel {channel.channel_id}, running full resync')
+
+    _bust_subscriber_cache(calendar)
+
+    now = datetime.now(tz=timezone.utc)
+    window_days = int(os.getenv('GOOGLE_FULL_RESYNC_WINDOW_DAYS', 90))
+    try:
+        events = google_client.list_events(
+            calendar.user,
+            now.isoformat(),
+            (now + timedelta(days=window_days)).isoformat(),
+            google_token,
+        )
+        if events:
+            _process_changed_events(
+                db, calendar.id, events, google_client, google_token, calendar.user
+            )
+    except Exception as ex:
+        # Fall through to re-establish the token regardless; the reconciliation
+        # sweep will retry, and until it succeeds the stale watermark keeps read
+        # paths polling.
+        log.warning(f'[tasks.google] Full resync scan failed for channel {channel.channel_id}: {ex}')
+        sentry_sdk.capture_exception(ex)
+
+    fresh_token = google_client.get_initial_sync_token(calendar.user, google_token)
+    if fresh_token:
+        repo.google_calendar_channel.record_sync(db, channel, fresh_token)
+    else:
+        log.warning(
+            f'[tasks.google] Could not re-establish sync token for channel {channel.channel_id}; '
+            f'push stays untrusted until reconciliation succeeds'
+        )
 
 
 def _process_changed_events(

--- a/backend/src/appointment/utils.py
+++ b/backend/src/appointment/utils.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import logging
 import os
@@ -215,3 +216,14 @@ def get_expiry_time_with_grace_period(expiry: int):
     grace_period = max(int(os.getenv('OIDC_EXP_GRACE_PERIOD', 0)), 120)
     expiry += grace_period
     return expiry
+
+
+def stable_hash(values) -> str:
+    """A short, deterministic hash of an iterable of strings.
+
+    Used to keep cache keys bounded when the key covers a set of calendar ids.
+    Deterministic across processes and restarts, unlike hash(), so a cache entry
+    written by one worker is found by the next.
+    """
+    joined = '\x00'.join(str(v) for v in values)
+    return hashlib.sha256(joined.encode('utf-8')).hexdigest()[:16]

--- a/backend/test/unit/test_google_push_polling.py
+++ b/backend/test/unit/test_google_push_polling.py
@@ -11,6 +11,8 @@ import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock
 
+import pytest
+
 from appointment.controller.calendar import BaseConnector, GoogleConnector, push_cache_expiry
 from appointment.controller.google_watch import (
     CHANNEL_EXPIRY_MARGIN,
@@ -19,6 +21,7 @@ from appointment.controller.google_watch import (
     push_backed_calendar_ids,
 )
 from appointment.database import models, repo
+from appointment.routes.webhooks import _parse_expiration
 
 
 class FakeRedis:
@@ -178,6 +181,11 @@ class TestPushBackedCalendarIds:
 
 class TestGetBusyTimeCaching:
     """The hot path: freebusy was called on *every* availability request."""
+
+    @pytest.fixture(autouse=True)
+    def push_enabled(self, monkeypatch):
+        """Watch channels only exist under this flag, so the cache path needs it on."""
+        monkeypatch.setenv('GOOGLE_INVITE_ENABLED', 'True')
 
     @staticmethod
     def _connector(db, subscriber_id, calendar, redis_instance, google_client):
@@ -373,32 +381,6 @@ class TestGetBusyTimeCaching:
         assert 0 < expiry <= 24 * 3600
 
 
-class TestFreeBusyTimestampParsing:
-    """Free/busy timestamps are RFC-3339, which permits fractional seconds.
-
-    A strict '%Y-%m-%dT%H:%M:%SZ' parse raised on those and took the whole
-    availability lookup down with it; observed against a Calendar twin returning
-    '2026-08-20T17:52:58.000Z'.
-    """
-
-    def test_parses_whole_seconds(self):
-        from appointment.controller.apis.google_client import parse_rfc3339_utc
-
-        assert parse_rfc3339_utc('2026-08-20T17:52:58Z') == datetime(2026, 8, 20, 17, 52, 58)
-
-    def test_parses_fractional_seconds(self):
-        from appointment.controller.apis.google_client import parse_rfc3339_utc
-
-        assert parse_rfc3339_utc('2026-08-20T17:52:58.000Z') == datetime(2026, 8, 20, 17, 52, 58)
-
-    def test_normalises_offsets_to_naive_utc(self):
-        from appointment.controller.apis.google_client import parse_rfc3339_utc
-
-        parsed = parse_rfc3339_utc('2026-08-20T19:52:58+02:00')
-        assert parsed == datetime(2026, 8, 20, 17, 52, 58)
-        assert parsed.tzinfo is None
-
-
 class TestBusyTimeCacheRoundTrip:
     def test_cached_entries_are_indistinguishable_from_fresh_ones(self):
         """Callers must not be able to tell a cache hit from a Google call."""
@@ -449,7 +431,7 @@ class TestBustAllCachedEvents:
 
 
 class TestRecordNotification:
-    """Message-number bookkeeping used to spot lossy delivery."""
+    """What an inbound notification is allowed to change."""
 
     def _stored_channel(self, db, calendar_id):
         return repo.google_calendar_channel.create(
@@ -462,34 +444,6 @@ class TestRecordNotification:
             sync_token='token-x',
         )
 
-    def test_returns_previous_and_advances_high_water_mark(
-        self, with_db, make_google_calendar, make_pro_subscriber
-    ):
-        subscriber = make_pro_subscriber()
-        calendar = make_google_calendar(subscriber_id=subscriber.id, connected=True)
-
-        with with_db() as db:
-            channel = self._stored_channel(db, calendar.id)
-
-            assert repo.google_calendar_channel.record_notification(db, channel, message_number=1) is None
-            assert repo.google_calendar_channel.record_notification(db, channel, message_number=2) == 1
-            assert channel.last_message_number == 2
-
-    def test_duplicate_delivery_does_not_move_mark_backwards(
-        self, with_db, make_google_calendar, make_pro_subscriber
-    ):
-        """Google may deliver the same notification more than once."""
-        subscriber = make_pro_subscriber()
-        calendar = make_google_calendar(subscriber_id=subscriber.id, connected=True)
-
-        with with_db() as db:
-            channel = self._stored_channel(db, calendar.id)
-            repo.google_calendar_channel.record_notification(db, channel, message_number=5)
-            previous = repo.google_calendar_channel.record_notification(db, channel, message_number=3)
-
-            assert previous == 5
-            assert channel.last_message_number == 5
-
     def test_expiration_is_refreshed_from_the_notification(
         self, with_db, make_google_calendar, make_pro_subscriber
     ):
@@ -500,7 +454,7 @@ class TestRecordNotification:
 
         with with_db() as db:
             channel = self._stored_channel(db, calendar.id)
-            repo.google_calendar_channel.record_notification(db, channel, message_number=2, expiration=new_expiry)
+            repo.google_calendar_channel.record_notification(db, channel, expiration=new_expiry)
 
             assert abs((channel.expiration.replace(tzinfo=timezone.utc) - new_expiry).total_seconds()) < 2
 
@@ -513,9 +467,63 @@ class TestRecordNotification:
 
         with with_db() as db:
             channel = self._stored_channel(db, calendar.id)  # never synced
-            repo.google_calendar_channel.record_notification(db, channel, message_number=2)
+            repo.google_calendar_channel.record_notification(db, channel)
 
             assert is_push_active(channel) is False
+
+
+class TestPushDisabledSkipsLookups:
+    """Channels are only ever created under GOOGLE_INVITE_ENABLED.
+
+    With the flag off the lookups can only come back empty, and this runs on the
+    public availability path, so they must not be issued at all.
+    """
+
+    def test_no_db_work_when_the_flag_is_off(self, monkeypatch):
+        monkeypatch.setenv('GOOGLE_INVITE_ENABLED', 'False')
+
+        db = Mock()
+        con = GoogleConnector(
+            db=db,
+            redis_instance=None,
+            google_client=Mock(),
+            remote_calendar_id='remote-id',
+            calendar_id=1,
+            subscriber_id=1,
+            google_tkn=GOOGLE_CREDS,
+        )
+
+        assert con._push_backed_remote_ids(['remote-id']) == set()
+        assert con._push_backed_for_this_calendar() is False
+        db.query.assert_not_called()
+
+
+class TestParseExpirationHeader:
+    """X-Goog-Channel-Expiration is an RFC-1123 string, not epoch milliseconds.
+
+    The watch API *response body* uses epoch milliseconds for the same value, and
+    conflating the two meant this silently never worked. The literal example below
+    is the one from Google's push-notifications guide.
+    """
+
+    def test_parses_the_documented_rfc1123_form(self):
+        assert _parse_expiration('Tue, 19 Nov 2013 01:13:52 GMT') == datetime(
+            2013, 11, 19, 1, 13, 52, tzinfo=timezone.utc
+        )
+
+    def test_rejects_epoch_milliseconds(self):
+        """The shape this used to assume. It must not parse, quietly or otherwise."""
+        assert _parse_expiration('1763946832000') is None
+
+    def test_rejects_a_timezone_less_value(self):
+        """record_notification stores what it is given as naive UTC, so an
+        unzoned parse would write an unknown offset into the trust column."""
+        assert _parse_expiration('Mon, 24 Aug 2026 20:15:26 -0000') is None
+
+    def test_missing_and_malformed_headers_are_none(self):
+        assert _parse_expiration(None) is None
+        assert _parse_expiration('') is None
+        assert _parse_expiration('not a date') is None
 
 
 class TestGetStale:

--- a/backend/test/unit/test_google_push_polling.py
+++ b/backend/test/unit/test_google_push_polling.py
@@ -21,7 +21,6 @@ from appointment.controller.google_watch import (
     push_backed_calendar_ids,
 )
 from appointment.database import models, repo
-from appointment.routes.webhooks import _parse_expiration
 
 
 class FakeRedis:
@@ -444,19 +443,26 @@ class TestRecordNotification:
             sync_token='token-x',
         )
 
-    def test_expiration_is_refreshed_from_the_notification(
+    def test_expiration_is_left_alone(
         self, with_db, make_google_calendar, make_pro_subscriber
     ):
-        """Google restates the expiry on every notification -- keep ours honest."""
+        """A channel's expiration is fixed when it is created and never moves.
+
+        Google has no renewal mechanism -- a channel is replaced, not extended --
+        so a notification carries no expiry news, and re-deriving it from the
+        header would only be a second chance to get it wrong.
+        """
         subscriber = make_pro_subscriber()
         calendar = make_google_calendar(subscriber_id=subscriber.id, connected=True)
-        new_expiry = datetime.now(tz=timezone.utc) + timedelta(days=7)
 
         with with_db() as db:
             channel = self._stored_channel(db, calendar.id)
-            repo.google_calendar_channel.record_notification(db, channel, expiration=new_expiry)
+            before = channel.expiration
 
-            assert abs((channel.expiration.replace(tzinfo=timezone.utc) - new_expiry).total_seconds()) < 2
+            repo.google_calendar_channel.record_notification(db, channel)
+
+            assert channel.expiration == before
+            assert channel.last_notification_at is not None
 
     def test_notification_does_not_by_itself_make_push_trusted(
         self, with_db, make_google_calendar, make_pro_subscriber
@@ -496,34 +502,6 @@ class TestPushDisabledSkipsLookups:
         assert con._push_backed_remote_ids(['remote-id']) == set()
         assert con._push_backed_for_this_calendar() is False
         db.query.assert_not_called()
-
-
-class TestParseExpirationHeader:
-    """X-Goog-Channel-Expiration is an RFC-1123 string, not epoch milliseconds.
-
-    The watch API *response body* uses epoch milliseconds for the same value, and
-    conflating the two meant this silently never worked. The literal example below
-    is the one from Google's push-notifications guide.
-    """
-
-    def test_parses_the_documented_rfc1123_form(self):
-        assert _parse_expiration('Tue, 19 Nov 2013 01:13:52 GMT') == datetime(
-            2013, 11, 19, 1, 13, 52, tzinfo=timezone.utc
-        )
-
-    def test_rejects_epoch_milliseconds(self):
-        """The shape this used to assume. It must not parse, quietly or otherwise."""
-        assert _parse_expiration('1763946832000') is None
-
-    def test_rejects_a_timezone_less_value(self):
-        """record_notification stores what it is given as naive UTC, so an
-        unzoned parse would write an unknown offset into the trust column."""
-        assert _parse_expiration('Mon, 24 Aug 2026 20:15:26 -0000') is None
-
-    def test_missing_and_malformed_headers_are_none(self):
-        assert _parse_expiration(None) is None
-        assert _parse_expiration('') is None
-        assert _parse_expiration('not a date') is None
 
 
 class TestGetStale:

--- a/backend/test/unit/test_google_push_polling.py
+++ b/backend/test/unit/test_google_push_polling.py
@@ -1,0 +1,556 @@
+"""Tests for skipping Google polling while a push channel is live (issue #1607).
+
+The property under test throughout is one-directional: when push is trustworthy
+we may serve cached data, and when anything about push is uncertain we must fall
+back to polling Google. Being wrong in the "poll anyway" direction costs an API
+call; being wrong the other way shows users stale availability, so most of these
+tests pin down the cases that must *not* be trusted.
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
+
+from appointment.controller.calendar import BaseConnector, GoogleConnector, push_cache_expiry
+from appointment.controller.google_watch import (
+    CHANNEL_EXPIRY_MARGIN,
+    MAX_SYNC_AGE,
+    is_push_active,
+    push_backed_calendar_ids,
+)
+from appointment.database import models, repo
+
+
+class FakeRedis:
+    """Minimal in-memory stand-in covering the calls the cache layer makes."""
+
+    def __init__(self):
+        self.store = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def set(self, key, value, ex=None):
+        self.store[key] = value
+        return True
+
+    def delete(self, *keys):
+        removed = 0
+        for key in keys:
+            if key in self.store:
+                del self.store[key]
+                removed += 1
+        return removed
+
+    def scan_iter(self, match=None, count=None):
+        # Only the trailing-'*' form is used by the cache layer.
+        prefix = match[:-1] if match and match.endswith('*') else match
+        for key in list(self.store.keys()):
+            if prefix is None or key.startswith(prefix):
+                yield key
+
+    def scan(self, cursor, match=None):
+        return 0, list(self.scan_iter(match=match))
+
+
+def _channel(**overrides):
+    """A channel that is healthy unless a test makes it otherwise."""
+    now = datetime.now(tz=timezone.utc)
+    defaults = {
+        'expiration': now + timedelta(days=6),
+        'sync_token': 'sync-token',
+        'last_synced_at': now,
+    }
+    defaults.update(overrides)
+    return models.GoogleCalendarChannel(**defaults)
+
+
+GOOGLE_CREDS = json.dumps({
+    'token': 'fake-token',
+    'refresh_token': 'fake-refresh',
+    'client_id': 'fake-client-id',
+    'client_secret': 'fake-secret',
+})
+
+
+class TestIsPushActive:
+    """The gate that decides whether polling can be skipped."""
+
+    def test_healthy_channel_is_active(self):
+        assert is_push_active(_channel()) is True
+
+    def test_missing_channel_is_not_active(self):
+        # A calendar with no channel at all must keep polling.
+        assert is_push_active(None) is False
+
+    def test_expired_channel_is_not_active(self):
+        assert is_push_active(_channel(expiration=datetime.now(tz=timezone.utc) - timedelta(minutes=1))) is False
+
+    def test_channel_inside_expiry_margin_is_not_active(self):
+        # Google stops delivering the moment the channel lapses, so we have to
+        # stop trusting it slightly early rather than exactly at expiry.
+        expiring = datetime.now(tz=timezone.utc) + (CHANNEL_EXPIRY_MARGIN / 2)
+        assert is_push_active(_channel(expiration=expiring)) is False
+
+    def test_channel_without_sync_token_is_not_active(self):
+        # Without a delta chain a notification cannot tell us what changed.
+        assert is_push_active(_channel(sync_token=None)) is False
+
+    def test_never_synced_channel_is_not_active(self):
+        assert is_push_active(_channel(last_synced_at=None)) is False
+
+    def test_channel_stale_beyond_max_sync_age_is_not_active(self):
+        """Push and reconciliation both silently dead -> stop trusting push.
+
+        This is the backstop that turns an undetectable failure (notifications
+        simply never arriving) into a detectable one.
+        """
+        stale = datetime.now(tz=timezone.utc) - (MAX_SYNC_AGE + timedelta(minutes=1))
+        assert is_push_active(_channel(last_synced_at=stale)) is False
+
+    def test_naive_datetimes_are_treated_as_utc(self):
+        """Columns come back naive; comparing them to aware values must not raise."""
+        naive_future = (datetime.now(tz=timezone.utc) + timedelta(days=6)).replace(tzinfo=None)
+        naive_now = datetime.now(tz=timezone.utc).replace(tzinfo=None)
+        assert is_push_active(_channel(expiration=naive_future, last_synced_at=naive_now)) is True
+
+
+class TestPushBackedCalendarIds:
+    def test_only_returns_calendars_with_live_channels(
+        self, with_db, make_google_calendar, make_external_connections, make_pro_subscriber
+    ):
+        subscriber = make_pro_subscriber()
+        ext_conn = make_external_connections(
+            subscriber.id, type=models.ExternalConnectionType.google, token=GOOGLE_CREDS
+        )
+        watched = make_google_calendar(
+            subscriber_id=subscriber.id, connected=True, external_connection_id=ext_conn.id
+        )
+        unwatched = make_google_calendar(
+            subscriber_id=subscriber.id, connected=True, external_connection_id=ext_conn.id
+        )
+
+        with with_db() as db:
+            repo.google_calendar_channel.create(
+                db,
+                calendar_id=watched.id,
+                channel_id='channel-a',
+                resource_id='resource-a',
+                expiration=datetime.now(tz=timezone.utc) + timedelta(days=6),
+                state='state-a',
+                sync_token='token-a',
+                last_synced_at=datetime.now(tz=timezone.utc),
+            )
+
+            calendars = [repo.calendar.get(db, watched.id), repo.calendar.get(db, unwatched.id)]
+            backed = push_backed_calendar_ids(db, calendars)
+
+        assert watched.user in backed
+        assert unwatched.user not in backed
+
+    def test_expired_channel_is_excluded(
+        self, with_db, make_google_calendar, make_external_connections, make_pro_subscriber
+    ):
+        subscriber = make_pro_subscriber()
+        ext_conn = make_external_connections(
+            subscriber.id, type=models.ExternalConnectionType.google, token=GOOGLE_CREDS
+        )
+        calendar = make_google_calendar(
+            subscriber_id=subscriber.id, connected=True, external_connection_id=ext_conn.id
+        )
+
+        with with_db() as db:
+            repo.google_calendar_channel.create(
+                db,
+                calendar_id=calendar.id,
+                channel_id='channel-expired',
+                resource_id='resource-expired',
+                expiration=datetime.now(tz=timezone.utc) - timedelta(hours=1),
+                state='state-expired',
+                sync_token='token-expired',
+                last_synced_at=datetime.now(tz=timezone.utc),
+            )
+
+            backed = push_backed_calendar_ids(db, [repo.calendar.get(db, calendar.id)])
+
+        assert backed == set()
+
+
+class TestGetBusyTimeCaching:
+    """The hot path: freebusy was called on *every* availability request."""
+
+    @staticmethod
+    def _connector(db, subscriber_id, calendar, redis_instance, google_client):
+        return GoogleConnector(
+            db=db,
+            redis_instance=redis_instance,
+            google_client=google_client,
+            remote_calendar_id=calendar.user,
+            calendar_id=calendar.id,
+            subscriber_id=subscriber_id,
+            google_tkn=GOOGLE_CREDS,
+        )
+
+    @staticmethod
+    def _make_channel(db, calendar_id, **overrides):
+        kwargs = {
+            'calendar_id': calendar_id,
+            'channel_id': f'channel-{calendar_id}',
+            'resource_id': f'resource-{calendar_id}',
+            'expiration': datetime.now(tz=timezone.utc) + timedelta(days=6),
+            'state': 'state',
+            'sync_token': 'token',
+            'last_synced_at': datetime.now(tz=timezone.utc),
+        }
+        kwargs.update(overrides)
+        return repo.google_calendar_channel.create(db, **kwargs)
+
+    def test_push_backed_calendar_is_served_from_cache_on_repeat(
+        self, with_db, make_google_calendar, make_external_connections, make_pro_subscriber
+    ):
+        """The actual issue #1607 win: second request makes no Google call."""
+        subscriber = make_pro_subscriber()
+        ext_conn = make_external_connections(
+            subscriber.id, type=models.ExternalConnectionType.google, token=GOOGLE_CREDS
+        )
+        calendar = make_google_calendar(
+            subscriber_id=subscriber.id, connected=True, external_connection_id=ext_conn.id
+        )
+
+        google_client = Mock()
+        google_client.SCOPES = ['https://www.googleapis.com/auth/calendar']
+        # get_free_busy returns naive-UTC datetimes, matching the CalDAV connector.
+        google_client.get_free_busy.return_value = [
+            {'start': datetime(2026, 8, 20, 10, 0), 'end': datetime(2026, 8, 20, 11, 0)}
+        ]
+
+        redis_instance = FakeRedis()
+
+        with with_db() as db:
+            self._make_channel(db, calendar.id)
+            db_cal = repo.calendar.get(db, calendar.id)
+            con = self._connector(db, subscriber.id, db_cal, redis_instance, google_client)
+
+            first = con.get_busy_time([db_cal.user], '2026-08-01', '2026-08-31')
+            second = con.get_busy_time([db_cal.user], '2026-08-01', '2026-08-31')
+
+        assert first == second
+        assert google_client.get_free_busy.call_count == 1
+
+    def test_calendar_without_channel_still_polls_every_request(
+        self, with_db, make_google_calendar, make_external_connections, make_pro_subscriber
+    ):
+        """No channel -> unchanged behaviour, no new staleness introduced."""
+        subscriber = make_pro_subscriber()
+        ext_conn = make_external_connections(
+            subscriber.id, type=models.ExternalConnectionType.google, token=GOOGLE_CREDS
+        )
+        calendar = make_google_calendar(
+            subscriber_id=subscriber.id, connected=True, external_connection_id=ext_conn.id
+        )
+
+        google_client = Mock()
+        google_client.SCOPES = ['https://www.googleapis.com/auth/calendar']
+        google_client.get_free_busy.return_value = []
+
+        redis_instance = FakeRedis()
+
+        with with_db() as db:
+            db_cal = repo.calendar.get(db, calendar.id)
+            con = self._connector(db, subscriber.id, db_cal, redis_instance, google_client)
+
+            con.get_busy_time([db_cal.user], '2026-08-01', '2026-08-31')
+            con.get_busy_time([db_cal.user], '2026-08-01', '2026-08-31')
+
+        assert google_client.get_free_busy.call_count == 2
+
+    def test_expired_channel_falls_back_to_polling(
+        self, with_db, make_google_calendar, make_external_connections, make_pro_subscriber
+    ):
+        subscriber = make_pro_subscriber()
+        ext_conn = make_external_connections(
+            subscriber.id, type=models.ExternalConnectionType.google, token=GOOGLE_CREDS
+        )
+        calendar = make_google_calendar(
+            subscriber_id=subscriber.id, connected=True, external_connection_id=ext_conn.id
+        )
+
+        google_client = Mock()
+        google_client.SCOPES = ['https://www.googleapis.com/auth/calendar']
+        google_client.get_free_busy.return_value = []
+
+        redis_instance = FakeRedis()
+
+        with with_db() as db:
+            self._make_channel(
+                db, calendar.id, expiration=datetime.now(tz=timezone.utc) - timedelta(minutes=1)
+            )
+            db_cal = repo.calendar.get(db, calendar.id)
+            con = self._connector(db, subscriber.id, db_cal, redis_instance, google_client)
+
+            con.get_busy_time([db_cal.user], '2026-08-01', '2026-08-31')
+            con.get_busy_time([db_cal.user], '2026-08-01', '2026-08-31')
+
+        assert google_client.get_free_busy.call_count == 2
+
+    def test_mixed_batch_polls_only_the_unbacked_calendar(
+        self, with_db, make_google_calendar, make_external_connections, make_pro_subscriber
+    ):
+        """A watched and an unwatched calendar in one request.
+
+        The unwatched one must still be fetched fresh every time; the watched one
+        must not re-hit Google.
+        """
+        subscriber = make_pro_subscriber()
+        ext_conn = make_external_connections(
+            subscriber.id, type=models.ExternalConnectionType.google, token=GOOGLE_CREDS
+        )
+        watched = make_google_calendar(
+            subscriber_id=subscriber.id, connected=True, external_connection_id=ext_conn.id
+        )
+        unwatched = make_google_calendar(
+            subscriber_id=subscriber.id, connected=True, external_connection_id=ext_conn.id
+        )
+
+        google_client = Mock()
+        google_client.SCOPES = ['https://www.googleapis.com/auth/calendar']
+        google_client.get_free_busy.return_value = []
+
+        redis_instance = FakeRedis()
+
+        with with_db() as db:
+            self._make_channel(db, watched.id)
+            db_watched = repo.calendar.get(db, watched.id)
+            db_unwatched = repo.calendar.get(db, unwatched.id)
+            con = self._connector(db, subscriber.id, db_watched, redis_instance, google_client)
+
+            ids = [db_watched.user, db_unwatched.user]
+            con.get_busy_time(ids, '2026-08-01', '2026-08-31')
+            first_round = google_client.get_free_busy.call_count
+            con.get_busy_time(ids, '2026-08-01', '2026-08-31')
+            second_round = google_client.get_free_busy.call_count - first_round
+
+        # Round 1: one call for each partition. Round 2: only the unbacked one.
+        assert first_round == 2
+        assert second_round == 1
+
+    def test_cache_key_distinguishes_calendar_sets(
+        self, with_db, make_google_calendar, make_external_connections, make_pro_subscriber
+    ):
+        """A request for one calendar must not be answered from a two-calendar entry."""
+        subscriber = make_pro_subscriber()
+        ext_conn = make_external_connections(
+            subscriber.id, type=models.ExternalConnectionType.google, token=GOOGLE_CREDS
+        )
+        cal_a = make_google_calendar(
+            subscriber_id=subscriber.id, connected=True, external_connection_id=ext_conn.id
+        )
+        cal_b = make_google_calendar(
+            subscriber_id=subscriber.id, connected=True, external_connection_id=ext_conn.id
+        )
+
+        google_client = Mock()
+        google_client.SCOPES = ['https://www.googleapis.com/auth/calendar']
+        google_client.get_free_busy.return_value = []
+
+        redis_instance = FakeRedis()
+
+        with with_db() as db:
+            self._make_channel(db, cal_a.id)
+            self._make_channel(db, cal_b.id)
+            db_a = repo.calendar.get(db, cal_a.id)
+            db_b = repo.calendar.get(db, cal_b.id)
+            con = self._connector(db, subscriber.id, db_a, redis_instance, google_client)
+
+            con.get_busy_time([db_a.user, db_b.user], '2026-08-01', '2026-08-31')
+            con.get_busy_time([db_a.user], '2026-08-01', '2026-08-31')
+
+        assert google_client.get_free_busy.call_count == 2
+
+    def test_cache_is_bounded_by_push_expiry(self):
+        """Even a perfectly healthy channel must not cache forever."""
+        expiry = push_cache_expiry()
+        assert 0 < expiry <= 24 * 3600
+
+
+class TestFreeBusyTimestampParsing:
+    """Free/busy timestamps are RFC-3339, which permits fractional seconds.
+
+    A strict '%Y-%m-%dT%H:%M:%SZ' parse raised on those and took the whole
+    availability lookup down with it; observed against a Calendar twin returning
+    '2026-08-20T17:52:58.000Z'.
+    """
+
+    def test_parses_whole_seconds(self):
+        from appointment.controller.apis.google_client import parse_rfc3339_utc
+
+        assert parse_rfc3339_utc('2026-08-20T17:52:58Z') == datetime(2026, 8, 20, 17, 52, 58)
+
+    def test_parses_fractional_seconds(self):
+        from appointment.controller.apis.google_client import parse_rfc3339_utc
+
+        assert parse_rfc3339_utc('2026-08-20T17:52:58.000Z') == datetime(2026, 8, 20, 17, 52, 58)
+
+    def test_normalises_offsets_to_naive_utc(self):
+        from appointment.controller.apis.google_client import parse_rfc3339_utc
+
+        parsed = parse_rfc3339_utc('2026-08-20T19:52:58+02:00')
+        assert parsed == datetime(2026, 8, 20, 17, 52, 58)
+        assert parsed.tzinfo is None
+
+
+class TestBusyTimeCacheRoundTrip:
+    def test_cached_entries_are_indistinguishable_from_fresh_ones(self):
+        """Callers must not be able to tell a cache hit from a Google call."""
+        redis_instance = FakeRedis()
+        con = BaseConnector(subscriber_id=1, calendar_id=2, redis_instance=redis_instance)
+
+        original = [{'start': datetime(2026, 8, 20, 10), 'end': datetime(2026, 8, 20, 11)}]
+        assert con.put_cached_busy_times('scope', original) is True
+
+        assert con.get_cached_busy_times('scope') == original
+
+    def test_malformed_entry_is_treated_as_a_miss(self):
+        """A poisoned cache entry must fall back to polling, not raise."""
+        redis_instance = FakeRedis()
+        con = BaseConnector(subscriber_id=1, calendar_id=2, redis_instance=redis_instance)
+        key_scope = con.obscure_key('scope')
+        from appointment.defines import REDIS_REMOTE_EVENTS_KEY
+
+        redis_instance.set(
+            f'{REDIS_REMOTE_EVENTS_KEY}:{con.get_key_body()}:{key_scope}', 'not json'
+        )
+
+        assert con.get_cached_busy_times('scope') is None
+
+
+class TestBustAllCachedEvents:
+    def test_deletes_every_matching_key(self):
+        """Push invalidation must be complete; a survivor is silent divergence.
+
+        The pre-existing bust_cached_events reads a single SCAN batch, which is
+        not guaranteed to return everything.
+        """
+        redis_instance = FakeRedis()
+        con = BaseConnector(subscriber_id=1, calendar_id=2, redis_instance=redis_instance)
+
+        for i in range(1200):
+            con.put_cached_busy_times(f'scope-{i}', [])
+
+        assert len(redis_instance.store) == 1200
+        deleted = con.bust_cached_events(all_calendars=True)
+
+        assert deleted == 1200
+        assert redis_instance.store == {}
+
+    def test_is_a_noop_without_redis(self):
+        con = BaseConnector(subscriber_id=1, calendar_id=2, redis_instance=None)
+        assert con.bust_cached_events() == 0
+
+
+class TestRecordNotification:
+    """Message-number bookkeeping used to spot lossy delivery."""
+
+    def _stored_channel(self, db, calendar_id):
+        return repo.google_calendar_channel.create(
+            db,
+            calendar_id=calendar_id,
+            channel_id='channel-x',
+            resource_id='resource-x',
+            expiration=datetime.now(tz=timezone.utc) + timedelta(days=6),
+            state='state-x',
+            sync_token='token-x',
+        )
+
+    def test_returns_previous_and_advances_high_water_mark(
+        self, with_db, make_google_calendar, make_pro_subscriber
+    ):
+        subscriber = make_pro_subscriber()
+        calendar = make_google_calendar(subscriber_id=subscriber.id, connected=True)
+
+        with with_db() as db:
+            channel = self._stored_channel(db, calendar.id)
+
+            assert repo.google_calendar_channel.record_notification(db, channel, message_number=1) is None
+            assert repo.google_calendar_channel.record_notification(db, channel, message_number=2) == 1
+            assert channel.last_message_number == 2
+
+    def test_duplicate_delivery_does_not_move_mark_backwards(
+        self, with_db, make_google_calendar, make_pro_subscriber
+    ):
+        """Google may deliver the same notification more than once."""
+        subscriber = make_pro_subscriber()
+        calendar = make_google_calendar(subscriber_id=subscriber.id, connected=True)
+
+        with with_db() as db:
+            channel = self._stored_channel(db, calendar.id)
+            repo.google_calendar_channel.record_notification(db, channel, message_number=5)
+            previous = repo.google_calendar_channel.record_notification(db, channel, message_number=3)
+
+            assert previous == 5
+            assert channel.last_message_number == 5
+
+    def test_expiration_is_refreshed_from_the_notification(
+        self, with_db, make_google_calendar, make_pro_subscriber
+    ):
+        """Google restates the expiry on every notification -- keep ours honest."""
+        subscriber = make_pro_subscriber()
+        calendar = make_google_calendar(subscriber_id=subscriber.id, connected=True)
+        new_expiry = datetime.now(tz=timezone.utc) + timedelta(days=7)
+
+        with with_db() as db:
+            channel = self._stored_channel(db, calendar.id)
+            repo.google_calendar_channel.record_notification(db, channel, message_number=2, expiration=new_expiry)
+
+            assert abs((channel.expiration.replace(tzinfo=timezone.utc) - new_expiry).total_seconds()) < 2
+
+    def test_notification_does_not_by_itself_make_push_trusted(
+        self, with_db, make_google_calendar, make_pro_subscriber
+    ):
+        """Receiving a notification is not evidence the *sync* succeeded."""
+        subscriber = make_pro_subscriber()
+        calendar = make_google_calendar(subscriber_id=subscriber.id, connected=True)
+
+        with with_db() as db:
+            channel = self._stored_channel(db, calendar.id)  # never synced
+            repo.google_calendar_channel.record_notification(db, channel, message_number=2)
+
+            assert is_push_active(channel) is False
+
+
+class TestGetStale:
+    def test_includes_never_synced_and_old_channels_only(
+        self, with_db, make_google_calendar, make_pro_subscriber
+    ):
+        subscriber = make_pro_subscriber()
+        fresh_cal = make_google_calendar(subscriber_id=subscriber.id, connected=True)
+        stale_cal = make_google_calendar(subscriber_id=subscriber.id, connected=True)
+        never_cal = make_google_calendar(subscriber_id=subscriber.id, connected=True)
+
+        now = datetime.now(tz=timezone.utc)
+
+        with with_db() as db:
+            for cal, synced in (
+                (fresh_cal, now),
+                (stale_cal, now - timedelta(hours=2)),
+                (never_cal, None),
+            ):
+                repo.google_calendar_channel.create(
+                    db,
+                    calendar_id=cal.id,
+                    channel_id=f'channel-{cal.id}',
+                    resource_id=f'resource-{cal.id}',
+                    expiration=now + timedelta(days=6),
+                    state='state',
+                    sync_token='token',
+                    last_synced_at=synced.replace(tzinfo=None) if synced else None,
+                )
+
+            stale = repo.google_calendar_channel.get_stale(
+                db, synced_before=(now - timedelta(minutes=15)).replace(tzinfo=None)
+            )
+
+        stale_calendar_ids = {c.calendar_id for c in stale}
+        assert stale_cal.id in stale_calendar_ids
+        assert never_cal.id in stale_calendar_ids
+        assert fresh_cal.id not in stale_calendar_ids

--- a/backend/test/unit/test_google_push_recovery.py
+++ b/backend/test/unit/test_google_push_recovery.py
@@ -6,16 +6,23 @@ notifications, and a channel that goes quiet. In every case the requirement is
 the same -- local state either catches up, or stops claiming to be current.
 """
 
+import httplib2
 import json
 from datetime import datetime, timedelta, timezone
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from googleapiclient.errors import HttpError
 
 from appointment.controller.google_watch import is_push_active
 from appointment.database import models, repo
 
 MODULE = 'appointment.tasks.google'
+
+
+class BoomError(Exception):
+    """A distinctive failure, so tests assert on the real error rather than on
+    anything the task machinery might raise in its place."""
 
 
 def _google_token():
@@ -220,7 +227,10 @@ class TestInvalidSyncToken:
         """If we cannot get a new token we must stop claiming to be current.
 
         This is the property that turns an unrecoverable push failure into
-        degraded-but-correct polling instead of silent divergence.
+        degraded-but-correct polling instead of silent divergence. Asserted by
+        comparing against the watermark captured *before* the call -- assigning a
+        stale value here and re-checking is_push_active would only test that
+        function's arithmetic, and would pass even if recovery advanced it.
         """
         _, calendar = push_setup()
         client = _mock_client(
@@ -228,28 +238,197 @@ class TestInvalidSyncToken:
             get_initial_sync_token=Mock(return_value=None),
         )
 
+        with with_db() as db:
+            before = repo.google_calendar_channel.get_by_calendar_id(db, calendar.id).last_synced_at
+
         _run_sync(with_db, client, FakeRedis())
 
         with with_db() as db:
             channel = repo.google_calendar_channel.get_by_calendar_id(db, calendar.id)
-            # Watermark not advanced -> ages out -> reads fall back to polling.
-            stale = datetime.now(tz=timezone.utc) - timedelta(hours=7)
-            channel.last_synced_at = stale.replace(tzinfo=None)
-            assert is_push_active(channel) is False
+            assert channel.last_synced_at == before
 
-    def test_resync_scan_failure_still_reestablishes_the_token(self, with_db, push_setup):
-        """A failing re-scan must not leave the channel without a delta chain."""
+    def test_resync_scan_failure_does_not_reestablish_the_token(self, with_db, push_setup):
+        """A failed recovery scan must abort recovery, not paper over it.
+
+        A fresh sync token starts its delta chain after the blackout, so storing
+        one here would make the changes we failed to re-scan unrecoverable by any
+        later sync. Keeping the old (invalid) token means the next attempt
+        re-enters recovery instead of skipping past the gap.
+        """
         _, calendar = push_setup()
         client = _mock_client(
             list_events_sync=Mock(return_value=(None, None)),
-            list_events=Mock(side_effect=Exception('google exploded')),
+            list_events=Mock(side_effect=BoomError('google exploded')),
         )
+
+        with with_db() as db:
+            before = repo.google_calendar_channel.get_by_calendar_id(db, calendar.id).last_synced_at
+
+        with pytest.raises(BoomError):
+            _run_sync(with_db, client, FakeRedis())
+
+        client.get_initial_sync_token.assert_not_called()
+        with with_db() as db:
+            channel = repo.google_calendar_channel.get_by_calendar_id(db, calendar.id)
+            assert channel.sync_token == 'token-v1'
+            assert channel.last_synced_at == before
+
+    def test_resync_scans_a_window_starting_before_now(self, with_db, push_setup):
+        """Events that began before the blackout may still have changed during it."""
+        push_setup()
+        client = _mock_client(list_events_sync=Mock(return_value=(None, None)))
 
         _run_sync(with_db, client, FakeRedis())
 
+        _, time_min, time_max, _ = client.list_events.call_args.args
+        now = datetime.now(tz=timezone.utc)
+        # Meaningfully in the past, not merely a few microseconds earlier than
+        # the timestamp this assertion happens to compute.
+        assert datetime.fromisoformat(time_min) < now - timedelta(days=1)
+        assert datetime.fromisoformat(time_max) > now + timedelta(days=1)
+
+
+class TestSyncFailureIsNotSuccess:
+    """A failed sync must never look like a quiet one.
+
+    list_events_sync used to swallow non-410 errors and return ([], None), which
+    the caller could not distinguish from "nothing changed" -- so it stamped the
+    watermark, kept serving the un-busted cache, and hid the channel from the
+    reconciliation sweep, which filters on that same watermark. Persistent errors
+    therefore produced a channel that self-reported healthy forever.
+    """
+
+    def _captured(self, with_db, calendar_id):
+        with with_db() as db:
+            channel = repo.google_calendar_channel.get_by_calendar_id(db, calendar_id)
+            return channel.last_synced_at, channel.sync_token
+
+    def test_transport_error_propagates_and_advances_nothing(self, with_db, push_setup):
+        _, calendar = push_setup()
+        client = _mock_client(list_events_sync=Mock(side_effect=BoomError('502 from google')))
+
+        before = self._captured(with_db, calendar.id)
+
+        with pytest.raises(BoomError):
+            _run_sync(with_db, client, FakeRedis())
+
+        assert self._captured(with_db, calendar.id) == before
+
+    def test_missing_sync_token_is_an_error_not_an_empty_sync(self, with_db, push_setup):
+        """A completed pagination always ends with a nextSyncToken."""
+        _, calendar = push_setup()
+        client = _mock_client(list_events_sync=Mock(return_value=([], None)))
+
+        before = self._captured(with_db, calendar.id)
+
+        with pytest.raises(RuntimeError):
+            _run_sync(with_db, client, FakeRedis())
+
+        assert self._captured(with_db, calendar.id) == before
+
+    def test_partial_page_failure_records_nothing(self, with_db, push_setup):
+        """Page 1 succeeded, page 2 returned a non-410 error.
+
+        Drives the real pagination loop rather than mocking its result, because
+        mocking that result is precisely what hid this bug: returning the items
+        gathered so far alongside a null token is indistinguishable from a clean
+        empty delta.
+        """
+        _, calendar = push_setup()
+
+        pages = [
+            {'items': [{'id': 'evt-1', 'status': 'confirmed'}], 'nextPageToken': 'page-2'},
+            HttpError(httplib2.Response({'status': 503}), b'{"error": {"message": "unavailable"}}'),
+        ]
+
+        def execute():
+            page = pages.pop(0)
+            if isinstance(page, Exception):
+                raise page
+            return page
+
+        service = MagicMock()
+        service.events.return_value.list.return_value.execute.side_effect = execute
+        service.__enter__.return_value = service
+        # A MagicMock __exit__ returns a truthy mock, which would suppress the
+        # very exception under test.
+        service.__exit__.return_value = False
+
+        from appointment.controller.apis.google_client import GoogleClient
+
+        client = _mock_client()
+        client.list_events_sync = lambda *a, **kw: GoogleClient.list_events_sync(
+            client, 'cal-id', 'token-v1', None
+        )
+
+        before = self._captured(with_db, calendar.id)
+
+        with patch('appointment.controller.apis.google_client.build', return_value=service):
+            with pytest.raises(HttpError):
+                _run_sync(with_db, client, FakeRedis())
+
+        assert self._captured(with_db, calendar.id) == before
+
+    def test_410_on_a_later_page_still_routes_to_recovery(self, with_db, push_setup):
+        """The one status that must not propagate: it means "resync", not "failed"."""
+        _, calendar = push_setup()
+
+        pages = [
+            {'items': [], 'nextPageToken': 'page-2'},
+            HttpError(httplib2.Response({'status': 410}), b'{}'),
+        ]
+
+        def execute():
+            page = pages.pop(0)
+            if isinstance(page, Exception):
+                raise page
+            return page
+
+        service = MagicMock()
+        service.events.return_value.list.return_value.execute.side_effect = execute
+        service.__enter__.return_value = service
+        # A MagicMock __exit__ returns a truthy mock, which would suppress the
+        # very exception under test.
+        service.__exit__.return_value = False
+
+        from appointment.controller.apis.google_client import GoogleClient
+
+        client = _mock_client()
+        client.list_events_sync = lambda *a, **kw: GoogleClient.list_events_sync(
+            client, 'cal-id', 'token-v1', None
+        )
+
+        with patch('appointment.controller.apis.google_client.build', return_value=service):
+            _run_sync(with_db, client, FakeRedis())
+
+        # Recovery ran rather than the error escaping.
+        client.list_events.assert_called_once()
+        with with_db() as db:
+            assert repo.google_calendar_channel.get_by_calendar_id(db, calendar.id).sync_token == 'fresh-token'
+
+    def test_persistently_failing_channel_ages_out_and_is_reconciled(self, with_db, push_setup):
+        """The layered defence, end to end.
+
+        Distinct from the assertions above: an untouched-but-recent watermark
+        still reads as trusted for up to MAX_SYNC_AGE, so ageing out has to be
+        tested from an already-stale starting point rather than inferred from
+        "nothing was advanced".
+        """
+        stale = datetime.now(tz=timezone.utc) - timedelta(hours=7)
+        _, calendar = push_setup(last_synced_at=stale)
+        client = _mock_client(list_events_sync=Mock(side_effect=BoomError('still broken')))
+
+        with pytest.raises(BoomError):
+            _run_sync(with_db, client, FakeRedis())
+
         with with_db() as db:
             channel = repo.google_calendar_channel.get_by_calendar_id(db, calendar.id)
-            assert channel.sync_token == 'fresh-token'
+            # Reads fall back to polling ...
+            assert is_push_active(channel) is False
+            # ... and the sweep still sees it, rather than being told it is fresh.
+            synced_before = (datetime.now(tz=timezone.utc) - timedelta(minutes=15)).replace(tzinfo=None)
+            stale_ids = [c.id for c in repo.google_calendar_channel.get_stale(db, synced_before)]
+            assert channel.id in stale_ids
 
 
 class TestReconciliation:

--- a/backend/test/unit/test_google_push_recovery.py
+++ b/backend/test/unit/test_google_push_recovery.py
@@ -1,0 +1,312 @@
+"""Recovery behaviour when push delivery is imperfect.
+
+Covers the failure modes that make a push-only pipeline diverge from the real
+calendar: an invalidated sync token, dropped notifications, duplicate
+notifications, and a channel that goes quiet. In every case the requirement is
+the same -- local state either catches up, or stops claiming to be current.
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock, patch
+
+import pytest
+
+from appointment.controller.google_watch import is_push_active
+from appointment.database import models, repo
+
+MODULE = 'appointment.tasks.google'
+
+
+def _google_token():
+    return json.dumps({
+        'token': 'fake-token',
+        'refresh_token': 'fake-refresh',
+        'client_id': 'fake-client-id',
+        'client_secret': 'fake-secret',
+        'scopes': ['https://www.googleapis.com/auth/calendar'],
+    })
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def set(self, key, value, ex=None):
+        self.store[key] = value
+        return True
+
+    def delete(self, *keys):
+        removed = 0
+        for key in keys:
+            if key in self.store:
+                del self.store[key]
+                removed += 1
+        return removed
+
+    def scan_iter(self, match=None, count=None):
+        prefix = match[:-1] if match and match.endswith('*') else match
+        for key in list(self.store.keys()):
+            if prefix is None or key.startswith(prefix):
+                yield key
+
+
+@pytest.fixture
+def push_setup(with_db, make_google_calendar, make_external_connections, make_pro_subscriber):
+    """A connected Google calendar with a healthy, already-synced channel."""
+
+    def _setup(last_synced_at=None, sync_token='token-v1'):
+        subscriber = make_pro_subscriber()
+        ext_conn = make_external_connections(
+            subscriber.id, type=models.ExternalConnectionType.google, token=_google_token()
+        )
+        calendar = make_google_calendar(
+            subscriber_id=subscriber.id, connected=True, external_connection_id=ext_conn.id
+        )
+
+        synced = last_synced_at if last_synced_at is not None else datetime.now(tz=timezone.utc)
+
+        with with_db() as db:
+            repo.google_calendar_channel.create(
+                db,
+                calendar_id=calendar.id,
+                channel_id='channel-1',
+                resource_id='resource-1',
+                expiration=datetime.now(tz=timezone.utc) + timedelta(days=6),
+                state='state-1',
+                sync_token=sync_token,
+                last_synced_at=synced.replace(tzinfo=None) if synced else None,
+            )
+
+        return subscriber, calendar
+
+    return _setup
+
+
+def _run_sync(with_db, google_client, redis_instance, channel_id='channel-1'):
+    with patch(f'{MODULE}.get_google_client', return_value=google_client):
+        with patch(f'{MODULE}.get_engine_and_session', return_value=(None, with_db)):
+            with patch(f'{MODULE}.get_redis', return_value=redis_instance):
+                from appointment.tasks.google import sync_google_calendar_changes
+
+                sync_google_calendar_changes(channel_id)
+
+
+def _mock_client(**overrides):
+    client = Mock()
+    client.SCOPES = ['https://www.googleapis.com/auth/calendar']
+    client.list_events_sync.return_value = ([], 'token-v2')
+    client.get_initial_sync_token.return_value = 'fresh-token'
+    client.list_events.return_value = []
+    for key, value in overrides.items():
+        setattr(client, key, value)
+    return client
+
+
+class TestNormalSync:
+    def test_successful_sync_advances_watermark_and_token(self, with_db, push_setup):
+        _, calendar = push_setup()
+        client = _mock_client()
+
+        _run_sync(with_db, client, FakeRedis())
+
+        with with_db() as db:
+            channel = repo.google_calendar_channel.get_by_calendar_id(db, calendar.id)
+            assert channel.sync_token == 'token-v2'
+            assert channel.last_synced_at is not None
+            assert is_push_active(channel) is True
+
+    def test_sync_with_changes_busts_the_cache(self, with_db, push_setup):
+        """Otherwise a cached availability answer would outlive the change."""
+        subscriber, calendar = push_setup()
+        client = _mock_client(
+            list_events_sync=Mock(return_value=([{'id': 'evt-1', 'status': 'confirmed'}], 'token-v2'))
+        )
+
+        redis_instance = FakeRedis()
+        from appointment.controller.calendar import BaseConnector
+
+        con = BaseConnector(
+            subscriber_id=subscriber.id, calendar_id=calendar.id, redis_instance=redis_instance
+        )
+        con.put_cached_busy_times(
+            'freebusy_scope', [{'start': datetime(2026, 8, 20, 10), 'end': datetime(2026, 8, 20, 11)}]
+        )
+        assert len(redis_instance.store) == 1
+
+        _run_sync(with_db, client, redis_instance)
+
+        assert redis_instance.store == {}
+
+    def test_quiet_sync_leaves_cache_intact(self, with_db, push_setup):
+        """No changes means the cached answer is still correct -- keep it."""
+        subscriber, calendar = push_setup()
+        client = _mock_client()  # returns no changed events
+
+        redis_instance = FakeRedis()
+        from appointment.controller.calendar import BaseConnector
+
+        con = BaseConnector(
+            subscriber_id=subscriber.id, calendar_id=calendar.id, redis_instance=redis_instance
+        )
+        con.put_cached_busy_times(
+            'freebusy_scope', [{'start': datetime(2026, 8, 20, 10), 'end': datetime(2026, 8, 20, 11)}]
+        )
+
+        _run_sync(with_db, client, redis_instance)
+
+        assert len(redis_instance.store) == 1
+
+
+class TestDuplicateNotifications:
+    def test_replayed_notification_is_idempotent(self, with_db, push_setup):
+        """Google may deliver the same notification twice; syncing twice must be safe."""
+        _, calendar = push_setup()
+        client = _mock_client(
+            list_events_sync=Mock(return_value=([{'id': 'evt-1', 'status': 'confirmed'}], 'token-v2'))
+        )
+        redis_instance = FakeRedis()
+
+        _run_sync(with_db, client, redis_instance)
+        with with_db() as db:
+            after_first = repo.google_calendar_channel.get_by_calendar_id(db, calendar.id).sync_token
+
+        _run_sync(with_db, client, redis_instance)
+        with with_db() as db:
+            after_second = repo.google_calendar_channel.get_by_calendar_id(db, calendar.id).sync_token
+
+        assert after_first == after_second == 'token-v2'
+
+
+class TestInvalidSyncToken:
+    """410 fullSyncRequired -- the delta we would have received is unrecoverable."""
+
+    def test_full_resync_runs_and_token_is_reestablished(self, with_db, push_setup):
+        _, calendar = push_setup()
+        client = _mock_client(list_events_sync=Mock(return_value=(None, None)))
+
+        _run_sync(with_db, client, FakeRedis())
+
+        # A bounded forward window is re-scanned rather than silently skipped.
+        client.list_events.assert_called_once()
+        with with_db() as db:
+            channel = repo.google_calendar_channel.get_by_calendar_id(db, calendar.id)
+            assert channel.sync_token == 'fresh-token'
+            assert is_push_active(channel) is True
+
+    def test_cache_is_dropped_on_invalidation(self, with_db, push_setup):
+        """We cannot know what changed, so nothing derived from the lost delta may survive."""
+        subscriber, calendar = push_setup()
+        client = _mock_client(list_events_sync=Mock(return_value=(None, None)))
+
+        redis_instance = FakeRedis()
+        from appointment.controller.calendar import BaseConnector
+
+        con = BaseConnector(
+            subscriber_id=subscriber.id, calendar_id=calendar.id, redis_instance=redis_instance
+        )
+        con.put_cached_busy_times(
+            'freebusy_scope', [{'start': datetime(2026, 8, 20, 10), 'end': datetime(2026, 8, 20, 11)}]
+        )
+
+        _run_sync(with_db, client, redis_instance)
+
+        assert redis_instance.store == {}
+
+    def test_failure_to_reestablish_leaves_push_untrusted(self, with_db, push_setup):
+        """If we cannot get a new token we must stop claiming to be current.
+
+        This is the property that turns an unrecoverable push failure into
+        degraded-but-correct polling instead of silent divergence.
+        """
+        _, calendar = push_setup()
+        client = _mock_client(
+            list_events_sync=Mock(return_value=(None, None)),
+            get_initial_sync_token=Mock(return_value=None),
+        )
+
+        _run_sync(with_db, client, FakeRedis())
+
+        with with_db() as db:
+            channel = repo.google_calendar_channel.get_by_calendar_id(db, calendar.id)
+            # Watermark not advanced -> ages out -> reads fall back to polling.
+            stale = datetime.now(tz=timezone.utc) - timedelta(hours=7)
+            channel.last_synced_at = stale.replace(tzinfo=None)
+            assert is_push_active(channel) is False
+
+    def test_resync_scan_failure_still_reestablishes_the_token(self, with_db, push_setup):
+        """A failing re-scan must not leave the channel without a delta chain."""
+        _, calendar = push_setup()
+        client = _mock_client(
+            list_events_sync=Mock(return_value=(None, None)),
+            list_events=Mock(side_effect=Exception('google exploded')),
+        )
+
+        _run_sync(with_db, client, FakeRedis())
+
+        with with_db() as db:
+            channel = repo.google_calendar_channel.get_by_calendar_id(db, calendar.id)
+            assert channel.sync_token == 'fresh-token'
+
+
+class TestReconciliation:
+    """The sweep that bounds how long a dropped notification goes unnoticed."""
+
+    def _run_reconcile(self, with_db, google_client, redis_instance):
+        with patch(f'{MODULE}.get_google_client', return_value=google_client):
+            with patch(f'{MODULE}.get_engine_and_session', return_value=(None, with_db)):
+                with patch(f'{MODULE}.get_redis', return_value=redis_instance):
+                    from appointment.tasks.google import reconcile_google_channels
+
+                    reconcile_google_channels()
+
+    def test_stale_channel_is_synced(self, with_db, push_setup):
+        """No notification arrived, but the sweep catches the change anyway."""
+        _, calendar = push_setup(last_synced_at=datetime.now(tz=timezone.utc) - timedelta(hours=2))
+        client = _mock_client()
+
+        self._run_reconcile(with_db, client, FakeRedis())
+
+        client.list_events_sync.assert_called_once()
+        with with_db() as db:
+            channel = repo.google_calendar_channel.get_by_calendar_id(db, calendar.id)
+            assert channel.sync_token == 'token-v2'
+
+    def test_recently_synced_channel_is_left_alone(self, with_db, push_setup):
+        """Reconciliation must not undo the point of the feature by re-polling everything."""
+        push_setup(last_synced_at=datetime.now(tz=timezone.utc))
+        client = _mock_client()
+
+        self._run_reconcile(with_db, client, FakeRedis())
+
+        client.list_events_sync.assert_not_called()
+
+    def test_one_broken_channel_does_not_stop_the_sweep(
+        self, with_db, push_setup, make_google_calendar, make_external_connections, make_pro_subscriber
+    ):
+        stale = datetime.now(tz=timezone.utc) - timedelta(hours=2)
+        push_setup(last_synced_at=stale)
+
+        # A second stale channel whose calendar has no usable connection.
+        subscriber = make_pro_subscriber()
+        calendar = make_google_calendar(subscriber_id=subscriber.id, connected=True)
+        with with_db() as db:
+            repo.google_calendar_channel.create(
+                db,
+                calendar_id=calendar.id,
+                channel_id='channel-broken',
+                resource_id='resource-broken',
+                expiration=datetime.now(tz=timezone.utc) + timedelta(days=6),
+                state='state-broken',
+                sync_token='token-broken',
+                last_synced_at=stale.replace(tzinfo=None),
+            )
+
+        client = _mock_client()
+        self._run_reconcile(with_db, client, FakeRedis())
+
+        # The healthy one still got synced despite the broken sibling.
+        client.list_events_sync.assert_called_once()


### PR DESCRIPTION
Closes #1607.

The booking page issues an uncached `freebusy.query` per Google connection on **every** availability request: every page load, every slot re-check, every visitor. This takes that off the hot path when a push channel is live.

> **Note on scope:** the `bust_cached_events` fix is split out into #1796 at review request. It's still in this branch's diff until that merges, then I'll rebase and it drops out of here.

## Why not "read the local database instead"

The issue proposes dropping the polling because push notifications keep the local DB current. The first half is right, the second isn't. `sync_google_calendar_changes` only acts on changed events that match an existing `Appointment`; everything else is discarded. There is no local table of remote calendar events, so reading the local DB would show subscribers as free during real meetings.

Mirroring Google's events locally was the alternative, and I rejected it on two grounds. One is documented: [sync tokens aren't compatible with most filters](https://developers.google.com/workspace/calendar/api/guides/sync), so a `syncToken` mirror can't be bounded with `timeMin`/`timeMax` and is unbounded in time. The other is an observation I could not find documented either way: incremental sync appeared to return recurring *masters* carrying `RRULE` rather than expanded instances, even with `singleEvents=true`. Either way it means reimplementing RRULE expansion, timezones and cancellation tombstones, where every bug is wrong availability.

## What this does instead

Keep asking Google, cache the answer, let push invalidate it. Google stays authoritative for expansion and timezones, so no correctness is reimplemented.

`is_push_active()` is the single decision point and is deliberately one-directional. Saying "no" when push is fine costs one API call; saying "yes" when push is dead shows stale availability. Trust needs a channel that exists, isn't near expiry, holds a sync token, and synced recently. Anything unknown answers no.

Four layers, each degrading into the one below, the bottom one being today's behaviour:

1. **Push** invalidates within seconds of a change.
2. **Reconciliation** (15 min) bounds how long a dropped notification goes unnoticed.
3. **The gate** stops trusting push after 6h.
4. **TTL** (1h) caps staleness if invalidation is missed entirely.

A stale read can't cause a double booking: `request_schedule_availability_slot` busts the cache and re-validates against the remote calendar before accepting.

## API volume, honestly

Repeated availability requests now make **0** Google calls instead of one each. But reconciliation re-syncs every watched channel every 15 minutes regardless of activity, which is roughly **96 `events.list` calls/day/channel**, unconditionally.

So this is a clear win for a booking page with real traffic, and a **net increase** for a subscriber whose page is viewed a handful of times a day. I don't think that can be optimised away safely: a calendar that changed but sent nothing is indistinguishable from one that didn't change, so the sweep can't be made conditional on observed activity without an independent signal. Happy to set `GOOGLE_RECONCILE_INTERVAL_SECONDS` to whatever you prefer; `MAX_SYNC_AGE` (6h) just needs to stay comfortably above it.

## Bugs fixed on this path

**410 `fullSyncRequired` discarded changes.** The handler fetched a fresh token and returned, dropping the lost delta. Recovery now follows what the [sync guide](https://developers.google.com/workspace/calendar/api/guides/sync) prescribes: wipe the derived store, then do a full sync, then re-establish the token. A failed scan aborts rather than re-tokening, because a fresh token's chain starts *after* the blackout and would make the gap permanent.

**A redundant expiration refresh, removed rather than fixed.** Review caught that the `X-Goog-Channel-Expiration` header was being parsed as epoch milliseconds when it is an RFC-1123 string. Fixing the parse was the obvious response, but a channel's expiration is set at creation and never moves (Google has no renewal mechanism; a channel is replaced, not extended), so the header restated a value we already held and could not have changed. The refresh is gone.

**Sync failures looked like successful empty syncs.** `list_events_sync` swallowed non-410 errors and returned `([], None)`, which stamped the channel healthy, skipped the bust, and hid it from reconciliation (which filters on the same column). It propagates now and the task's existing autoretry handles it.

## What changed

| Area | Change |
|---|---|
| `controller/google_watch.py` | `is_push_active()`, `push_backed_calendar_ids()` |
| `controller/calendar.py` | Cached busy-time reads for push-backed calendars, gated on `GOOGLE_INVITE_ENABLED` |
| `routes/webhooks.py` | Records that a notification arrived (`last_notification_at`) |
| `tasks/google.py` | Cache bust on change, 410 recovery, `reconcile_google_channels` |
| `models.py` + migration `e5f6a7b8c9d0` | `last_synced_at`, `last_notification_at` |
| `celery_app.py` | Renewal hourly (was ~6 days), reconciliation every 15 min |

### Configuration

| Variable | Default | Meaning |
|---|---|---|
| `REDIS_EVENT_EXPIRE_SECONDS_PUSH` | `3600` | Cache TTL when push is live |
| `GOOGLE_RECONCILE_INTERVAL_SECONDS` | `900` | How stale a channel may get before re-sync |
| `GOOGLE_CHANNEL_RENEW_INTERVAL_SECONDS` | `3600` | Renewal cadence |
| `GOOGLE_FULL_RESYNC_WINDOW_DAYS` | `90` | Window re-scanned each way after a 410 |

All four are in `.env.example` and `.env.test`. `MAX_SYNC_AGE` (6h) and `CHANNEL_EXPIRY_MARGIN` (5 min) are constants in `google_watch.py`.

## Testing

482 passed / 1 skipped, `ruff` clean. Migration verified on a disposable Postgres: applies, idempotent, reverses cleanly.

The failure modes were exercised against a sandboxed Google Calendar twin during development. **Three bugs in the first revision came from trusting that sandbox over Google's documentation**: the expiration header format, message-number sequencing, and fractional-second timestamps. All three were caught in review by @MooseTheRebel and @davinotdavid against real Google traffic. Anything read off the wire now carries a docs link next to it and a test fed the literal string from those docs, and where the docs are silent I've said so rather than filling the gap from the sandbox.

I also re-ran the suite with each fix reverted one at a time to confirm the new tests fail rather than agreeing with the code. Two didn't and were wrong, so those were fixed too.

## Deliberately not handled

- **Channel coverage unchanged.** Still only a schedule's default calendar, only under `GOOGLE_INVITE_ENABLED`. Widening multiplies channel count and quota, which is a policy call beyond this issue.
- **Reconciliation still syncs channels serially in one beat task.** Fanning out per channel needs deduplication against concurrent webhook-triggered syncs, and there's no locking primitive in the codebase yet, so fan-out without one would make the existing race more likely. Better as a follow-up.
- **No distributed lock on concurrent syncs.** Residual cost is duplicate API calls, never incorrect state. `SELECT … FOR UPDATE` is the obvious step, but SQLite ignores it so it'd ship untested.
- **CalDAV untouched** (no push mechanism), **frontend untouched** (no API shape changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
