### PR TITLE
Reclassify 4XX errors to the WARN level (#1790)

### DIFF
--- a/backend/src/appointment/logs.py
+++ b/backend/src/appointment/logs.py
@@ -2,11 +2,17 @@ import logging
 
 
 class AccessLogLevelFilter(logging.Filter):
-    """Elevate uvicorn access log records for failed requests (status >= 400) to ERROR."""
+    """
+    Because random sites can send junk, log 4XX at WARN level to Sentry noise
+    5XX conditions are considered errors and will be sent to Sentry.
+    """
 
     def filter(self, record: logging.LogRecord) -> bool:
         status_code = record.args[-1] if record.args else None
-        if isinstance(status_code, int) and status_code >= 400:
+        if isinstance(status_code, int) and 400 <= status_code < 500:
+            record.levelno = logging.WARNING
+            record.levelname = logging.getLevelName(logging.WARNING)
+        elif isinstance(status_code, int) and status_code >= 500:
             record.levelno = logging.ERROR
             record.levelname = logging.getLevelName(logging.ERROR)
         return True


### PR DESCRIPTION
Fixes #1790

## What changed?

Log level for 4XX error was changed from ERROR to WARN

## Why?

4XX errors relate to problems with the client request that often out of control,
and there's a *lot* of background noise on the net sending us junk requests.

All messages logged at ERROR level or above are turned into Sentry exceptions, generating
a large amount of alerts and alert fatigue at Sentry.

Reclassifying as WARN appears similar in the logs but doesn't blow up Sentry with noise about
issues that are largely not out our problem.

## Limitations and Notes

We'd love to get alerted every time our frontend makes a bad 400 or 404 request. But unless we
can write a filter to to distinguish calls from ourselves vs the open internet, reclassifying
4XX as warnings is the more practical solution.

## Applicable Issues

 * #1790

## Screenshots

 * See issue.

