### PR TITLE
Delete every cached key when busting, not just the first SCAN batch

### DIFF
--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -107,26 +107,37 @@ class BaseConnector:
 
     def bust_cached_events(self, all_calendars=False):
         """Delete cached events for a specific subscriber/calendar.
-        Optionally pass in all_calendars to remove all cached calendar events for a specific subscriber."""
+        Optionally pass in all_calendars to remove all cached calendar events for a specific subscriber.
+
+        Walks the whole keyspace with scan_iter. A single SCAN call returns one
+        batch and a cursor, not the complete set, so the previous implementation
+        could silently leave entries behind whenever the keyspace did not happen
+        to fit in one batch. The booking write path busts and then immediately
+        re-checks availability, so a survivor there is a stale answer on the one
+        path that is meant to be authoritative.
+
+        Returns the number of keys deleted.
+        """
         if self.redis_instance is None:
-            return False
+            return 0
 
         timer_boot = time.perf_counter_ns()
+        match = f'{REDIS_REMOTE_EVENTS_KEY}:{self.get_key_body(only_subscriber=all_calendars)}:*'
 
-        # Scan returns a tuple like: (Cursor start, [...keys found])
-        ret = self.redis_instance.scan(
-            0, f'{REDIS_REMOTE_EVENTS_KEY}:{self.get_key_body(only_subscriber=all_calendars)}:*'
-        )
-
-        if len(ret[1]) == 0:
-            return False
-
-        # Expand the list in position 1, which is a list of keys found from the scan
-        self.redis_instance.delete(*ret[1])
+        deleted = 0
+        # Delete in batches; scan_iter keeps memory flat on large keyspaces.
+        batch = []
+        for key in self.redis_instance.scan_iter(match=match, count=500):
+            batch.append(key)
+            if len(batch) >= 500:
+                deleted += self.redis_instance.delete(*batch)
+                batch = []
+        if batch:
+            deleted += self.redis_instance.delete(*batch)
 
         sentry_sdk.set_measurement('redis_bust_time', time.perf_counter_ns() - timer_boot, 'nanosecond')
 
-        return True
+        return deleted
 
 
 class GoogleConnector(BaseConnector):

--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -109,12 +109,19 @@ class BaseConnector:
         """Delete cached events for a specific subscriber/calendar.
         Optionally pass in all_calendars to remove all cached calendar events for a specific subscriber.
 
-        Walks the whole keyspace with scan_iter. A single SCAN call returns one
-        batch and a cursor, not the complete set, so the previous implementation
-        could silently leave entries behind whenever the keyspace did not happen
-        to fit in one batch. The booking write path busts and then immediately
-        re-checks availability, so a survivor there is a stale answer on the one
-        path that is meant to be authoritative.
+        Walks the whole keyspace with scan_iter.
+
+        The previous implementation read a single SCAN call and treated an empty
+        result as "nothing cached". Redis does not work that way: MATCH is
+        applied *after* a batch is pulled from the keyspace, so when our keys are
+        a small share of the DB the first call routinely comes back empty with a
+        non-zero cursor. That made the bust delete nothing at all, not merely
+        miss a few stragglers.
+
+        The booking write path busts and then immediately re-checks availability
+        against the remote calendar, and that re-check is what stops a slot being
+        double booked -- so a survivor turns the authoritative path into a stale
+        one. Ref: https://redis.io/docs/latest/commands/scan/
 
         Returns the number of keys deleted.
         """

--- a/backend/test/unit/test_cache_bust.py
+++ b/backend/test/unit/test_cache_bust.py
@@ -1,0 +1,99 @@
+"""Cache invalidation has to be exhaustive.
+
+`bust_cached_events` is called by the booking write path immediately before it
+re-checks availability, so a key that survives the bust becomes a stale answer on
+the one path that is supposed to be authoritative.
+"""
+
+from appointment.controller.calendar import BaseConnector
+
+
+class BatchedFakeRedis:
+    """In-memory Redis whose SCAN returns one batch at a time, like the real one.
+
+    This is the whole point of the test: `scan()` is documented to return a
+    cursor plus *a* batch, not the complete key set. A fake that returns
+    everything in one call would let an implementation that reads a single batch
+    look correct.
+    """
+
+    BATCH = 10
+
+    def __init__(self):
+        self.store = {}
+
+    def set(self, key, value, ex=None):
+        self.store[key] = value
+        return True
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def delete(self, *keys):
+        removed = 0
+        for key in keys:
+            if key in self.store:
+                del self.store[key]
+                removed += 1
+        return removed
+
+    def _matching(self, match):
+        prefix = match[:-1] if match and match.endswith('*') else match
+        return [k for k in self.store if prefix is None or k.startswith(prefix)]
+
+    def scan(self, cursor, match=None):
+        """One batch plus a cursor, exactly as redis-py returns it."""
+        keys = self._matching(match)
+        batch = keys[cursor:cursor + self.BATCH]
+        next_cursor = cursor + self.BATCH
+        return (0 if next_cursor >= len(keys) else next_cursor), batch
+
+    def scan_iter(self, match=None, count=None):
+        cursor = 0
+        while True:
+            cursor, batch = self.scan(cursor, match=match)
+            yield from batch
+            if cursor == 0:
+                return
+
+
+def _connector(redis_instance):
+    return BaseConnector(subscriber_id=1, calendar_id=2, redis_instance=redis_instance)
+
+
+class TestBustCachedEvents:
+    def test_deletes_every_key_not_just_the_first_batch(self):
+        redis_instance = BatchedFakeRedis()
+        con = _connector(redis_instance)
+
+        for i in range(95):
+            con.put_cached_events(f'scope-{i}', [])
+
+        assert len(redis_instance.store) == 95
+
+        deleted = con.bust_cached_events(all_calendars=True)
+
+        assert deleted == 95
+        assert redis_instance.store == {}
+
+    def test_leaves_other_subscribers_alone(self):
+        redis_instance = BatchedFakeRedis()
+        mine = _connector(redis_instance)
+        theirs = BaseConnector(subscriber_id=99, calendar_id=3, redis_instance=redis_instance)
+
+        for i in range(30):
+            mine.put_cached_events(f'scope-{i}', [])
+        for i in range(30):
+            theirs.put_cached_events(f'scope-{i}', [])
+
+        mine.bust_cached_events(all_calendars=True)
+
+        assert len(redis_instance.store) == 30
+        assert theirs.get_cached_events('scope-0') == []
+
+    def test_returns_zero_when_there_is_nothing_to_delete(self):
+        con = _connector(BatchedFakeRedis())
+        assert con.bust_cached_events() == 0
+
+    def test_is_a_noop_without_redis(self):
+        assert _connector(None).bust_cached_events() == 0

--- a/backend/test/unit/test_cache_bust.py
+++ b/backend/test/unit/test_cache_bust.py
@@ -6,15 +6,26 @@ the one path that is supposed to be authoritative.
 """
 
 from appointment.controller.calendar import BaseConnector
+from appointment.defines import REDIS_REMOTE_EVENTS_KEY
 
 
 class BatchedFakeRedis:
-    """In-memory Redis whose SCAN returns one batch at a time, like the real one.
+    """In-memory Redis that iterates the way the real one does.
 
-    This is the whole point of the test: `scan()` is documented to return a
-    cursor plus *a* batch, not the complete key set. A fake that returns
-    everything in one call would let an implementation that reads a single batch
-    look correct.
+    Two properties matter here, and both come straight from the SCAN docs:
+
+    * A single call returns one batch plus a cursor, never the whole key set.
+      "the client should not consider the iteration complete as long as the
+      returned cursor is not zero."
+
+    * MATCH "is applied after elements are retrieved from the collection", so a
+      batch is sliced out of *all* keys first and only then filtered. When the
+      pattern matches a small share of the keyspace, "SCAN will likely return no
+      elements in most iterations" -- a call can legitimately return nothing
+      while plenty of matching keys are still to come.
+
+    A fake that filtered before batching would never produce that second case,
+    and an implementation reading a single batch would look correct.
     """
 
     BATCH = 10
@@ -37,16 +48,16 @@ class BatchedFakeRedis:
                 removed += 1
         return removed
 
-    def _matching(self, match):
-        prefix = match[:-1] if match and match.endswith('*') else match
-        return [k for k in self.store if prefix is None or k.startswith(prefix)]
-
     def scan(self, cursor, match=None):
-        """One batch plus a cursor, exactly as redis-py returns it."""
-        keys = self._matching(match)
-        batch = keys[cursor:cursor + self.BATCH]
+        all_keys = list(self.store)
+        batch = all_keys[cursor:cursor + self.BATCH]
         next_cursor = cursor + self.BATCH
-        return (0 if next_cursor >= len(keys) else next_cursor), batch
+
+        if match is not None:
+            prefix = match[:-1] if match.endswith('*') else match
+            batch = [k for k in batch if k.startswith(prefix)]
+
+        return (0 if next_cursor >= len(all_keys) else next_cursor), batch
 
     def scan_iter(self, match=None, count=None):
         cursor = 0
@@ -75,6 +86,33 @@ class TestBustCachedEvents:
 
         assert deleted == 95
         assert redis_instance.store == {}
+
+    def test_deletes_when_the_first_batch_matches_nothing(self):
+        """The realistic shape, and the one that makes the old code delete zero.
+
+        MATCH is applied after a batch is pulled from the keyspace, so when this
+        subscriber's keys sit behind a pile of unrelated ones the first SCAN
+        returns an empty list with a non-zero cursor. Reading a single batch
+        reads that as "nothing cached" and busts nothing at all.
+        """
+        redis_instance = BatchedFakeRedis()
+
+        for i in range(40):
+            redis_instance.set(f'unrelated:key:{i}', 'x')
+
+        con = _connector(redis_instance)
+        for i in range(12):
+            con.put_cached_events(f'scope-{i}', [])
+
+        # Precondition: the first batch really is empty, with more to come.
+        cursor, first_batch = redis_instance.scan(0, match=f'{REDIS_REMOTE_EVENTS_KEY}:*')
+        assert first_batch == []
+        assert cursor != 0
+
+        deleted = con.bust_cached_events(all_calendars=True)
+
+        assert deleted == 12
+        assert len(redis_instance.store) == 40
 
     def test_leaves_other_subscribers_alone(self):
         redis_instance = BatchedFakeRedis()


### PR DESCRIPTION
Split out of #1788 at review request, so it can be reviewed on its own.

## The bug

`bust_cached_events` read a single `SCAN` call and treated an empty result as "nothing cached":

```python
ret = self.redis_instance.scan(0, f'...:*')
if len(ret[1]) == 0:
    return False          # <- gives up here
self.redis_instance.delete(*ret[1])
```

Two things in the [SCAN docs](https://redis.io/docs/latest/commands/scan/) make that wrong, and the second is the serious one:

> The commands are also allowed to return zero elements, and the client should not consider the iteration complete as long as the returned cursor is not zero.

> It is important to note that the **MATCH** filter is applied after elements are retrieved from the collection, just before returning data to the client. This means that if the pattern matches very little elements inside the collection, `SCAN` will likely return no elements in most iterations.

Because MATCH is applied *after* a batch is pulled, one subscriber's cache keys sitting among everything else in the DB means the first call very often returns an empty list with a non-zero cursor. So this wasn't leaving a few stragglers behind. It was frequently **deleting nothing at all**.

## Why it matters

Two callers rely on the bust being exhaustive. The serious one is the booking write path: `request_schedule_availability_slot` busts the cache and then immediately re-checks availability against the remote calendar, and that re-check is what stops a slot being double booked. A surviving key turns the authoritative path into a stale one.

## The fix

Walks the keyspace with `scan_iter`, deleting in batches to keep memory flat, and returns the number of keys deleted rather than a bool so callers can log it.

## Testing

The fake Redis in `test_cache_bust.py` slices a batch out of *all* keys and only then applies the pattern, the way Redis does. That's deliberate: a fake that filters before batching can never produce an empty-but-unfinished call, which is exactly the case that breaks the old code. My first version of this test made that mistake, and it's fixed here.

Against the old implementation, three of the five cases fail, including `assert False == 12` for the empty-first-batch shape: zero keys deleted out of twelve.

446 passed, 1 skipped; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)