### PR TITLE
perf(frontend): cache hashed bundles for a year and mark them immutable

### DIFF
--- a/frontend/docker/etc/nginx/conf.d/appointments.conf
+++ b/frontend/docker/etc/nginx/conf.d/appointments.conf
@@ -74,35 +74,33 @@ server {
     # repeated in each location below, or they vanish on exactly the SPA shell
     # and the bundle.
 
-    # Content-hashed Vite bundles, cached for a year and declared immutable.
+    # Content-hashed Vite bundles: cached for a year, never revalidated.
     #
-    # This is the follow-up the previous revision promised, and it is the ONE
-    # IRREVERSIBLE header in this file: a viewer who caches an object under a
-    # one-year max-age holds it for a year, and a CloudFront invalidation does not
-    # reach browser caches. So it is scoped as tightly as possible -- this location
-    # only, never the unhashed root files below.
+    # HOW UPDATES REACH USERS -- we never invalidate these; we rename them. Vite puts
+    # a hash of the file's contents in its name (index-<hash>.js), so changed bytes
+    # always mean a changed URL. A year-old cached copy is not stale, it is simply
+    # never asked for again.
     #
-    # SAFE HERE, AND ONLY HERE, because the filename IS the version. Vite emits
-    # content-hashed names (index-<hash>.js), so changed bytes mean a changed URL and
-    # a stale entry is unreachable rather than wrong. The two things that make that
-    # true are both in this block and must stay:
-    #   - `try_files $uri =404` -- without it a missing asset would fall through to
-    #     the SPA shell, and a one-year-cached shell served AT a bundle URL is
-    #     unfixable by headers and untouched by invalidation.
-    #   - no `always` on add_header, so that =404 does not carry a one-year TTL.
-    # index.html and /config.js are `no-store` below and are the only things that name
-    # bundle URLs, so a deploy is picked up on the next shell fetch.
+    # The thing that actually ships an update is index.html, which is `no-store` below
+    # and refetched on every page load. It is the only file that names bundle URLs
+    # (verified: no service worker, no precache manifest, no hardcoded /assets/ paths
+    # in src/), so a new deploy is live the moment someone loads the page.
     #
-    # Preconditions verified live through the CloudFront edge before this landed
-    # (2026-08-18): /assets/<hash>.js -> 200 `public, max-age=300`,
-    # /assets/missing-000.js -> 404 (not the shell), /assets/<hash>.js.map -> 404.
+    # Note a CDN invalidation would not help even at a short TTL -- it clears edge
+    # caches, not browser caches. Renaming is the only lever that reaches a browser,
+    # and the hash gives us that for free.
     #
-    # Why now: the edge went live and measured `RefreshHit` on first fetch of every
-    # bundle -- at max-age=300 CloudFront revalidated against the origin every five
-    # minutes, which counts as a cache hit for billing while still paying an origin
-    # round-trip. For content-hashed output that revalidation is pure waste.
-    # The distribution honours this: /assets/* uses Managed-CachingOptimized, whose
-    # MaxTTL is 31536000 -- exactly one year -- so nothing is clamped.
+    # `immutable` is the real win here, not the year: it stops the browser
+    # revalidating even on reload. The year is just the conventional large number.
+    #
+    # IRREVERSIBLE, so scoped to this location only. A browser that caches under a
+    # one-year max-age keeps it for a year. The unhashed root files (favicon.svg,
+    # sitemap.txt, site.webmanifest) stay at max-age=300 on purpose.
+    #
+    # Two rules below make a stale entry unreachable rather than wrong. Both must stay:
+    #   - try_files $uri =404: a missing asset 404s instead of falling through to the
+    #     SPA shell. A year-cached shell sitting at a bundle URL would be unfixable.
+    #   - no `always` on add_header, so that 404 does not itself get a one-year TTL.
     location ^~ /assets/ {
         # Deliberately no `always`: the =404 below must not carry this header,
         # or a missing asset gets cached for a YEAR.

--- a/frontend/docker/etc/nginx/conf.d/appointments.conf
+++ b/frontend/docker/etc/nginx/conf.d/appointments.conf
@@ -74,13 +74,39 @@ server {
     # repeated in each location below, or they vanish on exactly the SPA shell
     # and the bundle.
 
-    # Content-hashed Vite bundles. Short TTL for now; raised to
-    # `public, max-age=31536000, immutable` in a follow-up once this location
-    # matching has been verified against the running pod.
+    # Content-hashed Vite bundles, cached for a year and declared immutable.
+    #
+    # This is the follow-up the previous revision promised, and it is the ONE
+    # IRREVERSIBLE header in this file: a viewer who caches an object under a
+    # one-year max-age holds it for a year, and a CloudFront invalidation does not
+    # reach browser caches. So it is scoped as tightly as possible -- this location
+    # only, never the unhashed root files below.
+    #
+    # SAFE HERE, AND ONLY HERE, because the filename IS the version. Vite emits
+    # content-hashed names (index-<hash>.js), so changed bytes mean a changed URL and
+    # a stale entry is unreachable rather than wrong. The two things that make that
+    # true are both in this block and must stay:
+    #   - `try_files $uri =404` -- without it a missing asset would fall through to
+    #     the SPA shell, and a one-year-cached shell served AT a bundle URL is
+    #     unfixable by headers and untouched by invalidation.
+    #   - no `always` on add_header, so that =404 does not carry a one-year TTL.
+    # index.html and /config.js are `no-store` below and are the only things that name
+    # bundle URLs, so a deploy is picked up on the next shell fetch.
+    #
+    # Preconditions verified live through the CloudFront edge before this landed
+    # (2026-08-18): /assets/<hash>.js -> 200 `public, max-age=300`,
+    # /assets/missing-000.js -> 404 (not the shell), /assets/<hash>.js.map -> 404.
+    #
+    # Why now: the edge went live and measured `RefreshHit` on first fetch of every
+    # bundle -- at max-age=300 CloudFront revalidated against the origin every five
+    # minutes, which counts as a cache hit for billing while still paying an origin
+    # round-trip. For content-hashed output that revalidation is pure waste.
+    # The distribution honours this: /assets/* uses Managed-CachingOptimized, whose
+    # MaxTTL is 31536000 -- exactly one year -- so nothing is clamped.
     location ^~ /assets/ {
         # Deliberately no `always`: the =404 below must not carry this header,
-        # or a missing asset gets cached for the full TTL.
-        add_header Cache-Control "public, max-age=300";
+        # or a missing asset gets cached for a YEAR.
+        add_header Cache-Control "public, max-age=31536000, immutable";
         # 404 a missing asset instead of falling through to the SPA shell.
         try_files $uri =404;
 

--- a/frontend/docker/test-nginx-config.sh
+++ b/frontend/docker/test-nginx-config.sh
@@ -123,8 +123,8 @@ probe() {
 }
 
 echo "== cache headers =="
-probe "hashed JS"            /assets/index-abc123.js      200 "public, max-age=300"
-probe "hashed CSS"           /assets/index-abc123.css     200 "public, max-age=300"
+probe "hashed JS"            /assets/index-abc123.js      200 "public, max-age=31536000, immutable"
+probe "hashed CSS"           /assets/index-abc123.css     200 "public, max-age=31536000, immutable"
 probe "missing asset"        /assets/missing-000.js        404 -
 probe "sourcemap (on disk)"  /assets/index-abc123.js.map   404 -
 probe "sourcemap (absent)"   /assets/nope.js.map           404 -


### PR DESCRIPTION
Cache hashed JS/CSS bundles for a year instead of 5 minutes.

`/assets/`: `public, max-age=300` → `public, max-age=31536000, immutable`

## Why

The CloudFront edge revalidates every bundle against the origin every 5 minutes. Pointless
work — Vite puts a hash of the file's contents in its name, so a cached copy can never be
stale.

`immutable` is the real win: it stops the browser revalidating even on reload. The year is
just the conventional large number.

## How updates reach users

**We never invalidate these — we rename them.** Changed bytes mean a changed hash, so a new
build produces new URLs. The year-old copy isn't stale; it's simply never asked for again.

`index.html` is what ships the update. It's `no-store`, refetched on every page load, and
it's the only file that names bundle URLs — no service worker, no precache manifest, no
hardcoded `/assets/` paths in `src/`. Load the page, get the new bundles.

Worth knowing: a CDN invalidation wouldn't have helped even at 5 minutes. It clears edge
caches, not browser caches. Renaming is the only lever that reaches a browser, and the hash
gives it to us for free.

## The catch

A one-year cache can't be taken back, so it applies to `/assets/` only. Unhashed files
(`favicon.svg`, `sitemap.txt`, `site.webmanifest`) stay at 5 minutes.

Two existing rules make a stale entry unreachable rather than wrong. Both must stay:

- `try_files $uri =404` — a missing asset 404s instead of returning the app shell. A
  year-cached shell at a bundle URL would be unfixable.
- no `always` on the header — so that 404 doesn't get the one-year TTL either.

## Tests

`test-nginx-config.sh` updated (JS + CSS probes). Full suite passes:

```
PASS  hashed JS -> 200 'public, max-age=31536000, immutable'
PASS  missing asset -> 404 cache-control=''
PASS  sourcemap (absent) -> 404 cache-control=''
PASS  favicon -> 200 'public, max-age=300'
```

Old 5-minute copies expire within 5 minutes, so no long tail.

Refs thunderbird/platform-infrastructure#931