### PR TITLE
test(e2e): non-destructive @deployment-analysis sign-in smoke

### DIFF
--- a/test/e2e/.env.tb-dev.example
+++ b/test/e2e/.env.tb-dev.example
@@ -1,0 +1,21 @@
+# Appointment E2E -- @deployment-analysis freight-verification sign-in smoke (tb-dev).
+# Copy to test/e2e/.env for a local run, or export these as env vars in CI/Kargo.
+# Run with: npm run deployment-analysis-e2e
+#
+# Non-destructive: OIDC sign-in only. No booking, no email, no settings/availability mutation.
+
+# Any value other than the literal `dev` drives the real OIDC sign-in path
+# (navigateToAppointmentAndSignIn). `dev` would select the local-password path.
+APPT_TARGET_ENV=tb-dev
+
+# Public edge URL. TRAILING SLASH REQUIRED -- constants build `${APPT_URL}dashboard`.
+APPT_URL=https://appointment.tb-dev.thunderbird.dev/
+
+# tbpro (TB Accounts) test-user credentials used by TBAcctsPage.signIn.
+TB_ACCTS_EMAIL=
+TB_ACCTS_PWORD=
+
+# NOTE: the @deployment-analysis tag consumes ONLY the four vars above. It does NOT need
+# APPT_DISPLAY_NAME, APPT_MY_SHARE_LINK, or the APPT_BOOKEE_* vars (it never mutates
+# settings/availability or books an appointment). Keep the AnalysisTemplate/ExternalSecret
+# contract limited to these four.

--- a/test/e2e/.env.tb-dev.example
+++ b/test/e2e/.env.tb-dev.example
@@ -1,6 +1,6 @@
 # Appointment E2E -- @deployment-analysis freight-verification sign-in smoke (tb-dev).
 # Copy to test/e2e/.env for a local run, or export these as env vars in CI/Kargo.
-# Run with: npm run deployment-analysis-e2e
+# Run with: pnpm run deployment-analysis-e2e
 #
 # Non-destructive: OIDC sign-in only. No booking, no email, no settings/availability mutation.
 

--- a/test/e2e/const/constants.ts
+++ b/test/e2e/const/constants.ts
@@ -34,6 +34,7 @@ export const PLAYWRIGHT_TAG_E2E_SUITE = '@e2e-suite';
 export const PLAYWRIGHT_TAG_PROD_NIGHTLY = '@prod-nightly';
 export const PLAYWRIGHT_TAG_E2E_SUITE_MOBILE = '@e2e-mobile-suite';
 export const PLAYWRIGHT_TAG_PROD_MOBILE_NIGHTLY = '@prod-mobile-nightly';
+export const PLAYWRIGHT_TAG_DEPLOYMENT_ANALYSIS = '@deployment-analysis';
 
 // general settings options
 export const APPT_LANGUAGE_SETTING_EN = 'EN — English';

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -10,6 +10,8 @@
     "e2e-tests-mobile-browserstack-ios-safari": "npx browserstack-node-sdk playwright test --grep e2e-mobile-suite --project=ios-safari --max-failures=2 --browserstack.buildName 'Appointment E2E Tests iOS Safari' --browserstack.config 'browserstack-mobile.yml'",
     "stage-sanity-test": "npx playwright test --grep stage-sanity --project=firefox",
     "stage-sanity-test-headed": "npx playwright test --grep stage-sanity --project=firefox --headed",
+    "deployment-analysis-e2e": "npx playwright test --grep @deployment-analysis --project=deployment-analysis",
+    "deployment-analysis-e2e-headed": "npx playwright test --grep @deployment-analysis --project=deployment-analysis --headed",
     "stage-sanity-test-browserstack-firefox": "npx browserstack-node-sdk playwright test --grep stage-sanity --project=Firefox-OSX --max-failures=2 --browserstack.buildName 'Appointment Stage Sanity Test Firefox Desktop' --browserstack.config 'browserstack-desktop.yml'",
     "prod-sanity-test": "npx playwright test --grep prod-sanity --project=firefox",
     "prod-sanity-test-headed": "npx playwright test --grep prod-sanity --project=firefox --headed",

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -97,7 +97,7 @@ export default defineConfig({
     // its own OIDC sign-in and asserts the dashboard renders. firefox-only per milestone.
     {
       name: 'deployment-analysis',
-      testMatch: /deployment-analysis-signin\.spec\.ts/,
+      testMatch: /tests\/desktop\/deployment-analysis-signin\.spec\.ts$/,
       use: {
         ...devices['Desktop Firefox'],
         screenshot: 'only-on-failure',

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -91,6 +91,19 @@ export default defineConfig({
       dependencies: ['desktop-setup'],
     },
 
+    // Freight-verification sign-in smoke (@deployment-analysis, #1046). Standalone:
+    // no desktop-setup dependency (that project configures availability/settings, which
+    // this non-destructive gate must not do) and no saved storageState -- the spec does
+    // its own OIDC sign-in and asserts the dashboard renders. firefox-only per milestone.
+    {
+      name: 'deployment-analysis',
+      testMatch: /deployment-analysis-signin\.spec\.ts/,
+      use: {
+        ...devices['Desktop Firefox'],
+        screenshot: 'only-on-failure',
+      },
+    },
+
     /* Test against mobile viewports. */
     {
       name: 'Google-Pixel-7-View',

--- a/test/e2e/tests/desktop/deployment-analysis-signin.spec.ts
+++ b/test/e2e/tests/desktop/deployment-analysis-signin.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+import { DashboardPage } from '../../pages/dashboard-page';
+import { navigateToAppointmentAndSignIn } from '../../utils/utils';
+
+import {
+  APPT_DASHBOARD_HOME_PAGE,
+  PLAYWRIGHT_TAG_DEPLOYMENT_ANALYSIS,
+  TIMEOUT_30_SECONDS,
+  TIMEOUT_60_SECONDS,
+} from '../../const/constants';
+
+/**
+ * Deployment-analysis freight-verification smoke (@deployment-analysis).
+ *
+ * Non-destructive OIDC sign-in check consumed by the Kargo `appointment-signin-e2e`
+ * AnalysisTemplate (platform-infrastructure argocd/kargo/tb-appointment) to verify a
+ * freshly-promoted tb-dev deployment. It signs in through the public tbpro Keycloak realm
+ * using the EXISTING navigateToAppointmentAndSignIn helper (-> TBAcctsPage.signIn) and
+ * asserts the signed-in Appointment dashboard renders.
+ *
+ * Deliberately SAFE to run on every freight: it performs NO booking, sends NO email, and
+ * mutates NO availability/settings (it does not call setDefaultUserSettingsLocalStore, and
+ * it does NOT reuse @stage-sanity, which requests a real booking and emails a bookee).
+ *
+ * Env consumed (all via ../../const/constants -> process.env, i.e. test/e2e .env):
+ *   APPT_URL          public edge, e.g. https://appointment.tb-dev.thunderbird.dev/
+ *                     (TRAILING SLASH REQUIRED -- constants build `${APPT_URL}dashboard`).
+ *   APPT_TARGET_ENV   any value other than the literal `dev` (drives the OIDC sign-in path
+ *                     in navigateToAppointmentAndSignIn; `dev` selects the local-password path).
+ *   TB_ACCTS_EMAIL    tbpro test-user email  (TBAcctsPage.signIn).
+ *   TB_ACCTS_PWORD    tbpro test-user password (TBAcctsPage.signIn).
+ * It does NOT consume APPT_DISPLAY_NAME or any APPT_BOOKEE_* var.
+ */
+test.describe('deployment analysis sign-in smoke', () => {
+  test('signs in via OIDC and the Appointment dashboard renders', {
+    tag: [PLAYWRIGHT_TAG_DEPLOYMENT_ANALYSIS],
+  }, async ({ page }) => {
+    // Fresh context (this project loads no saved storageState): performs a real OIDC
+    // sign-in through the public tbpro Keycloak. A broken sign-in throws in the helper
+    // (or the title assertion within it) -> non-zero exit -> freight not marked verified.
+    // navigateToAppointmentAndSignIn already asserts the page title is 'Thunderbird Appointment'.
+    await navigateToAppointmentAndSignIn(page);
+
+    // Landed on the authenticated dashboard (not bounced back to sign-in or /subscribe).
+    await page.waitForURL(APPT_DASHBOARD_HOME_PAGE, { timeout: TIMEOUT_60_SECONDS });
+
+    // Signed-in dashboard chrome renders. The Dashboard nav link is the reliable,
+    // always-present signed-in element; asserting it (plus the dashboard URL above)
+    // proves the dashboard rendered without a flaky testid that could wedge promotion.
+    const dashboardPage = new DashboardPage(page);
+    await expect(dashboardPage.navBarDashboardBtn).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+  });
+});

--- a/test/e2e/tests/desktop/deployment-analysis-signin.spec.ts
+++ b/test/e2e/tests/desktop/deployment-analysis-signin.spec.ts
@@ -1,53 +1,43 @@
 import { test, expect } from '@playwright/test';
-import { DashboardPage } from '../../pages/dashboard-page';
 import { navigateToAppointmentAndSignIn } from '../../utils/utils';
-
-import {
-  APPT_DASHBOARD_HOME_PAGE,
-  PLAYWRIGHT_TAG_DEPLOYMENT_ANALYSIS,
-  TIMEOUT_30_SECONDS,
-  TIMEOUT_60_SECONDS,
-} from '../../const/constants';
+import { PLAYWRIGHT_TAG_DEPLOYMENT_ANALYSIS } from '../../const/constants';
 
 /**
  * Deployment-analysis freight-verification smoke (@deployment-analysis).
  *
  * Non-destructive OIDC sign-in check consumed by the Kargo `appointment-signin-e2e`
- * AnalysisTemplate (platform-infrastructure argocd/kargo/tb-appointment) to verify a
- * freshly-promoted tb-dev deployment. It signs in through the public tbpro Keycloak realm
- * using the EXISTING navigateToAppointmentAndSignIn helper (-> TBAcctsPage.signIn) and
- * asserts the signed-in Appointment dashboard renders.
+ * AnalysisTemplate (platform-infrastructure#1046): it clones this repo at main and runs
+ * `deployment-analysis-e2e` against a freshly-promoted tb-dev deployment. A red run means
+ * the freight is not marked verified.
  *
- * Deliberately SAFE to run on every freight: it performs NO booking, sends NO email, and
- * mutates NO availability/settings (it does not call setDefaultUserSettingsLocalStore, and
- * it does NOT reuse @stage-sanity, which requests a real booking and emails a bookee).
+ * SAFE to run on every freight: sign-in only -- no booking, no email, no availability/
+ * settings mutation (it does not use auth.desktop.setup or @stage-sanity).
  *
- * Env consumed (all via ../../const/constants -> process.env, i.e. test/e2e .env):
- *   APPT_URL          public edge, e.g. https://appointment.tb-dev.thunderbird.dev/
- *                     (TRAILING SLASH REQUIRED -- constants build `${APPT_URL}dashboard`).
- *   APPT_TARGET_ENV   any value other than the literal `dev` (drives the OIDC sign-in path
- *                     in navigateToAppointmentAndSignIn; `dev` selects the local-password path).
- *   TB_ACCTS_EMAIL    tbpro test-user email  (TBAcctsPage.signIn).
- *   TB_ACCTS_PWORD    tbpro test-user password (TBAcctsPage.signIn).
- * It does NOT consume APPT_DISPLAY_NAME or any APPT_BOOKEE_* var.
+ * Env consumed (via ../../const/constants -> process.env, i.e. test/e2e .env):
+ *   APPT_URL          public edge, e.g. https://appointment.tb-dev.thunderbird.dev/ (trailing slash).
+ *   APPT_TARGET_ENV   any value other than the literal `dev` (drives the OIDC path).
+ *   TB_ACCTS_EMAIL / TB_ACCTS_PWORD   tbpro test-user creds (TBAcctsPage.signIn).
  */
 test.describe('deployment analysis sign-in smoke', () => {
-  test('signs in via OIDC and the Appointment dashboard renders', {
+  test('signs in via OIDC and the authenticated app renders', {
     tag: [PLAYWRIGHT_TAG_DEPLOYMENT_ANALYSIS],
   }, async ({ page }) => {
-    // Fresh context (this project loads no saved storageState): performs a real OIDC
-    // sign-in through the public tbpro Keycloak. A broken sign-in throws in the helper
-    // (or the title assertion within it) -> non-zero exit -> freight not marked verified.
-    // navigateToAppointmentAndSignIn already asserts the page title is 'Thunderbird Appointment'.
+    // Fail LOUD and immediately if the gate is misconfigured, rather than signing in as
+    // nobody and timing out 60s later (which reads like a broken deploy, not a config error).
+    for (const key of ['APPT_URL', 'TB_ACCTS_EMAIL', 'TB_ACCTS_PWORD']) {
+      expect(process.env[key], `${key} must be set for the deployment-analysis smoke`).toBeTruthy();
+    }
+
+    // Real OIDC sign-in through the public tbpro Keycloak. The helper asserts the app title,
+    // but that title is also present on the signed-OUT app, so it is NOT sufficient on its own.
     await navigateToAppointmentAndSignIn(page);
 
-    // Landed on the authenticated dashboard (not bounced back to sign-in or /subscribe).
-    await page.waitForURL(APPT_DASHBOARD_HOME_PAGE, { timeout: TIMEOUT_60_SECONDS });
-
-    // Signed-in dashboard chrome renders. The Dashboard nav link is the reliable,
-    // always-present signed-in element; asserting it (plus the dashboard URL above)
-    // proves the dashboard rendered without a flaky testid that could wedge promotion.
-    const dashboardPage = new DashboardPage(page);
-    await expect(dashboardPage.navBarDashboardBtn).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+    // The real gate: an element that ONLY renders for an authenticated subscriber. The desktop
+    // NavBar (`.nav-items-container`, NavBar.vue) is present only when user.authenticated, on
+    // BOTH /dashboard and the first-time-user /setup redirect, so this proves sign-in succeeded
+    // without conflating it with FTUE-complete. Scoped to the nav container so it resolves to a
+    // single element (a page-wide getByRole('link',{name:'Dashboard'}) also matches the footer).
+    const navDashboardLink = page.locator('.nav-items-container').getByRole('link', { name: 'Dashboard' });
+    await expect(navDashboardLink).toBeVisible({ timeout: 60_000 });
   });
 });


### PR DESCRIPTION
A freight-verification smoke for the EKS/Kargo pipeline (platform-infrastructure#1046), mirroring the accounts one (#1146). Kargo clones this repo at `main` and runs `deployment-analysis-e2e` against a freshly-promoted tb-dev deploy; red = freight not verified.

## What it does
OIDC sign-in via the tbpro realm (reusing `navigateToAppointmentAndSignIn`), then asserts the dashboard renders. **Non-destructive** — no booking, no email, no settings/availability mutation, and deliberately not `@stage-sanity`.

## Changes
- `tests/desktop/deployment-analysis-signin.spec.ts` — the `@deployment-analysis` spec
- `playwright.config.ts` — standalone `deployment-analysis` project (firefox-only, no `desktop-setup` dep, no `storageState`)
- `package.json` — `deployment-analysis-e2e` (+ `-headed`) scripts
- `.env.tb-dev.example` — the four vars it consumes

## Verified
`pnpm install --frozen-lockfile` + `playwright test --list --project=deployment-analysis` → discovers exactly this one test.