### PR TITLE
fix(e2e): @deployment-analysis asserts authenticated landing, not the NavBar

### DIFF
--- a/test/e2e/tests/desktop/deployment-analysis-signin.spec.ts
+++ b/test/e2e/tests/desktop/deployment-analysis-signin.spec.ts
@@ -32,12 +32,12 @@ test.describe('deployment analysis sign-in smoke', () => {
     // but that title is also present on the signed-OUT app, so it is NOT sufficient on its own.
     await navigateToAppointmentAndSignIn(page);
 
-    // The real gate: an element that ONLY renders for an authenticated subscriber. The desktop
-    // NavBar (`.nav-items-container`, NavBar.vue) is present only when user.authenticated, on
-    // BOTH /dashboard and the first-time-user /setup redirect, so this proves sign-in succeeded
-    // without conflating it with FTUE-complete. Scoped to the nav container so it resolves to a
-    // single element (a page-wide getByRole('link',{name:'Dashboard'}) also matches the footer).
-    const navDashboardLink = page.locator('.nav-items-container').getByRole('link', { name: 'Dashboard' });
-    await expect(navDashboardLink).toBeVisible({ timeout: 60_000 });
+    // The real gate: land on an AUTHENTICATED-ONLY route. A signed-in user is routed to
+    // /dashboard, or to /setup when they have not completed first-time setup (a fresh user, or
+    // after a tb-dev Neon branch reset). Both are auth-gated -- an unauthenticated user is
+    // bounced back to sign-in and reaches neither -- so matching either proves OIDC sign-in
+    // succeeded, independent of FTUE state. (Asserting a dashboard DOM element instead would
+    // false-fail on /setup, where the app chrome differs; verified in-cluster with a fresh user.)
+    await page.waitForURL(/\/(dashboard|setup)\/?$/, { timeout: 60_000 });
   });
 });


### PR DESCRIPTION
Follow-up to #1801. Running the smoke as a real Kargo freight gate — in-cluster, against the shared tb-dev test user — surfaced a false-FAIL that the local runs (yours and mine) missed because they used an already-set-up user.

## What happened
A user who hasn't completed appointment first-time-setup lands on **/setup**, where the desktop NavBar (`.nav-items-container`) isn't rendered — so the `navBarDashboardBtn` assertion timed out on a *healthy* deploy. Set-up users land on `/dashboard` (NavBar present), which is why it passed locally.

Confirmed in-cluster: with a fresh user, sign-in succeeds and lands on `https://appointment.tb-dev.thunderbird.dev/setup`.

## Fix
Assert the authenticated **landing route** (`/dashboard` or `/setup`) instead of a dashboard DOM element. Both are auth-gated — a failed sign-in reaches neither — so this proves OIDC sign-in succeeded independent of FTUE state (which a shared/Neon-reset test user needs). Still fail-closed.

## Verified
In-cluster AnalysisRun against this branch with the shared user landing on `/setup`: **1 passed (21.7s)**.

Refs platform-infrastructure#1046