### PR TITLE
Remove the time format setting

### DIFF
--- a/backend/src/appointment/database/models.py
+++ b/backend/src/appointment/database/models.py
@@ -97,11 +97,6 @@ class ColourScheme(enum.Enum):
     light = 'light'
 
 
-class TimeMode(enum.Enum):
-    h12 = 12
-    h24 = 24
-
-
 # Use ISO 8601 format to specify day of week
 class IsoWeekday(enum.Enum):
     monday = 1
@@ -177,7 +172,6 @@ class Subscriber(HasSoftDelete, Base):
     language = Column(encrypted_type(String), nullable=False, default=FALLBACK_LOCALE, index=True)
     timezone = Column(encrypted_type(String), index=True)
     colour_scheme = Column(Enum(ColourScheme), default=ColourScheme.system, nullable=False, index=True)
-    time_mode = Column(Enum(TimeMode), default=TimeMode.h12, nullable=False, index=True)
     start_of_week = Column(Enum(IsoWeekday), default=IsoWeekday.sunday, nullable=False, index=True)
 
     # Only accept the times greater than the one specified in the `iat` claim of the jwt token

--- a/backend/src/appointment/database/schemas.py
+++ b/backend/src/appointment/database/schemas.py
@@ -27,7 +27,6 @@ from .models import (
     ExternalConnectionType,
     MeetingLinkProviderType,
     ColourScheme,
-    TimeMode,
     IsoWeekday,
 )
 from .. import utils, defines
@@ -322,7 +321,6 @@ class SubscriberIn(BaseModel):
     secondary_email: str | None = None
     language: str | None = FALLBACK_LOCALE
     colour_scheme: ColourScheme = ColourScheme.system
-    time_mode: TimeMode = TimeMode.h12
     start_of_week: IsoWeekday = IsoWeekday.sunday
 
 

--- a/backend/src/appointment/migrations/versions/2025_01_15_1340-4a15d01919b8_add_config_fields_to_subscribers_table.py
+++ b/backend/src/appointment/migrations/versions/2025_01_15_1340-4a15d01919b8_add_config_fields_to_subscribers_table.py
@@ -5,10 +5,11 @@ Revises: 0c99f6a02f3b
 Create Date: 2025-01-15 13:40:12.022117
 
 """
+import enum
 import os
 from alembic import op
 import sqlalchemy as sa
-from appointment.database.models import ColourScheme, TimeMode
+from appointment.database.models import ColourScheme
 
 
 def secret():
@@ -20,6 +21,11 @@ revision = '4a15d01919b8'
 down_revision = '0c99f6a02f3b'
 branch_labels = None
 depends_on = None
+
+
+class TimeMode(enum.Enum):
+    h12 = 12
+    h24 = 24
 
 
 def upgrade() -> None:

--- a/backend/src/appointment/migrations/versions/2025_02_11_1254-330fdd8cd0f8_modify_subscribers_table.py
+++ b/backend/src/appointment/migrations/versions/2025_02_11_1254-330fdd8cd0f8_modify_subscribers_table.py
@@ -6,7 +6,7 @@ Create Date: 2025-02-11 12:54:51.256163
 
 """
 from alembic import op
-from appointment.database.models import TimeMode
+import enum
 
 
 # revision identifiers, used by Alembic.
@@ -14,6 +14,11 @@ revision = '330fdd8cd0f8'
 down_revision = '16c0299eff23'
 branch_labels = None
 depends_on = None
+
+
+class TimeMode(enum.Enum):
+    h12 = 12
+    h24 = 24
 
 
 def upgrade() -> None:

--- a/backend/src/appointment/migrations/versions/2026_08_18_2102-e0edc48b1a2d_remove_time_mode_from_subscribers_table.py
+++ b/backend/src/appointment/migrations/versions/2026_08_18_2102-e0edc48b1a2d_remove_time_mode_from_subscribers_table.py
@@ -1,0 +1,33 @@
+"""remove time_mode from subscribers table
+
+Revision ID: e0edc48b1a2d
+Revises: d4e5f6a7b8c9
+Create Date: 2026-08-18 21:02:33.879876
+
+"""
+import enum
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e0edc48b1a2d'
+down_revision = 'd4e5f6a7b8c9'
+branch_labels = None
+depends_on = None
+
+
+class TimeMode(enum.Enum):
+    h12 = 12
+    h24 = 24
+
+
+def upgrade() -> None:
+    op.drop_column('subscribers', 'time_mode')
+
+
+def downgrade() -> None:
+    op.add_column(
+        'subscribers',
+        sa.Column('time_mode', sa.Enum(TimeMode), default=TimeMode.h12, nullable=False, index=True)
+    )

--- a/backend/src/appointment/routes/api.py
+++ b/backend/src/appointment/routes/api.py
@@ -87,7 +87,6 @@ def update_me(
         unique_hash=me.unique_hash,
         language=me.language,
         colour_scheme=me.colour_scheme,
-        time_mode=me.time_mode,
         start_of_week=me.start_of_week,
     )
 

--- a/backend/src/appointment/routes/auth.py
+++ b/backend/src/appointment/routes/auth.py
@@ -356,7 +356,6 @@ def me(
         unique_hash=hash,
         language=subscriber.language,
         colour_scheme=subscriber.colour_scheme,
-        time_mode=subscriber.time_mode,
         start_of_week=subscriber.start_of_week,
     )
 

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -181,8 +181,6 @@
     "slotIsAvailableAgain": "Das Zeitfenster ist jetzt wieder buchbar."
   },
   "label": {
-    "12hAmPm": "12:00 Uhr (12-Stunden-Format)",
-    "24h": "24:00 (24-Stunden-Format)",
     "DDMMYYYY": "TT/MM/YYYY",
     "MMDDYYYY": "MM/TT/YYYY",
     "accepted": "Akzeptiert",
@@ -457,7 +455,6 @@
     "time": "Zeit",
     "timeCreated": "Erstellt am",
     "timeDeleted": "Gelöscht am",
-    "timeFormat": "Zeitformat",
     "timeOfTheEvent": "Uhrzeit der Veranstaltung:",
     "timeUpdated": "Geändert am",
     "timeZone": "Zeitzone",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -121,7 +121,6 @@
     "connectedApplications": "Verbundene Anwendungen",
     "contactRequest": "Kontaktanfrage",
     "createNewAppointment": "Neuen Termin erstellen",
-    "dateAndTimeFormatting": "Datums- und Zeitformat",
     "deleteAppointmentData": "Termin-Daten löschen",
     "discoverCaldavcalendars": "CalDAV-Kalender abfragen",
     "displayInformation": "Anzeige-Informationen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -124,7 +124,6 @@
     "connectedApplications": "Connected Applications",
     "contactRequest": "Contact Request",
     "createNewAppointment": "Create new appointment",
-    "dateAndTimeFormatting": "Date and Time Format",
     "deleteAppointmentData": "Delete Appointment Data",
     "discoverCaldavcalendars": "Discover CalDAV Calendars",
     "displayInformation": "Display information",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -181,8 +181,6 @@
     "slotIsAvailableAgain": "Time slot now available for bookings."
   },
   "label": {
-    "12hAmPm": "12:00 AM/PM (12-hour)",
-    "24h": "24:00 (24-hour)",
     "DDMMYYYY": "DD/MM/YYYY",
     "MMDDYYYY": "MM/DD/YYYY",
     "accepted": "Accepted",
@@ -458,7 +456,6 @@
     "time": "Time",
     "timeCreated": "Time Created",
     "timeDeleted": "Time Deleted",
-    "timeFormat": "Time Format",
     "timeOfTheEvent": "Time of the event:",
     "timeUpdated": "Time Updated",
     "timeZone": "Timezone",

--- a/frontend/src/models.ts
+++ b/frontend/src/models.ts
@@ -245,7 +245,6 @@ export type SettingsForm = {
   displayName?: string;
   language?: string;
   startOfWeek?: number;
-  timeFormat?: number;
   changedCalendars?: { [id: number]: boolean };
   changedCalendarColors?: { [id: number]: string };
 };
@@ -257,7 +256,6 @@ export type SettingsForm = {
 export type UserConfig = {
   language: string;
   colourScheme: string;
-  timeFormat: number;
   timezone: string;
   startOfWeek: number;
 };
@@ -272,7 +270,6 @@ export type Subscriber = {
   language?: string;
   timezone?: string;
   colour_scheme?: string;
-  time_mode?: number;
   start_of_week?: number;
   avatar_url?: string;
   is_setup?: boolean;

--- a/frontend/src/stores/settings-store.ts
+++ b/frontend/src/stores/settings-store.ts
@@ -56,7 +56,6 @@ export const useSettingsStore = defineStore('settings', () => {
     initialState.value.language = userStore.data.settings.language;
     initialState.value.startOfWeek = userStore.data.settings.startOfWeek;
     initialState.value.defaultTimeZone = userStore.data.settings.timezone;
-    initialState.value.timeFormat = userStore.data.settings.timeFormat;
 
     // Connected Applications section
     initialState.value.defaultCalendarId = scheduleStore.firstSchedule?.calendar_id;

--- a/frontend/src/stores/user-store.ts
+++ b/frontend/src/stores/user-store.ts
@@ -23,7 +23,6 @@ import { isOidcAuth, isPasswordAuth } from '@/composables/authSchemes';
 const initialUserConfigObject = {
   language: null,
   colourScheme: null,
-  timeFormat: null,
   timezone: null,
   startOfWeek: null,
 } as UserConfig;
@@ -61,11 +60,9 @@ export const useUserStore = defineStore('user', () => {
 
   // Init user config if not already available
   const dj = inject(dayjsKey);
-  const detectedTimeFormat = Number(dj('2022-05-24 20:00:00').format('LT').split(':')[0]) > 12 ? 24 : 12;
   const defaultSettings = {
     language: i18n.locale.value,
     colourScheme: ColourSchemes.System,
-    timeFormat: detectedTimeFormat,
     timezone: dj.tz.guess(),
     startOfWeek: 7,
   };
@@ -158,7 +155,6 @@ export const useUserStore = defineStore('user', () => {
       settings: {
         language: subscriber.language,
         colourScheme: subscriber.colour_scheme,
-        timeFormat: subscriber.time_mode,
         timezone: subscriber.timezone,
         startOfWeek: subscriber.start_of_week,
       },

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -82,13 +82,10 @@ export const enumToObject = (e: object): { [key in string]: number } => {
   return o;
 };
 
-// handle time format, return dayjs format string
-// can be either set by the user (local storage) or detected from system.
-// This functions works independent from Pinia stores so that
-// it can be called even if stores are not initialized yet.
+// Handle time format, return dayjs format string.
+// Detected from system, falling back to the configured default.
 export const timeFormat = (): string => {
   const fallbackFormat = config.defaultHourFormat ?? 12;
-  const user = JSON.parse(localStorage?.getItem('tba/user') ?? '{}') as User;
 
   let use12HourTime = null;
   try {
@@ -98,13 +95,9 @@ export const timeFormat = (): string => {
     // Catch any range error raised by invalid language/locale codes and pass
   }
 
-  // `.hour12` is an optional value and can be undefined (we cast it as null.) So default to our env value, and if not null use it.
-  let detected = fallbackFormat;
-  if (use12HourTime !== null) {
-    detected = use12HourTime ? 12 : 24;
-  }
-
-  const format = Number(user.settings?.timeFormat ?? detected);
+  // `.hour12` is an optional value and can be undefined (we cast it as null.)
+  // So default to our env value, and if not null use it.
+  const format = Number(use12HourTime !== null ? (use12HourTime ? 12 : 24) : fallbackFormat);
   return format === 24 ? 'HH:mm' : 'hh:mma';
 };
 

--- a/frontend/src/views/DashboardView/components/WeekCalendar.vue
+++ b/frontend/src/views/DashboardView/components/WeekCalendar.vue
@@ -5,7 +5,7 @@ import { dayjsKey } from '@/keys';
 import { useBookingViewStore } from '@/stores/booking-view-store';
 import { useUserStore } from '@/stores/user-store';
 import EventPopup from '@/elements/EventPopup.vue';
-import { initialEventPopupData, showEventPopup } from '@/utils';
+import { initialEventPopupData, showEventPopup, timeFormat } from '@/utils';
 import { Appointment, EventPopup as EventPopupType, GridElement, GridTimeSlot, RemoteEvent, Slot } from '@/models';
 import { BookingStatus, ColourSchemes, DateFormatStrings } from '@/definitions';
 import { Dayjs } from 'dayjs';
@@ -45,6 +45,8 @@ const { selectedEvent } = storeToRefs(useBookingViewStore());
 const calendarContainerRef = ref<HTMLElement | null>(null);
 const calendarHeaderRef = ref<HTMLElement | null>(null);
 const popup = ref<EventPopupType>({ ...initialEventPopupData });
+
+const hourFormat = computed(() => timeFormat());
 
 // Scroll sync state
 let pendingScrollSync: number | null = null;
@@ -210,6 +212,9 @@ const timeSlotsForGrid = computed(() => {
   const endTime = dj('00:00', 'HH:mm').add(1, 'day');
   const slotDuration = 60;
 
+  // Hour label format based on the browser's locale (e.g. "9 AM" or "09")
+  const hourLabelFormat = hourFormat.value === 'HH:mm' ? 'HH:mm' : 'h A';
+
   let currentTime = startTime;
 
   // Start grid rows at 1
@@ -218,8 +223,8 @@ const timeSlotsForGrid = computed(() => {
   while (currentTime.isBefore(endTime)) {
     // Create the slot for the current time
     slots.push({
-      // The text to display (e.g., "9 AM" or empty for non-hour slots)
-      text: currentTime.minute() === 0 ? currentTime.format('h A') : '',
+      // The text to display (e.g., "9 AM"/"09" or empty for non-hour slots)
+      text: currentTime.minute() === 0 ? currentTime.format(hourLabelFormat) : '',
       // The start time in a consistent format, useful for keys
       startTime: currentTime.format('HH:mm'),
       // Grid properties

--- a/frontend/src/views/SettingsView/components/Preferences.vue
+++ b/frontend/src/views/SettingsView/components/Preferences.vue
@@ -3,7 +3,7 @@ import { computed, inject } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { dayjsKey } from '@/keys';
 import { ColourSchemes } from '@/definitions';
-import { BubbleSelect, SegmentedControl, SelectInput } from '@thunderbirdops/services-ui';
+import { BubbleSelect, SelectInput } from '@thunderbirdops/services-ui';
 import { useSettingsStore } from '@/stores/settings-store';
 import { useUserStore } from '@/stores/user-store';
 import { storeToRefs } from 'pinia';
@@ -57,25 +57,6 @@ const defaultTimeZone = computed({
   get: () => currentState.value.defaultTimeZone,
   set: (value) => {
     settingsStore.$patch({ currentState: { defaultTimeZone: value } });
-  },
-});
-
-// Time Format
-const timeFormatOptions = computed(() => [
-  {
-    label: t('label.12hAmPm'),
-    value: 12,
-  },
-  {
-    label: t('label.24h'),
-    value: 24,
-  },
-]);
-
-const timeFormat = computed({
-  get: () => currentState.value.timeFormat,
-  set: (value) => {
-    settingsStore.$patch({ currentState: { timeFormat: value } });
   },
 });
 
@@ -152,10 +133,6 @@ export default {
       {{ t('label.defaultTimeZone') }}
     </select-input>
 
-    <segmented-control name="time-format" v-model="timeFormat" :options="timeFormatOptions">
-      {{ t('label.timeFormat') }}
-    </segmented-control>
-
     <bubble-select
       name="start-of-week"
       class="start-of-week-bubble-select"
@@ -192,9 +169,5 @@ h2 {
   flex-wrap: wrap;
   justify-content: flex-start;
   gap: 0.5rem;
-}
-
-:deep(.segment-list) {
-  flex-wrap: wrap;
 }
 </style>

--- a/frontend/src/views/SettingsView/index.vue
+++ b/frontend/src/views/SettingsView/index.vue
@@ -64,7 +64,6 @@ async function updatePreferences() {
     timezone: currentState.value.defaultTimeZone,
     language: currentState.value.language,
     colour_scheme: currentState.value.colourScheme,
-    time_mode: currentState.value.timeFormat,
     start_of_week: currentState.value.startOfWeek,
   };
 
@@ -74,7 +73,6 @@ async function updatePreferences() {
     timezone: userStore.data.settings.timezone,
     language: userStore.data.settings.language,
     colour_scheme: userStore.data.settings.colourScheme,
-    time_mode: userStore.data.settings.timeFormat,
     start_of_week: userStore.data.settings.startOfWeek,
   };
 

--- a/frontend/test/stores/user-store.test.js
+++ b/frontend/test/stores/user-store.test.js
@@ -56,7 +56,6 @@ const restHandlers = [
       level: 1,
       timezone: 'America/Vancouver',
       language: 'de',
-      time_mode: 12,
       colour_scheme: 'dark',
       start_of_week: 7,
       avatar_url: null,
@@ -174,7 +173,6 @@ describe('User Store', () => {
     expect(user.data.level).toBeTruthy();
     expect(user.data.settings.timezone).toBeTruthy();
     expect(user.data.settings.language).toBeTruthy();
-    expect(user.data.settings.timeFormat).toBeTruthy();
     expect(user.data.settings.colourScheme).toBeTruthy();
     expect(user.data.settings.startOfWeek).toBeTruthy();
     expect(user.data.signedUrl).toBeTruthy();

--- a/frontend/test/utils.test.js
+++ b/frontend/test/utils.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { timeFormat } from '@/utils';
+
+// Mock the browser locale with setting window.navigator.language directly.
+const setLocale = (locale) => {
+  Object.defineProperty(window.navigator, 'language', { value: locale, configurable: true });
+};
+
+describe('timeFormat', () => {
+  afterEach(() => {
+    setLocale('en-US');
+    delete window.__APP_CONFIG__;
+  });
+
+  it('detects a 12-hour format for a 12-hour locale (en-US)', () => {
+    setLocale('en-US');
+    expect(timeFormat()).toBe('hh:mma');
+  });
+
+  it('detects a 24-hour format for a 24-hour locale (de-DE)', () => {
+    setLocale('de-DE');
+    expect(timeFormat()).toBe('HH:mm');
+  });
+
+  it('detects a 24-hour format for en-GB, which uses 24-hour time despite being English', () => {
+    setLocale('en-GB');
+    expect(timeFormat()).toBe('HH:mm');
+  });
+
+  it('falls back to the configured default when the locale is invalid', () => {
+    setLocale('not-a-real-locale!!');
+    window.__APP_CONFIG__ = { defaultHourFormat: '24' };
+    expect(timeFormat()).toBe('HH:mm');
+  });
+
+  it('falls back to 12-hour format when the locale is invalid and no default is configured', () => {
+    setLocale('not-a-real-locale!!');
+    expect(timeFormat()).toBe('hh:mma');
+  });
+});

--- a/test/e2e/const/constants.ts
+++ b/test/e2e/const/constants.ts
@@ -55,7 +55,6 @@ export const APPT_BROWSER_STORE_LANGUAGE_EN = 'en';
 export const APPT_BROWSER_STORE_LANGUAGE_DE = 'de';
 export const APPT_BROWSER_STORE_THEME_LIGHT = 'light';
 export const APPT_BROWSER_STORE_THEME_DARK = 'dark';
-export const APPT_BROWSER_STORE_12HR_TIME = 12;
 export const APPT_BROWSER_STORE_START_WEEK_SUN = 7;
 export const APPT_BROWSER_STORE_START_WEEK_MON = 1;
 

--- a/test/e2e/utils/utils.ts
+++ b/test/e2e/utils/utils.ts
@@ -12,7 +12,6 @@ import {
   APPT_TIMEZONE_SETTING_PRIMARY,
   APPT_BROWSER_STORE_LANGUAGE_EN,
   APPT_BROWSER_STORE_THEME_LIGHT,
-  APPT_BROWSER_STORE_12HR_TIME,
   APPT_BROWSER_STORE_START_WEEK_SUN,
   TIMEOUT_1_SECOND,
   TIMEOUT_2_SECONDS,
@@ -98,7 +97,6 @@ export const setDefaultUserSettingsLocalStore = async (page: Page, setTimeZone: 
   localUserStoreData['settings'] = {
       "language": APPT_BROWSER_STORE_LANGUAGE_EN,
       "colourScheme": APPT_BROWSER_STORE_THEME_LIGHT,
-      "timeFormat": APPT_BROWSER_STORE_12HR_TIME,
       "timezone": setTimeZone,
       "startOfWeek": APPT_BROWSER_STORE_START_WEEK_SUN,
   }


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

This PR removes the time format setting from the Users settings page completely. Also 5 tests were added to ensure the correct auto-detection of the browsers time format (generated by Claude Code):

- 12h locale (en-US) -> hh:mma
- 24h locale (de-DE) -> HH:mm
- en-GB -> HH:mm (catches the "English != 12h" edge case)
- invalid locale -> falls back to config.defaultHourFormat when set
- invalid locale, no config -> falls back to hh:mma (12h default)

[Davi] Updated `WeekCalendar` component to make use of the time format setting.

## Why?

https://github.com/thunderbird/appointment/issues/901#issuecomment-4852916770

## Limitations and Notes

- I found one dead language key on the way (unrelated) and deleted it too.

## Applicable Issues

Closes #901
Closes https://github.com/thunderbird/appointment/issues/1795

## Screenshots

No time format option anymore:

<img width="707" height="531" alt="image" src="https://github.com/user-attachments/assets/f715b3b2-7066-40c9-8d91-9f8da7afa105" />


24 hours:

<img width="2752" height="2278" alt="Screenshot 2026-08-25 at 10-55-33 Thunderbird Appointment" src="https://github.com/user-attachments/assets/7e3b8f24-c413-43fb-8fb0-8c15131c0353" />

AM / PM:

<img width="2752" height="2278" alt="Screenshot 2026-08-25 at 10-53-44 Thunderbird Appointment" src="https://github.com/user-attachments/assets/fe0882cb-1578-40c0-954c-ac64633de266" />

