### PR TITLE
Ruff format + add --check to ruff format step in validate.yml

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Backend formatting check
         run: |
-          cd ./backend && ruff format
+          cd ./backend && ruff format --check
 
   validate-frontend:
     needs: detect-changes

--- a/backend/src/appointment/celery_app.py
+++ b/backend/src/appointment/celery_app.py
@@ -49,34 +49,36 @@ def create_celery_app() -> Celery:
 
     app = Celery('appointment')
 
-    app.config_from_object({
-        'broker_url': broker_url,
-        'result_backend': result_backend,
-        'result_expires': result_expires,
-        'task_always_eager': task_always_eager,
-        'broker_connection_retry_on_startup': True,
-        'task_default_queue': 'appointment',
-        'task_serializer': 'json',
-        'result_serializer': 'json',
-        'accept_content': ['json'],
-        'timezone': 'UTC',
-        'enable_utc': True,
-        'beat_scheduler': 'redbeat.RedBeatScheduler',
-        'beat_schedule': {
-            'heartbeat-every-60s': {
-                'task': 'appointment.tasks.health.heartbeat',
-                'schedule': 60.0,
+    app.config_from_object(
+        {
+            'broker_url': broker_url,
+            'result_backend': result_backend,
+            'result_expires': result_expires,
+            'task_always_eager': task_always_eager,
+            'broker_connection_retry_on_startup': True,
+            'task_default_queue': 'appointment',
+            'task_serializer': 'json',
+            'result_serializer': 'json',
+            'accept_content': ['json'],
+            'timezone': 'UTC',
+            'enable_utc': True,
+            'beat_scheduler': 'redbeat.RedBeatScheduler',
+            'beat_schedule': {
+                'heartbeat-every-60s': {
+                    'task': 'appointment.tasks.health.heartbeat',
+                    'schedule': 60.0,
+                },
+                'renew-google-channels': {
+                    'task': 'appointment.tasks.google.renew_google_channels',
+                    'schedule': google_channel_renew_interval,
+                },
+                'refresh-zoom-tokens': {
+                    'task': 'appointment.tasks.zoom.refresh_zoom_tokens',
+                    'schedule': zoom_token_renew_interval,
+                },
             },
-            'renew-google-channels': {
-                'task': 'appointment.tasks.google.renew_google_channels',
-                'schedule': google_channel_renew_interval,
-            },
-            'refresh-zoom-tokens': {
-                'task': 'appointment.tasks.zoom.refresh_zoom_tokens',
-                'schedule': zoom_token_renew_interval,
-            },
-        },
-    })
+        }
+    )
 
     app.autodiscover_tasks(['appointment'])
 

--- a/backend/src/appointment/commands/backfill_google_channels.py
+++ b/backend/src/appointment/commands/backfill_google_channels.py
@@ -30,15 +30,19 @@ def run():
     # Find connected Google calendars that are the default in a schedule
     # and don't yet have a watch channel
     schedule_calendar_ids = [
-        s.calendar_id for s in
-        db.query(models.Schedule.calendar_id).filter(models.Schedule.calendar_id != None).all()  # noqa: E711
+        s.calendar_id
+        for s in db.query(models.Schedule.calendar_id).filter(models.Schedule.calendar_id != None).all()  # noqa: E711
     ]
 
-    all_calendars = db.query(models.Calendar).filter(
-        models.Calendar.provider == models.CalendarProvider.google,
-        models.Calendar.connected == True,  # noqa: E712
-        models.Calendar.id.in_(schedule_calendar_ids),
-    ).all()
+    all_calendars = (
+        db.query(models.Calendar)
+        .filter(
+            models.Calendar.provider == models.CalendarProvider.google,
+            models.Calendar.connected == True,  # noqa: E712
+            models.Calendar.id.in_(schedule_calendar_ids),
+        )
+        .all()
+    )
 
     candidates = []
     for cal in all_calendars:
@@ -60,9 +64,7 @@ def run():
             continue
 
         try:
-            token = Credentials.from_authorized_user_info(
-                json.loads(ext_conn.token), google_client.SCOPES
-            )
+            token = Credentials.from_authorized_user_info(json.loads(ext_conn.token), google_client.SCOPES)
         except Exception as e:
             print(f'  Calendar {calendar.id}: failed to parse token ({e}), skipping.')
             skipped += 1

--- a/backend/src/appointment/controller/apis/google_client.py
+++ b/backend/src/appointment/controller/apis/google_client.py
@@ -18,7 +18,7 @@ from ...exceptions.calendar import (
     EventNotCreatedException,
     EventNotDeletedException,
     EventNotPatchedException,
-    FreeBusyTimeException
+    FreeBusyTimeException,
 )
 from ...exceptions.google_api import GoogleScopeChanged, GoogleInvalidCredentials
 
@@ -26,6 +26,7 @@ from ...exceptions.google_api import GoogleScopeChanged, GoogleInvalidCredential
 class SendUpdates(StrEnum):
     """Maps to the Google Calendar API ``sendUpdates`` parameter.
     Ref: https://developers.google.com/workspace/calendar/api/v3/reference/events/delete"""
+
     ALL = 'all'
     EXTERNAL_ONLY = 'externalOnly'
     NONE = 'none'
@@ -34,6 +35,7 @@ class SendUpdates(StrEnum):
 class EventStatus(StrEnum):
     """Maps to the Google Calendar API event ``status`` field.
     Ref: https://developers.google.com/workspace/calendar/api/v3/reference/events#status"""
+
     CONFIRMED = 'confirmed'
     TENTATIVE = 'tentative'
     CANCELLED = 'cancelled'
@@ -42,6 +44,7 @@ class EventStatus(StrEnum):
 class ResponseStatus(StrEnum):
     """Maps to the Google Calendar API attendee ``responseStatus`` field.
     Ref: https://developers.google.com/workspace/calendar/api/v3/reference/events"""
+
     NEEDS_ACTION = 'needsAction'
     DECLINED = 'declined'
     TENTATIVE = 'tentative'
@@ -75,7 +78,8 @@ class GoogleClient:
     def _create_flow(self, *, autogenerate_code_verifier: bool = False) -> Flow:
         """Create a fresh Flow instance for an OAuth exchange."""
         return Flow.from_client_config(
-            self.config, self.SCOPES,
+            self.config,
+            self.SCOPES,
             redirect_uri=self.callback_url,
             autogenerate_code_verifier=autogenerate_code_verifier,
         )
@@ -298,9 +302,7 @@ class GoogleClient:
     def insert_event(self, calendar_id, body, token, send_updates: SendUpdates = SendUpdates.ALL):
         with build('calendar', 'v3', credentials=token, cache_discovery=False) as service:
             try:
-                return service.events().insert(
-                    calendarId=calendar_id, body=body, sendUpdates=send_updates
-                ).execute()
+                return service.events().insert(calendarId=calendar_id, body=body, sendUpdates=send_updates).execute()
             except HttpError as e:
                 logging.warning(f'[google_client.insert_event] Request Error: {e.status_code}/{e.error_details}')
                 raise EventNotCreatedException()
@@ -340,17 +342,19 @@ class GoogleClient:
             'type': 'web_hook',
             'address': webhook_url,
             'token': state,
-            'params': {
-                'ttl': ttl
-            },
+            'params': {'ttl': ttl},
         }
 
         with build('calendar', 'v3', credentials=token, cache_discovery=False) as service:
             try:
-                response = service.events().watch(
-                    calendarId=calendar_id,
-                    body=body,
-                ).execute()
+                response = (
+                    service.events()
+                    .watch(
+                        calendarId=calendar_id,
+                        body=body,
+                    )
+                    .execute()
+                )
             except HttpError as e:
                 logging.error(f'[google_client.watch_events] Request Error: {e.status_code}/{e.error_details}')
                 return None

--- a/backend/src/appointment/controller/apis/zoom_client.py
+++ b/backend/src/appointment/controller/apis/zoom_client.py
@@ -41,7 +41,7 @@ class ZoomClient:
 
     def check_expiry(self, token: dict | None, threshold: float):
         """Checks expires_at and sets expires_in to a negative number to trigger refresh
-           if already expired or within the given renewal threshold
+        if already expired or within the given renewal threshold
         """
         if not token:
             return token

--- a/backend/src/appointment/controller/calendar.py
+++ b/backend/src/appointment/controller/calendar.py
@@ -325,10 +325,12 @@ class GoogleConnector(BaseConnector):
                 'start': {'dateTime': event.start.isoformat()},
                 'end': {'dateTime': event.end.isoformat()},
                 'attendees': [
-                    {'displayName': organizer.name, 'email': organizer_email,
-                     'responseStatus': ResponseStatus.ACCEPTED},
-                    {'displayName': attendee.name, 'email': attendee.email,
-                     'responseStatus': ResponseStatus.ACCEPTED},
+                    {
+                        'displayName': organizer.name,
+                        'email': organizer_email,
+                        'responseStatus': ResponseStatus.ACCEPTED,
+                    },
+                    {'displayName': attendee.name, 'email': attendee.email, 'responseStatus': ResponseStatus.ACCEPTED},
                 ],
                 'organizer': {
                     'displayName': organizer.name,
@@ -658,7 +660,7 @@ class CalDavConnector(BaseConnector):
 
             def is_midnight_one_day_span(vevent):
                 """For a given vevent object, check if it is an event spanning from midnight
-                   to midnight for exactly 24h.
+                to midnight for exactly 24h.
                 """
                 dtstart = vevent['DTSTART'].dt
                 dtend = vevent['DTEND'].dt
@@ -668,21 +670,19 @@ class CalDavConnector(BaseConnector):
                     return False
 
                 starts_at_midnight = (
-                    dtstart.hour == 0 and dtstart.minute == 0 and
-                    dtstart.second == 0 and dtstart.microsecond == 0
+                    dtstart.hour == 0 and dtstart.minute == 0 and dtstart.second == 0 and dtstart.microsecond == 0
                 )
                 ends_at_midnight = (
-                    dtend.hour == 0 and dtend.minute == 0 and
-                    dtend.second == 0 and dtend.microsecond == 0
+                    dtend.hour == 0 and dtend.minute == 0 and dtend.second == 0 and dtend.microsecond == 0
                 )
 
                 exactly_one_day = (dtend - dtstart) == timedelta(days=1)
 
                 return starts_at_midnight and ends_at_midnight and exactly_one_day
-            
+
             def has_domain(url, whitelist):
                 """Return True if the given url contains a whitelisted domain.
-                   Always True for development environments.
+                Always True for development environments.
                 """
                 if os.getenv('APP_ENV') == APP_ENV_DEV:
                     return True

--- a/backend/src/appointment/controller/external_connection.py
+++ b/backend/src/appointment/controller/external_connection.py
@@ -58,9 +58,7 @@ def _check_google(ec: ExternalConnections) -> ExternalConnectionStatus:
             os.getenv('GOOGLE_AUTH_CALLBACK'),
         )
 
-        creds = Credentials.from_authorized_user_info(
-            json.loads(ec.token), google_client.SCOPES
-        )
+        creds = Credentials.from_authorized_user_info(json.loads(ec.token), google_client.SCOPES)
 
         if creds.expired and creds.refresh_token:
             creds.refresh(Request())

--- a/backend/src/appointment/controller/google_watch.py
+++ b/backend/src/appointment/controller/google_watch.py
@@ -27,9 +27,7 @@ def get_google_token(google_client: GoogleClient, external_connection: models.Ex
     if not external_connection.token:
         return None
 
-    return Credentials.from_authorized_user_info(
-        json.loads(external_connection.token), google_client.SCOPES
-    )
+    return Credentials.from_authorized_user_info(json.loads(external_connection.token), google_client.SCOPES)
 
 
 def setup_watch_channel(db: Session, google_client: GoogleClient, calendar: models.Calendar) -> bool:
@@ -95,7 +93,9 @@ def teardown_watch_channel(db: Session, calendar: models.Calendar) -> bool:
 
     if calendar.external_connection and calendar.external_connection.token:
         stop_google_channel.delay(
-            channel.channel_id, channel.resource_id, calendar.external_connection.token,
+            channel.channel_id,
+            channel.resource_id,
+            calendar.external_connection.token,
         )
 
     repo.google_calendar_channel.delete(db, channel)
@@ -110,11 +110,7 @@ def teardown_watch_channels_for_connection(
     if not google_connection or not google_connection.token:
         return
 
-    calendars = (
-        db.query(models.Calendar)
-        .filter(models.Calendar.external_connection_id == google_connection.id)
-        .all()
-    )
+    calendars = db.query(models.Calendar).filter(models.Calendar.external_connection_id == google_connection.id).all()
 
     for calendar in calendars:
         channel = repo.google_calendar_channel.get_by_calendar_id(db, calendar.id)
@@ -122,7 +118,9 @@ def teardown_watch_channels_for_connection(
             continue
 
         stop_google_channel.delay(
-            channel.channel_id, channel.resource_id, google_connection.token,
+            channel.channel_id,
+            channel.resource_id,
+            google_connection.token,
         )
 
         repo.google_calendar_channel.delete(db, channel)

--- a/backend/src/appointment/controller/mailer.py
+++ b/backend/src/appointment/controller/mailer.py
@@ -482,7 +482,7 @@ class NewBookingMail(BaseBookingMail):
                 'email': self.email,
                 'date': self.date,
             },
-            lang=self.lang
+            lang=self.lang,
         )
 
     def html(self):

--- a/backend/src/appointment/database/repo/external_connection.py
+++ b/backend/src/appointment/database/repo/external_connection.py
@@ -172,9 +172,8 @@ def get_subscriber_without_oidc_by_email(db: Session, email: str):
 
 def get_zoom(db: Session) -> list[models.ExternalConnections] | None:
     """Return all external connections by Zoom type"""
-    query = (
-        db.query(models.ExternalConnections)
-        .filter(models.ExternalConnections.type == models.ExternalConnectionType.zoom)
+    query = db.query(models.ExternalConnections).filter(
+        models.ExternalConnections.type == models.ExternalConnectionType.zoom
     )
 
     result = query.all()

--- a/backend/src/appointment/database/repo/google_calendar_channel.py
+++ b/backend/src/appointment/database/repo/google_calendar_channel.py
@@ -11,26 +11,16 @@ from .. import models
 
 def get_by_calendar_id(db: Session, calendar_id: int) -> models.GoogleCalendarChannel | None:
     return (
-        db.query(models.GoogleCalendarChannel)
-        .filter(models.GoogleCalendarChannel.calendar_id == calendar_id)
-        .first()
+        db.query(models.GoogleCalendarChannel).filter(models.GoogleCalendarChannel.calendar_id == calendar_id).first()
     )
 
 
 def get_by_channel_id(db: Session, channel_id: str) -> models.GoogleCalendarChannel | None:
-    return (
-        db.query(models.GoogleCalendarChannel)
-        .filter(models.GoogleCalendarChannel.channel_id == channel_id)
-        .first()
-    )
+    return db.query(models.GoogleCalendarChannel).filter(models.GoogleCalendarChannel.channel_id == channel_id).first()
 
 
 def get_expiring(db: Session, before: datetime) -> list[models.GoogleCalendarChannel]:
-    return (
-        db.query(models.GoogleCalendarChannel)
-        .filter(models.GoogleCalendarChannel.expiration < before)
-        .all()
-    )
+    return db.query(models.GoogleCalendarChannel).filter(models.GoogleCalendarChannel.expiration < before).all()
 
 
 def create(

--- a/backend/src/appointment/database/repo/schedule.py
+++ b/backend/src/appointment/database/repo/schedule.py
@@ -49,9 +49,7 @@ def get_by_slug(db: Session, slug: str, subscriber_id: int) -> models.Schedule |
 def slug_taken(db: Session, slug: str, owner_id: int) -> bool:
     """True if the owner already has a schedule using this slug."""
     return (
-        db.query(models.Schedule)
-        .filter(models.Schedule.slug == slug, models.Schedule.owner_id == owner_id)
-        .first()
+        db.query(models.Schedule).filter(models.Schedule.slug == slug, models.Schedule.owner_id == owner_id).first()
         is not None
     )
 

--- a/backend/src/appointment/database/schemas.py
+++ b/backend/src/appointment/database/schemas.py
@@ -309,7 +309,6 @@ class CalendarOut(CalendarBase):
     provider: CalendarProvider | None = CalendarProvider.caldav
 
 
-
 """ SUBSCRIBER model schemas
 """
 

--- a/backend/src/appointment/defines.py
+++ b/backend/src/appointment/defines.py
@@ -45,6 +45,7 @@ BASE_PATH = f'{sys.modules["appointment"].__path__[0]}'
 ONE_DAY_IN_SECONDS = 86400
 SEVEN_DAYS_IN_SECONDS = 604800
 
+
 # This has to be lazy loaded because the env vars are not available at import time in main.py
 @cache
 def get_long_base_sign_url():

--- a/backend/src/appointment/exceptions/calendar.py
+++ b/backend/src/appointment/exceptions/calendar.py
@@ -9,6 +9,7 @@ class EventNotPatchedException(Exception):
 
     pass
 
+
 class EventNotDeletedException(Exception):
     """Raise if an event cannot be deleted on a remote calendar"""
 
@@ -26,6 +27,7 @@ class TestConnectionFailed(Exception):
 
     def __init__(self, reason: str | None = None):
         self.reason = reason
+
 
 class RemoteCalendarAuthenticationError(Exception):
     """Raise if the calendar authentication fails"""

--- a/backend/src/appointment/exceptions/validation.py
+++ b/backend/src/appointment/exceptions/validation.py
@@ -355,9 +355,11 @@ class ConnectionContainsDefaultCalendarException(APIException):
     def get_msg(self):
         return l10n('connection-contains-default-calendar')
 
+
 class RemoteCalendarAuthenticationException(APIException):
     id_code = 'REMOTE_CALENDAR_AUTHENTICATION_ERROR'
     status_code = 400
+
 
 class ScheduleAvailabilitySlotRequestException(APIException):
     id_code = 'SCHEDULE_AVAILABILITY_SLOT_REQUEST_EXCEPTION'

--- a/backend/src/appointment/main.py
+++ b/backend/src/appointment/main.py
@@ -64,11 +64,13 @@ def _common_setup():
     use_log_stream = os.getenv('LOG_USE_STREAM', False)
 
     log_handler = logging.StreamHandler(sys.stdout) if use_log_stream else logging.FileHandler('appointment.log')
-    log_handler.setFormatter(DefaultFormatter(
-        fmt='%(asctime)s %(levelprefix)s %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S',
-        use_colors=True,
-    ))
+    log_handler.setFormatter(
+        DefaultFormatter(
+            fmt='%(asctime)s %(levelprefix)s %(message)s',
+            datefmt='%Y-%m-%d %H:%M:%S',
+            use_colors=True,
+        )
+    )
 
     logging.basicConfig(level=getattr(logging, level), handlers=[log_handler])
 

--- a/backend/src/appointment/routes/commands.py
+++ b/backend/src/appointment/routes/commands.py
@@ -70,6 +70,7 @@ def backfill_channels():
     except FileExistsError:
         print('backfill-google-channels is already running, skipping.')
 
+
 @router.command('refresh-zoom-tokens')
 def refresh_tokens():
     from ..tasks.zoom import refresh_zoom_tokens as refresh_zoom_tokens_task

--- a/backend/src/appointment/routes/subscriber.py
+++ b/backend/src/appointment/routes/subscriber.py
@@ -27,13 +27,7 @@ def get_all_subscriber(
     per_page = data.per_page
 
     total_count = db.query(models.Subscriber).count()
-    subscribers = (
-        db.query(models.Subscriber)
-        .order_by('time_created')
-        .offset(page * per_page)
-        .limit(per_page)
-        .all()
-    )
+    subscribers = db.query(models.Subscriber).order_by('time_created').offset(page * per_page).limit(per_page).all()
 
     return schemas.SubscriberAdminOut(
         items=subscribers,

--- a/backend/src/appointment/tasks/emails.py
+++ b/backend/src/appointment/tasks/emails.py
@@ -19,8 +19,14 @@ from appointment.defines import APP_ENV_DEV
 def send_invite_email(owner_name, owner_email, date, duration, to, attachment, lang, meeting_link_url=None):
     try:
         mail = InvitationMail(
-            name=owner_name, email=owner_email, date=date, duration=duration,
-            to=to, attachments=[attachment], lang=lang, meeting_link_url=meeting_link_url,
+            name=owner_name,
+            email=owner_email,
+            date=date,
+            duration=duration,
+            to=to,
+            attachments=[attachment],
+            lang=lang,
+            meeting_link_url=meeting_link_url,
         )
         mail.send()
     except Exception as e:
@@ -62,7 +68,12 @@ def send_new_booking_email(name, email, date, duration, to, schedule_name, lang)
 def send_pending_email(owner_name, date, duration, to, attachment, lang):
     try:
         mail = PendingRequestMail(
-            owner_name=owner_name, date=date, duration=duration, to=to, attachments=[attachment], lang=lang,
+            owner_name=owner_name,
+            date=date,
+            duration=duration,
+            to=to,
+            attachments=[attachment],
+            lang=lang,
         )
         mail.send()
     except Exception as e:
@@ -76,7 +87,12 @@ def send_pending_email(owner_name, date, duration, to, attachment, lang):
 def send_cancel_email(owner_name, date, duration, to, attachment, lang):
     try:
         mail = CancelMail(
-            owner_name=owner_name, date=date, duration=duration, to=to, attachments=[attachment], lang=lang,
+            owner_name=owner_name,
+            date=date,
+            duration=duration,
+            to=to,
+            attachments=[attachment],
+            lang=lang,
         )
         mail.send()
     except Exception as e:
@@ -90,7 +106,12 @@ def send_cancel_email(owner_name, date, duration, to, attachment, lang):
 def send_rejection_email(owner_name, date, duration, to, attachment, lang):
     try:
         mail = RejectionMail(
-            owner_name=owner_name, date=date, duration=duration, to=to, attachments=[attachment], lang=lang,
+            owner_name=owner_name,
+            date=date,
+            duration=duration,
+            to=to,
+            attachments=[attachment],
+            lang=lang,
         )
         mail.send()
     except Exception as e:

--- a/backend/src/appointment/tasks/google.py
+++ b/backend/src/appointment/tasks/google.py
@@ -41,9 +41,7 @@ def renew_google_channels():
 def stop_google_channel(self, channel_id: str, resource_id: str, token_json: str):
     """Stop a Google Calendar push notification channel, with automatic retries."""
     google_client = get_google_client()
-    token = Credentials.from_authorized_user_info(
-        json.loads(token_json), google_client.SCOPES
-    )
+    token = Credentials.from_authorized_user_info(json.loads(token_json), google_client.SCOPES)
     google_client.stop_channel(channel_id, resource_id, token)
     log.info(f'Stopped Google Calendar channel {channel_id}')
 
@@ -91,9 +89,7 @@ def sync_google_calendar_changes(self, channel_id: str):
             if sync_token:
                 repo.google_calendar_channel.update_sync_token(db, channel, sync_token)
 
-        changed_events, new_sync_token = google_client.list_events_sync(
-            calendar.user, channel.sync_token, google_token
-        )
+        changed_events, new_sync_token = google_client.list_events_sync(calendar.user, channel.sync_token, google_token)
 
         if changed_events is None:
             fresh_token = google_client.get_initial_sync_token(calendar.user, google_token)
@@ -105,16 +101,18 @@ def sync_google_calendar_changes(self, channel_id: str):
             repo.google_calendar_channel.update_sync_token(db, channel, new_sync_token)
 
         if changed_events:
-            _process_changed_events(
-                db, calendar.id, changed_events, google_client, google_token, calendar.user
-            )
+            _process_changed_events(db, calendar.id, changed_events, google_client, google_token, calendar.user)
     finally:
         db.close()
 
 
 def _process_changed_events(
-    db, calendar_id: int, changed_events: list[dict],
-    google_client: GoogleClient, google_token, remote_calendar_id: str,
+    db,
+    calendar_id: int,
+    changed_events: list[dict],
+    google_client: GoogleClient,
+    google_token,
+    remote_calendar_id: str,
 ):
     """Walk through changed events and dispatch to the appropriate RSVP / cancellation handler."""
     for event in changed_events:
@@ -141,8 +139,13 @@ def _process_changed_events(
         self_attendee = next((a for a in attendees if a.get('self')), None)
         if self_attendee:
             _handle_subscriber_rsvp(
-                db, appointment, slot, self_attendee.get('responseStatus'),
-                google_client, google_token, remote_calendar_id,
+                db,
+                appointment,
+                slot,
+                self_attendee.get('responseStatus'),
+                google_client,
+                google_token,
+                remote_calendar_id,
             )
 
         attendee_email = slot.attendee.email.lower()
@@ -154,10 +157,7 @@ def _process_changed_events(
             continue
 
         response_status = google_attendee.get('responseStatus')
-        _handle_bookee_rsvp(
-            db, appointment, slot, response_status, google_client, google_token, remote_calendar_id
-        )
-
+        _handle_bookee_rsvp(db, appointment, slot, response_status, google_client, google_token, remote_calendar_id)
 
 
 def _handle_event_cancelled(
@@ -172,10 +172,7 @@ def _handle_event_cancelled(
     slot_update = schemas.SlotUpdate(booking_status=models.BookingStatus.cancelled)
     repo.slot.update(db, slot.id, slot_update)
 
-    log.info(
-        f'[tasks.google] Event cancelled for appointment {appointment.id}, '
-        f'slot {slot.id} marked as cancelled'
-    )
+    log.info(f'[tasks.google] Event cancelled for appointment {appointment.id}, slot {slot.id} marked as cancelled')
 
 
 def _handle_subscriber_rsvp(
@@ -230,7 +227,10 @@ def _handle_subscriber_rsvp(
                     body['attendees'] = remote_event['attendees']
 
                 google_client.patch_event(
-                    remote_calendar_id, appointment.external_id, body, google_token,
+                    remote_calendar_id,
+                    appointment.external_id,
+                    body,
+                    google_token,
                 )
             except Exception:
                 log.warning('[tasks.google] Failed to confirm event in Google')
@@ -248,7 +248,9 @@ def _handle_subscriber_rsvp(
             if appointment.external_id:
                 try:
                     google_client.delete_event(
-                        remote_calendar_id, appointment.external_id, google_token,
+                        remote_calendar_id,
+                        appointment.external_id,
+                        google_token,
                         send_updates=SendUpdates.ALL,
                     )
                 except Exception:
@@ -281,13 +283,7 @@ def _handle_bookee_rsvp(
                 except Exception:
                     log.warning('[tasks.google] Failed to delete declined event from Google')
 
-            log.info(
-                f'[tasks.google] Bookee declined appointment {appointment.id}, '
-                f'slot {slot.id} marked as declined'
-            )
+            log.info(f'[tasks.google] Bookee declined appointment {appointment.id}, slot {slot.id} marked as declined')
 
     elif response_status == ResponseStatus.ACCEPTED:
-        log.info(
-            f'[tasks.google] Bookee accepted appointment {appointment.id}, '
-            f'slot {slot.id}'
-        )
+        log.info(f'[tasks.google] Bookee accepted appointment {appointment.id}, slot {slot.id}')

--- a/backend/test/integration/test_appointment.py
+++ b/backend/test/integration/test_appointment.py
@@ -62,7 +62,7 @@ class TestAppointment:
         # Create mock events with various missing properties
         class MockEvent:
             """A fake caldav event, as returned by calendar.search(), whose icalendar_component
-               is a real icalendar.Event so it can go through recurring_ical_events expansion.
+            is a real icalendar.Event so it can go through recurring_ical_events expansion.
             """
 
             def __init__(self, has_dtstart=True, has_summary=True, has_dtend=True, has_duration=False):

--- a/backend/test/integration/test_auth.py
+++ b/backend/test/integration/test_auth.py
@@ -266,9 +266,7 @@ class TestCalDAV:
         username2 = 'username2'
         type_id2 = json.dumps(['url2', username2])
         ec2 = make_external_connections(TEST_USER_ID, type=models.ExternalConnectionType.caldav, type_id=type_id2)
-        make_caldav_calendar(
-            subscriber_id=TEST_USER_ID, user=username2, connected=True, external_connection_id=ec2.id
-        )
+        make_caldav_calendar(subscriber_id=TEST_USER_ID, user=username2, connected=True, external_connection_id=ec2.id)
 
         # Create a schedule that uses the first calendar (making it the "default" calendar)
         make_schedule(calendar_id=calendar1.id)
@@ -843,7 +841,7 @@ class TestOIDCToken:
             mock_introspect.return_value = {
                 'sub': oidc_id,
                 'email': email,
-                'preferred_username': email, # preferred_username is the thundermail address
+                'preferred_username': email,  # preferred_username is the thundermail address
                 'name': 'OIDC User',
             }
 
@@ -921,6 +919,7 @@ class TestOIDCToken:
             subscriber = repo.subscriber.get_by_email(db, email)
             assert subscriber is not None
             assert subscriber.email == email.lower()
+
 
 class TestWaffleFlags:
     """Tests for the /auth/waffle-flags endpoint."""

--- a/backend/test/integration/test_caldav_routes.py
+++ b/backend/test/integration/test_caldav_routes.py
@@ -362,9 +362,7 @@ class TestOidcAutodiscoverAuth:
         captured_urls = []
 
         monkeypatch.setattr(Tools, 'dns_caldav_lookup', lambda *a, **kw: (None, None))
-        monkeypatch.setattr(
-            Tools, 'well_known_caldav_lookup', lambda *a, **kw: 'https://wellknown.test.example/caldav'
-        )
+        monkeypatch.setattr(Tools, 'well_known_caldav_lookup', lambda *a, **kw: 'https://wellknown.test.example/caldav')
 
         def capturing_init(self, db, redis_instance, url, user, password, subscriber_id, calendar_id):
             captured_urls.append(url)
@@ -457,4 +455,3 @@ class TestOidcAutodiscoverAuth:
         """Request without auth headers should be rejected."""
         response = with_client.post('/caldav/oidc/auth')
         assert response.status_code == 401, response.text
-

--- a/backend/test/integration/test_google_calendar_webhook.py
+++ b/backend/test/integration/test_google_calendar_webhook.py
@@ -49,12 +49,14 @@ class TestGoogleCalendarWebhook:
     ):
         """A notification with a mismatched state token should be silently ignored."""
         subscriber = make_pro_subscriber()
-        google_creds = json.dumps({
-            'token': 'fake-token',
-            'refresh_token': 'fake-refresh',
-            'client_id': 'fake-client-id',
-            'client_secret': 'fake-secret',
-        })
+        google_creds = json.dumps(
+            {
+                'token': 'fake-token',
+                'refresh_token': 'fake-refresh',
+                'client_id': 'fake-client-id',
+                'client_secret': 'fake-secret',
+            }
+        )
         ext_conn = make_external_connections(
             subscriber.id,
             type=models.ExternalConnectionType.google,
@@ -98,12 +100,14 @@ class TestGoogleCalendarWebhook:
     ):
         """If the calendar is no longer connected, the channel should be cleaned up."""
         subscriber = make_pro_subscriber()
-        google_creds = json.dumps({
-            'token': 'fake-token',
-            'refresh_token': 'fake-refresh',
-            'client_id': 'fake-client-id',
-            'client_secret': 'fake-secret',
-        })
+        google_creds = json.dumps(
+            {
+                'token': 'fake-token',
+                'refresh_token': 'fake-refresh',
+                'client_id': 'fake-client-id',
+                'client_secret': 'fake-secret',
+            }
+        )
         ext_conn = make_external_connections(
             subscriber.id,
             type=models.ExternalConnectionType.google,
@@ -142,23 +146,19 @@ class TestGoogleCalendarWebhook:
 
     @patch('appointment.routes.webhooks.sync_google_calendar_changes')
     def test_valid_notification_returns_200(
-        self,
-        mock_sync_task,
-        with_db,
-        with_client,
-        make_pro_subscriber,
-        make_google_calendar,
-        make_external_connections
+        self, mock_sync_task, with_db, with_client, make_pro_subscriber, make_google_calendar, make_external_connections
     ):
         """A valid notification for a connected calendar should return 200
         immediately and dispatch the sync task."""
         subscriber = make_pro_subscriber()
-        google_creds = json.dumps({
-            'token': 'fake-token',
-            'refresh_token': 'fake-refresh',
-            'client_id': 'fake-client-id',
-            'client_secret': 'fake-secret',
-        })
+        google_creds = json.dumps(
+            {
+                'token': 'fake-token',
+                'refresh_token': 'fake-refresh',
+                'client_id': 'fake-client-id',
+                'client_secret': 'fake-secret',
+            }
+        )
         ext_conn = make_external_connections(
             subscriber.id,
             type=models.ExternalConnectionType.google,
@@ -203,17 +203,23 @@ class TestCalendarConnectWatchChannel:
     ):
         """Connecting a Google calendar alone should not create a watch channel.
         Channels are created when the calendar is set as default in a schedule."""
-        google_creds = json.dumps({
-            'token': 'fake-token',
-            'refresh_token': 'fake-refresh',
-            'client_id': 'fake-client-id',
-            'client_secret': 'fake-secret',
-        })
+        google_creds = json.dumps(
+            {
+                'token': 'fake-token',
+                'refresh_token': 'fake-refresh',
+                'client_id': 'fake-client-id',
+                'client_secret': 'fake-secret',
+            }
+        )
         ext_conn = make_external_connections(
-            TEST_USER_ID, type=models.ExternalConnectionType.google, token=google_creds,
+            TEST_USER_ID,
+            type=models.ExternalConnectionType.google,
+            token=google_creds,
         )
         calendar = make_google_calendar(
-            subscriber_id=TEST_USER_ID, connected=False, external_connection_id=ext_conn.id,
+            subscriber_id=TEST_USER_ID,
+            connected=False,
+            external_connection_id=ext_conn.id,
         )
 
         response = with_client.post(f'/cal/{calendar.id}/connect', headers=auth_headers)
@@ -228,17 +234,23 @@ class TestCalendarConnectWatchChannel:
     ):
         """Disconnecting a Google calendar should not tear down its watch channel.
         Channels are managed when the schedule's default calendar changes."""
-        google_creds = json.dumps({
-            'token': 'fake-token',
-            'refresh_token': 'fake-refresh',
-            'client_id': 'fake-client-id',
-            'client_secret': 'fake-secret',
-        })
+        google_creds = json.dumps(
+            {
+                'token': 'fake-token',
+                'refresh_token': 'fake-refresh',
+                'client_id': 'fake-client-id',
+                'client_secret': 'fake-secret',
+            }
+        )
         ext_conn = make_external_connections(
-            TEST_USER_ID, type=models.ExternalConnectionType.google, token=google_creds,
+            TEST_USER_ID,
+            type=models.ExternalConnectionType.google,
+            token=google_creds,
         )
         calendar = make_google_calendar(
-            subscriber_id=TEST_USER_ID, connected=True, external_connection_id=ext_conn.id,
+            subscriber_id=TEST_USER_ID,
+            connected=True,
+            external_connection_id=ext_conn.id,
         )
 
         with with_db() as db:
@@ -280,9 +292,14 @@ class TestGoogleCalendarEventRsvp:
 
     @pytest.fixture
     def rsvp_setup(
-        self, with_db,
-        make_pro_subscriber, make_google_calendar, make_external_connections,
-        make_appointment, make_attendee, make_appointment_slot,
+        self,
+        with_db,
+        make_pro_subscriber,
+        make_google_calendar,
+        make_external_connections,
+        make_appointment,
+        make_attendee,
+        make_appointment_slot,
     ):
         """Create an opened appointment with a requested slot, linked to a Google calendar."""
         subscriber = make_pro_subscriber()
@@ -331,8 +348,13 @@ class TestGoogleCalendarEventRsvp:
             appt = repo.appointment.get(db, appointment.id)
             slot = appt.slots[0]
             _handle_subscriber_rsvp(
-                db, appt, slot, 'accepted',
-                mock_google_client, mock_token, self.REMOTE_CALENDAR_ID,
+                db,
+                appt,
+                slot,
+                'accepted',
+                mock_google_client,
+                mock_token,
+                self.REMOTE_CALENDAR_ID,
             )
 
         appt, slot = self._reload(with_db, appointment.id)
@@ -361,8 +383,13 @@ class TestGoogleCalendarEventRsvp:
             appt = repo.appointment.get(db, appointment.id)
             slot = appt.slots[0]
             _handle_subscriber_rsvp(
-                db, appt, slot, 'accepted',
-                mock_google_client, mock_token, self.REMOTE_CALENDAR_ID,
+                db,
+                appt,
+                slot,
+                'accepted',
+                mock_google_client,
+                mock_token,
+                self.REMOTE_CALENDAR_ID,
             )
 
         _, slot = self._reload(with_db, appointment.id)
@@ -377,8 +404,13 @@ class TestGoogleCalendarEventRsvp:
             appt = repo.appointment.get(db, appointment.id)
             slot = appt.slots[0]
             _handle_bookee_rsvp(
-                db, appt, slot, 'accepted',
-                mock_google_client, mock_token, self.REMOTE_CALENDAR_ID,
+                db,
+                appt,
+                slot,
+                'accepted',
+                mock_google_client,
+                mock_token,
+                self.REMOTE_CALENDAR_ID,
             )
 
         appt, slot = self._reload(with_db, appointment.id)
@@ -395,15 +427,22 @@ class TestGoogleCalendarEventRsvp:
             appt = repo.appointment.get(db, appointment.id)
             slot = appt.slots[0]
             _handle_subscriber_rsvp(
-                db, appt, slot, 'declined',
-                mock_google_client, mock_token, self.REMOTE_CALENDAR_ID,
+                db,
+                appt,
+                slot,
+                'declined',
+                mock_google_client,
+                mock_token,
+                self.REMOTE_CALENDAR_ID,
             )
 
         _, slot = self._reload(with_db, appointment.id)
         assert slot.booking_status == models.BookingStatus.declined
 
         mock_google_client.delete_event.assert_called_once_with(
-            self.REMOTE_CALENDAR_ID, self.GOOGLE_EVENT_ID, mock_token,
+            self.REMOTE_CALENDAR_ID,
+            self.GOOGLE_EVENT_ID,
+            mock_token,
             send_updates=SendUpdates.ALL,
         )
 
@@ -413,15 +452,21 @@ class TestGoogleCalendarEventRsvp:
 
         with with_db() as db:
             slot_update = models.BookingStatus.declined
-            repo.slot.update(db, repo.appointment.get(db, appointment.id).slots[0].id,
-                             schemas.SlotUpdate(booking_status=slot_update))
+            repo.slot.update(
+                db, repo.appointment.get(db, appointment.id).slots[0].id, schemas.SlotUpdate(booking_status=slot_update)
+            )
 
         with with_db() as db:
             appt = repo.appointment.get(db, appointment.id)
             slot = appt.slots[0]
             _handle_subscriber_rsvp(
-                db, appt, slot, 'declined',
-                mock_google_client, mock_token, self.REMOTE_CALENDAR_ID,
+                db,
+                appt,
+                slot,
+                'declined',
+                mock_google_client,
+                mock_token,
+                self.REMOTE_CALENDAR_ID,
             )
 
         mock_google_client.delete_event.assert_not_called()
@@ -434,8 +479,13 @@ class TestGoogleCalendarEventRsvp:
             appt = repo.appointment.get(db, appointment.id)
             slot = appt.slots[0]
             _handle_bookee_rsvp(
-                db, appt, slot, 'declined',
-                mock_google_client, mock_token, self.REMOTE_CALENDAR_ID,
+                db,
+                appt,
+                slot,
+                'declined',
+                mock_google_client,
+                mock_token,
+                self.REMOTE_CALENDAR_ID,
             )
 
         _, slot = self._reload(with_db, appointment.id)
@@ -462,7 +512,8 @@ class TestGoogleCalendarEventRsvp:
         with with_db() as db:
             appt = repo.appointment.get(db, appointment.id)
             repo.slot.update(
-                db, appt.slots[0].id,
+                db,
+                appt.slots[0].id,
                 schemas.SlotUpdate(booking_status=models.BookingStatus.cancelled),
             )
 

--- a/backend/test/unit/test_accounts_client.py
+++ b/backend/test/unit/test_accounts_client.py
@@ -15,9 +15,7 @@ class TestAccountsClientWaffleFlags:
         mock_response.raise_for_status.return_value = None
         mock_response.json.return_value = {'flags': {'new-dashboard': True, 'beta-feature': False}}
 
-        with patch(
-            'appointment.controller.apis.accounts_client.requests.get', return_value=mock_response
-        ) as mock_get:
+        with patch('appointment.controller.apis.accounts_client.requests.get', return_value=mock_response) as mock_get:
             flags = accounts_client.get_waffle_flags('a-keycloak-access-token')
 
         assert flags == {'flags': {'new-dashboard': True, 'beta-feature': False}}

--- a/backend/test/unit/test_auth_dependency.py
+++ b/backend/test/unit/test_auth_dependency.py
@@ -181,9 +181,7 @@ class TestAuthDependency:
             oidc_id = uuid.uuid4().hex
             access_token = uuid.uuid4().hex
 
-            make_external_connections(
-                subscriber_id=subscriber.id, type_id=oidc_id, type=ExternalConnectionType.oidc
-            )
+            make_external_connections(subscriber_id=subscriber.id, type_id=oidc_id, type=ExternalConnectionType.oidc)
 
             request = mock.MagicMock()
 

--- a/backend/test/unit/test_calendar_tools.py
+++ b/backend/test/unit/test_calendar_tools.py
@@ -700,12 +700,15 @@ class TestVEventTimezoneFallback:
     def _make_attendee(self, tz='America/New_York'):
         return schemas.AttendeeBase(email='attendee@example.com', name='Attendee', timezone=tz)
 
-    @pytest.mark.parametrize('method_name,email_func_path', [
-        ('send_invitation_vevent', 'appointment.controller.mailer.send_invite_email'),
-        ('send_hold_vevent', 'appointment.controller.mailer.send_pending_email'),
-        ('send_reject_vevent', 'appointment.controller.mailer.send_rejection_email'),
-        ('send_cancel_vevent', 'appointment.controller.mailer.send_cancel_email'),
-    ])
+    @pytest.mark.parametrize(
+        'method_name,email_func_path',
+        [
+            ('send_invitation_vevent', 'appointment.controller.mailer.send_invite_email'),
+            ('send_hold_vevent', 'appointment.controller.mailer.send_pending_email'),
+            ('send_reject_vevent', 'appointment.controller.mailer.send_rejection_email'),
+            ('send_cancel_vevent', 'appointment.controller.mailer.send_cancel_email'),
+        ],
+    )
     def test_valid_timezone_is_applied(self, method_name, email_func_path):
         tools = self._make_tools()
         tools.create_vevent = Mock(return_value=b'VCALENDAR')
@@ -722,12 +725,15 @@ class TestVEventTimezoneFallback:
         expected = slot.start.replace(tzinfo=timezone.utc).astimezone(zoneinfo.ZoneInfo('America/New_York'))
         assert date_arg == expected
 
-    @pytest.mark.parametrize('method_name,email_func_path', [
-        ('send_invitation_vevent', 'appointment.controller.mailer.send_invite_email'),
-        ('send_hold_vevent', 'appointment.controller.mailer.send_pending_email'),
-        ('send_reject_vevent', 'appointment.controller.mailer.send_rejection_email'),
-        ('send_cancel_vevent', 'appointment.controller.mailer.send_cancel_email'),
-    ])
+    @pytest.mark.parametrize(
+        'method_name,email_func_path',
+        [
+            ('send_invitation_vevent', 'appointment.controller.mailer.send_invite_email'),
+            ('send_hold_vevent', 'appointment.controller.mailer.send_pending_email'),
+            ('send_reject_vevent', 'appointment.controller.mailer.send_rejection_email'),
+            ('send_cancel_vevent', 'appointment.controller.mailer.send_cancel_email'),
+        ],
+    )
     @pytest.mark.parametrize('bad_tz', ['Invalid/Timezone', 'Not_A_Zone', ''])
     def test_invalid_timezone_falls_back_to_utc(self, method_name, email_func_path, bad_tz):
         tools = self._make_tools()
@@ -746,12 +752,15 @@ class TestVEventTimezoneFallback:
         assert date_arg == expected
         assert date_arg.tzinfo == timezone.utc
 
-    @pytest.mark.parametrize('method_name', [
-        'send_invitation_vevent',
-        'send_hold_vevent',
-        'send_reject_vevent',
-        'send_cancel_vevent',
-    ])
+    @pytest.mark.parametrize(
+        'method_name',
+        [
+            'send_invitation_vevent',
+            'send_hold_vevent',
+            'send_reject_vevent',
+            'send_cancel_vevent',
+        ],
+    )
     def test_none_timezone_defaults_to_utc(self, method_name):
         tools = self._make_tools()
         tools.create_vevent = Mock(return_value=b'VCALENDAR')

--- a/backend/test/unit/test_commands.py
+++ b/backend/test/unit/test_commands.py
@@ -571,6 +571,7 @@ class TestRenewGoogleChannels:
             assert updated.state is not None
             assert updated.state != 'old-state'
 
+
 class TestRefreshZoomTokens:
     """Tests that the refresh command correctly renews Zoom OAuth tokens."""
 
@@ -632,9 +633,7 @@ class TestRefreshZoomTokens:
         assert setup_token['expires_at'] == 0
 
         with with_db() as db:
-            connections = repo.external_connection.get_by_type(
-                db, 1, models.ExternalConnectionType.zoom
-            )
+            connections = repo.external_connection.get_by_type(db, 1, models.ExternalConnectionType.zoom)
             assert len(connections) == 1
             stored_token = json.loads(connections[0].token)
             assert stored_token['access_token'] == 'new-access-token'
@@ -759,9 +758,7 @@ class TestRefreshZoomTokens:
         with with_db() as db:
             assert repo.external_connection.get_zoom(db) == []
 
-    def test_invalid_token_payload_does_not_stop_others(
-        self, with_db, make_external_connections, make_pro_subscriber
-    ):
+    def test_invalid_token_payload_does_not_stop_others(self, with_db, make_external_connections, make_pro_subscriber):
         """If one stored token is invalid JSON, the command should still refresh other users."""
         make_external_connections(
             subscriber_id=1,
@@ -805,4 +802,3 @@ class TestRefreshZoomTokens:
                 db, subscriber_2.id, models.ExternalConnectionType.zoom
             )[0]
             assert json.loads(valid_connection.token)['refresh_token'] == 'new-refresh-token'
-

--- a/backend/test/unit/test_google_webhook.py
+++ b/backend/test/unit/test_google_webhook.py
@@ -91,9 +91,7 @@ class TestHandleBookeeRsvp:
             db_appointment = repo.appointment.get(db, appointment_id)
             db_slot = repo.slot.get(db, slot_id)
 
-            _handle_bookee_rsvp(
-                db, db_appointment, db_slot, 'declined', mock_client, mock_token, calendar.user
-            )
+            _handle_bookee_rsvp(db, db_appointment, db_slot, 'declined', mock_client, mock_token, calendar.user)
 
             db.refresh(db_slot)
             assert db_slot.booking_status == models.BookingStatus.declined
@@ -115,9 +113,7 @@ class TestHandleBookeeRsvp:
             db_appointment = repo.appointment.get(db, appointment_id)
             db_slot = repo.slot.get(db, slot_id)
 
-            _handle_bookee_rsvp(
-                db, db_appointment, db_slot, 'accepted', mock_client, mock_token, calendar.user
-            )
+            _handle_bookee_rsvp(db, db_appointment, db_slot, 'accepted', mock_client, mock_token, calendar.user)
 
             db.refresh(db_slot)
             assert db_slot.booking_status == models.BookingStatus.requested
@@ -148,9 +144,7 @@ class TestHandleBookeeRsvp:
             db_appointment = repo.appointment.get(db, appointment.id)
             db_slot = db_appointment.slots[0]
 
-            _handle_bookee_rsvp(
-                db, db_appointment, db_slot, 'accepted', mock_client, mock_token, calendar.user
-            )
+            _handle_bookee_rsvp(db, db_appointment, db_slot, 'accepted', mock_client, mock_token, calendar.user)
 
             db.refresh(db_slot)
             assert db_slot.booking_status == models.BookingStatus.booked
@@ -170,9 +164,7 @@ class TestHandleBookeeRsvp:
             db_appointment = repo.appointment.get(db, appointment_id)
             db_slot = repo.slot.get(db, slot_id)
 
-            _handle_bookee_rsvp(
-                db, db_appointment, db_slot, 'needsAction', mock_client, mock_token, calendar.user
-            )
+            _handle_bookee_rsvp(db, db_appointment, db_slot, 'needsAction', mock_client, mock_token, calendar.user)
 
             db.refresh(db_slot)
             assert db_slot.booking_status == models.BookingStatus.requested
@@ -182,7 +174,12 @@ class TestHandleSubscriberRsvp:
     """Tests for _handle_subscriber_rsvp, focused on meeting-link and event-update behaviour."""
 
     def _make_test_objects(
-        self, with_db, make_google_calendar, make_appointment, make_attendee, make_appointment_slot,
+        self,
+        with_db,
+        make_google_calendar,
+        make_appointment,
+        make_attendee,
+        make_appointment_slot,
         meeting_link_provider=models.MeetingLinkProviderType.none,
         location_url='https://meet.example.com',
     ):
@@ -214,7 +211,11 @@ class TestHandleSubscriberRsvp:
     ):
         """Accepting via Google should patch the event with summary, location, and description."""
         calendar, appointment_id, slot_id = self._make_test_objects(
-            with_db, make_google_calendar, make_appointment, make_attendee, make_appointment_slot,
+            with_db,
+            make_google_calendar,
+            make_appointment,
+            make_attendee,
+            make_appointment_slot,
         )
 
         mock_client = Mock()
@@ -231,8 +232,13 @@ class TestHandleSubscriberRsvp:
             db_slot = repo.slot.get(db, slot_id)
 
             _handle_subscriber_rsvp(
-                db, db_appointment, db_slot, 'accepted',
-                mock_client, mock_token, calendar.user,
+                db,
+                db_appointment,
+                db_slot,
+                'accepted',
+                mock_client,
+                mock_token,
+                calendar.user,
             )
 
         mock_client.patch_event.assert_called_once()
@@ -246,14 +252,23 @@ class TestHandleSubscriberRsvp:
 
     @patch('appointment.controller.zoom.create_meeting_link')
     def test_accept_creates_zoom_link_when_configured(
-        self, mock_create_zoom,
-        with_db, make_google_calendar, make_appointment, make_attendee, make_appointment_slot,
+        self,
+        mock_create_zoom,
+        with_db,
+        make_google_calendar,
+        make_appointment,
+        make_attendee,
+        make_appointment_slot,
     ):
         """When meeting_link_provider is zoom, a Zoom link should be created and used as location."""
         mock_create_zoom.return_value = 'https://zoom.us/j/123456'
 
         calendar, appointment_id, slot_id = self._make_test_objects(
-            with_db, make_google_calendar, make_appointment, make_attendee, make_appointment_slot,
+            with_db,
+            make_google_calendar,
+            make_appointment,
+            make_attendee,
+            make_appointment_slot,
             meeting_link_provider=models.MeetingLinkProviderType.zoom,
         )
 
@@ -266,8 +281,13 @@ class TestHandleSubscriberRsvp:
             db_slot = repo.slot.get(db, slot_id)
 
             _handle_subscriber_rsvp(
-                db, db_appointment, db_slot, 'accepted',
-                mock_client, mock_token, calendar.user,
+                db,
+                db_appointment,
+                db_slot,
+                'accepted',
+                mock_client,
+                mock_token,
+                calendar.user,
             )
 
         mock_create_zoom.assert_called_once()
@@ -279,7 +299,11 @@ class TestHandleSubscriberRsvp:
     ):
         """The organizer (self) attendee responseStatus should be set to accepted."""
         calendar, appointment_id, slot_id = self._make_test_objects(
-            with_db, make_google_calendar, make_appointment, make_attendee, make_appointment_slot,
+            with_db,
+            make_google_calendar,
+            make_appointment,
+            make_attendee,
+            make_appointment_slot,
         )
 
         mock_client = Mock()
@@ -296,8 +320,13 @@ class TestHandleSubscriberRsvp:
             db_slot = repo.slot.get(db, slot_id)
 
             _handle_subscriber_rsvp(
-                db, db_appointment, db_slot, 'accepted',
-                mock_client, mock_token, calendar.user,
+                db,
+                db_appointment,
+                db_slot,
+                'accepted',
+                mock_client,
+                mock_token,
+                calendar.user,
             )
 
         patch_body = mock_client.patch_event.call_args.args[2]
@@ -334,8 +363,13 @@ class TestHandleSubscriberRsvp:
             db_slot = db_appointment.slots[0]
 
             _handle_subscriber_rsvp(
-                db, db_appointment, db_slot, 'accepted',
-                mock_client, mock_token, calendar.user,
+                db,
+                db_appointment,
+                db_slot,
+                'accepted',
+                mock_client,
+                mock_token,
+                calendar.user,
             )
 
         mock_client.patch_event.assert_not_called()
@@ -464,17 +498,23 @@ class TestSetupWatchChannel:
         self, with_db, make_google_calendar, make_external_connections, make_pro_subscriber
     ):
         subscriber = make_pro_subscriber()
-        google_creds = json.dumps({
-            'token': 'fake-token',
-            'refresh_token': 'fake-refresh',
-            'client_id': 'fake-client-id',
-            'client_secret': 'fake-secret',
-        })
+        google_creds = json.dumps(
+            {
+                'token': 'fake-token',
+                'refresh_token': 'fake-refresh',
+                'client_id': 'fake-client-id',
+                'client_secret': 'fake-secret',
+            }
+        )
         ext_conn = make_external_connections(
-            subscriber.id, type=models.ExternalConnectionType.google, token=google_creds,
+            subscriber.id,
+            type=models.ExternalConnectionType.google,
+            token=google_creds,
         )
         calendar = make_google_calendar(
-            subscriber_id=subscriber.id, connected=True, external_connection_id=ext_conn.id,
+            subscriber_id=subscriber.id,
+            connected=True,
+            external_connection_id=ext_conn.id,
         )
 
         mock_client = Mock()
@@ -503,17 +543,23 @@ class TestSetupWatchChannel:
         self, with_db, make_google_calendar, make_external_connections, make_pro_subscriber
     ):
         subscriber = make_pro_subscriber()
-        google_creds = json.dumps({
-            'token': 'fake-token',
-            'refresh_token': 'fake-refresh',
-            'client_id': 'fake-client-id',
-            'client_secret': 'fake-secret',
-        })
+        google_creds = json.dumps(
+            {
+                'token': 'fake-token',
+                'refresh_token': 'fake-refresh',
+                'client_id': 'fake-client-id',
+                'client_secret': 'fake-secret',
+            }
+        )
         ext_conn = make_external_connections(
-            subscriber.id, type=models.ExternalConnectionType.google, token=google_creds,
+            subscriber.id,
+            type=models.ExternalConnectionType.google,
+            token=google_creds,
         )
         calendar = make_google_calendar(
-            subscriber_id=subscriber.id, connected=True, external_connection_id=ext_conn.id,
+            subscriber_id=subscriber.id,
+            connected=True,
+            external_connection_id=ext_conn.id,
         )
 
         with with_db() as db:
@@ -563,17 +609,23 @@ class TestTeardownWatchChannel:
         self, mock_stop_task, with_db, make_google_calendar, make_external_connections, make_pro_subscriber
     ):
         subscriber = make_pro_subscriber()
-        google_creds = json.dumps({
-            'token': 'fake-token',
-            'refresh_token': 'fake-refresh',
-            'client_id': 'fake-client-id',
-            'client_secret': 'fake-secret',
-        })
+        google_creds = json.dumps(
+            {
+                'token': 'fake-token',
+                'refresh_token': 'fake-refresh',
+                'client_id': 'fake-client-id',
+                'client_secret': 'fake-secret',
+            }
+        )
         ext_conn = make_external_connections(
-            subscriber.id, type=models.ExternalConnectionType.google, token=google_creds,
+            subscriber.id,
+            type=models.ExternalConnectionType.google,
+            token=google_creds,
         )
         calendar = make_google_calendar(
-            subscriber_id=subscriber.id, connected=True, external_connection_id=ext_conn.id,
+            subscriber_id=subscriber.id,
+            connected=True,
+            external_connection_id=ext_conn.id,
         )
 
         with with_db() as db:

--- a/backend/test/unit/test_handle_availability_decision.py
+++ b/backend/test/unit/test_handle_availability_decision.py
@@ -33,8 +33,13 @@ class TestHandleScheduleAvailabilityDecisionGoogle:
         return subscriber
 
     def _setup(
-        self, with_db, make_google_calendar, make_appointment,
-        make_attendee, make_appointment_slot, has_external_id=True,
+        self,
+        with_db,
+        make_google_calendar,
+        make_appointment,
+        make_attendee,
+        make_appointment_slot,
+        has_external_id=True,
     ):
         calendar = make_google_calendar(connected=True)
         attendee = make_attendee(email='bookee@example.com', name='Bookee')
@@ -59,13 +64,22 @@ class TestHandleScheduleAvailabilityDecisionGoogle:
     @patch('appointment.routes.schedule.get_remote_connection')
     @patch.dict('os.environ', {'GOOGLE_INVITE_ENABLED': 'True'})
     def test_confirm_patches_existing_hold_event(
-        self, mock_get_remote_connection,
-        with_db, make_google_calendar, make_appointment, make_attendee, make_appointment_slot,
+        self,
+        mock_get_remote_connection,
+        with_db,
+        make_google_calendar,
+        make_appointment,
+        make_attendee,
+        make_appointment_slot,
     ):
         """When a hold event exists (has external_id), confirm_event should be called."""
         calendar, appointment = self._setup(
-            with_db, make_google_calendar, make_appointment,
-            make_attendee, make_appointment_slot, has_external_id=True,
+            with_db,
+            make_google_calendar,
+            make_appointment,
+            make_attendee,
+            make_appointment_slot,
+            has_external_id=True,
         )
 
         mock_connector = MagicMock()
@@ -83,8 +97,15 @@ class TestHandleScheduleAvailabilityDecisionGoogle:
             db.add(slot.attendee)
 
             handle_schedule_availability_decision(
-                True, google_calendar, schedule, subscriber, slot,
-                db, None, None, background_tasks,
+                True,
+                google_calendar,
+                schedule,
+                subscriber,
+                slot,
+                db,
+                None,
+                None,
+                background_tasks,
             )
 
             db.refresh(slot)
@@ -101,14 +122,23 @@ class TestHandleScheduleAvailabilityDecisionGoogle:
     @patch('appointment.routes.schedule.save_remote_event')
     @patch.dict('os.environ', {'GOOGLE_INVITE_ENABLED': 'True'})
     def test_confirm_creates_event_when_no_hold_exists(
-        self, mock_save_remote_event,
-        with_db, make_google_calendar, make_appointment, make_attendee, make_appointment_slot,
+        self,
+        mock_save_remote_event,
+        with_db,
+        make_google_calendar,
+        make_appointment,
+        make_attendee,
+        make_appointment_slot,
     ):
         """When no hold event exists (no external_id), save_remote_event should be called
         with send_google_notification=True and booking_confirmation=False."""
         calendar, appointment = self._setup(
-            with_db, make_google_calendar, make_appointment,
-            make_attendee, make_appointment_slot, has_external_id=False,
+            with_db,
+            make_google_calendar,
+            make_appointment,
+            make_attendee,
+            make_appointment_slot,
+            has_external_id=False,
         )
 
         mock_event = schemas.Event(
@@ -133,8 +163,15 @@ class TestHandleScheduleAvailabilityDecisionGoogle:
             db.add(slot.attendee)
 
             handle_schedule_availability_decision(
-                True, google_calendar, schedule, subscriber, slot,
-                db, None, None, background_tasks,
+                True,
+                google_calendar,
+                schedule,
+                subscriber,
+                slot,
+                db,
+                None,
+                None,
+                background_tasks,
             )
 
             db.refresh(slot)
@@ -152,14 +189,23 @@ class TestHandleScheduleAvailabilityDecisionGoogle:
     @patch('appointment.routes.schedule.save_remote_event')
     @patch.dict('os.environ', {'GOOGLE_INVITE_ENABLED': 'True'})
     def test_confirm_creates_event_does_not_send_branded_vevent(
-        self, mock_save_remote_event,
-        with_db, make_google_calendar, make_appointment, make_attendee, make_appointment_slot,
+        self,
+        mock_save_remote_event,
+        with_db,
+        make_google_calendar,
+        make_appointment,
+        make_attendee,
+        make_appointment_slot,
     ):
         """For Google invites, the branded vevent email should NOT be sent
         (Google handles notifications via sendUpdates)."""
         calendar, appointment = self._setup(
-            with_db, make_google_calendar, make_appointment,
-            make_attendee, make_appointment_slot, has_external_id=False,
+            with_db,
+            make_google_calendar,
+            make_appointment,
+            make_attendee,
+            make_appointment_slot,
+            has_external_id=False,
         )
 
         mock_event = schemas.Event(
@@ -183,8 +229,15 @@ class TestHandleScheduleAvailabilityDecisionGoogle:
             db.add(slot.attendee)
 
             handle_schedule_availability_decision(
-                True, google_calendar, schedule, subscriber, slot,
-                db, None, None, background_tasks,
+                True,
+                google_calendar,
+                schedule,
+                subscriber,
+                slot,
+                db,
+                None,
+                None,
+                background_tasks,
             )
 
         for call in background_tasks.add_task.call_args_list:
@@ -194,14 +247,23 @@ class TestHandleScheduleAvailabilityDecisionGoogle:
     @patch('appointment.routes.schedule.save_remote_event')
     @patch.dict('os.environ', {'GOOGLE_INVITE_ENABLED': 'False'})
     def test_flag_disabled_uses_non_google_path(
-        self, mock_save_remote_event,
-        with_db, make_google_calendar, make_appointment, make_attendee, make_appointment_slot,
+        self,
+        mock_save_remote_event,
+        with_db,
+        make_google_calendar,
+        make_appointment,
+        make_attendee,
+        make_appointment_slot,
     ):
         """When GOOGLE_INVITE_ENABLED is False, a Google calendar should fall back
         to the import/branded-email path (send_google_notification defaults to False)."""
         calendar, appointment = self._setup(
-            with_db, make_google_calendar, make_appointment,
-            make_attendee, make_appointment_slot, has_external_id=False,
+            with_db,
+            make_google_calendar,
+            make_appointment,
+            make_attendee,
+            make_appointment_slot,
+            has_external_id=False,
         )
 
         mock_event = schemas.Event(
@@ -226,8 +288,15 @@ class TestHandleScheduleAvailabilityDecisionGoogle:
             db.add(slot.attendee)
 
             handle_schedule_availability_decision(
-                True, google_calendar, schedule, subscriber, slot,
-                db, None, None, background_tasks,
+                True,
+                google_calendar,
+                schedule,
+                subscriber,
+                slot,
+                db,
+                None,
+                None,
+                background_tasks,
             )
 
             db.refresh(slot)

--- a/backend/test/unit/test_schedule_repo.py
+++ b/backend/test/unit/test_schedule_repo.py
@@ -68,9 +68,7 @@ class TestScheduleSlug:
 
         assert [s.id for s in schedules] == sorted([first.id, second.id, third.id])
 
-    def test_get_by_slug_is_scoped_to_owner(
-        self, with_db, make_schedule, make_pro_subscriber, make_caldav_calendar
-    ):
+    def test_get_by_slug_is_scoped_to_owner(self, with_db, make_schedule, make_pro_subscriber, make_caldav_calendar):
         slug = 'scoped01'
         make_schedule(slug=slug)
 

--- a/backend/test/unit/test_utils.py
+++ b/backend/test/unit/test_utils.py
@@ -196,9 +196,7 @@ class TestIsAValidBookingTimeWithCustomAvailability:
         schedule.availabilities = availabilities or []
 
         # Mock the timezone_offset property
-        schedule.timezone_offset = time_updated.replace(
-            tzinfo=zoneinfo.ZoneInfo(timezone)
-        ).utcoffset()
+        schedule.timezone_offset = time_updated.replace(tzinfo=zoneinfo.ZoneInfo(timezone)).utcoffset()
 
         return schedule
 


### PR DESCRIPTION
Currently, `main` fails a `ruff format --check` but it doesn't error in CI since we are silently formatting with `ruff format`.

These formatting changes are not backtracked into the code itself so we ended up in a place were lots of files are not formatted with ruff.

In this PR I've formatted all the files and added `--check` to the CI step so that this is enforced.