### PR TITLE
Push channel trust gate  tests only

### DIFF
--- a/backend/test/defines.py
+++ b/backend/test/defines.py
@@ -1,3 +1,4 @@
+import fnmatch
 from datetime import datetime, timedelta
 
 DATEFMT = '%Y-%m-%d'
@@ -25,3 +26,27 @@ FAKER_RANDOM_VALUE = '___faker_random_value___'
 def factory_has_value(val) -> bool:
     """For factories"""
     return val != FAKER_RANDOM_VALUE
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def set(self, key, value, ex=None):
+        self.store[key] = value
+        return True
+
+    def delete(self, *keys):
+        deleted = 0
+        for key in keys:
+            if key in self.store:
+                del self.store[key]
+                deleted += 1
+        return deleted
+
+    def scan_iter(self, match=None, count=None):
+        pattern = match or '*'
+        return iter([k for k in list(self.store.keys()) if fnmatch.fnmatch(k, pattern)])

--- a/backend/test/integration/test_google_calendar_webhook.py
+++ b/backend/test/integration/test_google_calendar_webhook.py
@@ -193,6 +193,68 @@ class TestGoogleCalendarWebhook:
         assert response.status_code == 200
         mock_sync_task.delay.assert_called_once_with('valid-channel')
 
+    @patch('appointment.routes.webhooks.sync_google_calendar_changes')
+    def test_notification_records_message_number_and_expiration(
+        self,
+        mock_sync_task,
+        with_db,
+        with_client,
+        make_pro_subscriber,
+        make_google_calendar,
+        make_external_connections,
+    ):
+        """Record the notification before dispatching the sync task, so is_push_active's
+        bookkeeping is current even if the sync task is slow or fails."""
+        subscriber = make_pro_subscriber()
+        google_creds = json.dumps(
+            {
+                'token': 'fake-token',
+                'refresh_token': 'fake-refresh',
+                'client_id': 'fake-client-id',
+                'client_secret': 'fake-secret',
+            }
+        )
+        ext_conn = make_external_connections(
+            subscriber.id,
+            type=models.ExternalConnectionType.google,
+            token=google_creds,
+        )
+        calendar = make_google_calendar(
+            subscriber_id=subscriber.id,
+            connected=True,
+            external_connection_id=ext_conn.id,
+        )
+
+        channel_state = 'notif-state-token'
+        with with_db() as db:
+            repo.google_calendar_channel.create(
+                db,
+                calendar_id=calendar.id,
+                channel_id='notif-channel',
+                resource_id='res-notif',
+                expiration=datetime.now(tz=timezone.utc) + timedelta(days=1),
+                state=channel_state,
+                sync_token='initial-sync-token',
+            )
+
+        response = with_client.post(
+            '/webhooks/google-calendar',
+            headers={
+                'X-Goog-Channel-Id': 'notif-channel',
+                'X-Goog-Resource-State': 'exists',
+                'X-Goog-Channel-Token': channel_state,
+                'X-Goog-Message-Number': '7',
+                'X-Goog-Channel-Expiration': 'Tue, 01 Sep 2026 12:00:00 GMT',
+            },
+        )
+        assert response.status_code == 200
+
+        with with_db() as db:
+            channel = repo.google_calendar_channel.get_by_channel_id(db, 'notif-channel')
+            assert channel.last_message_number == 7
+            assert channel.last_notification_at is not None
+            assert channel.expiration == datetime(2026, 9, 1, 12, 0, 0)
+
 
 class TestCalendarConnectWatchChannel:
     """Watch channels are managed at the schedule level, not on connect/disconnect.

--- a/backend/test/unit/test_google_channel_trust.py
+++ b/backend/test/unit/test_google_channel_trust.py
@@ -1,0 +1,243 @@
+"""Tests for is_push_active() and the schema/repo plumbing it reads
+(last_synced_at/last_notification_at/last_message_number).
+"""
+
+from datetime import datetime, timedelta, UTC
+
+import pytest
+
+from appointment.controller.google_watch import (
+    CHANNEL_EXPIRY_MARGIN,
+    MAX_SYNC_AGE,
+    is_push_active,
+    push_backed_calendar_ids,
+)
+from appointment.database import models, repo
+
+
+def _channel(**overrides) -> models.GoogleCalendarChannel:
+    """A channel that is_push_active() should consider healthy by default."""
+    now = overrides.pop('now', datetime.now(tz=UTC))
+    defaults = {
+        'calendar_id': 1,
+        'channel_id': 'chan-1',
+        'resource_id': 'res-1',
+        'expiration': now + timedelta(days=1),
+        'sync_token': 'sync-token-1',
+        'state': 'state-1',
+        'last_synced_at': now,
+    }
+    defaults.update(overrides)
+    return models.GoogleCalendarChannel(**defaults)
+
+
+def _healthy_channel(now: datetime) -> models.GoogleCalendarChannel:
+    return _channel(now=now)
+
+
+def _no_channel(now: datetime) -> None:
+    return None
+
+
+def _expired_channel(now: datetime) -> models.GoogleCalendarChannel:
+    return _channel(now=now, expiration=now - timedelta(hours=1))
+
+
+def _channel_inside_expiry_margin(now: datetime) -> models.GoogleCalendarChannel:
+    return _channel(now=now, expiration=now + (CHANNEL_EXPIRY_MARGIN / 2))
+
+
+def _channel_missing_sync_token(now: datetime) -> models.GoogleCalendarChannel:
+    return _channel(now=now, sync_token=None)
+
+
+def _never_synced_channel(now: datetime) -> models.GoogleCalendarChannel:
+    return _channel(now=now, last_synced_at=None)
+
+
+def _channel_stale_beyond_max_sync_age(now: datetime) -> models.GoogleCalendarChannel:
+    return _channel(now=now, last_synced_at=now - MAX_SYNC_AGE - timedelta(minutes=1))
+
+
+def _channel_with_naive_db_datetimes(now: datetime) -> models.GoogleCalendarChannel:
+    return _channel(
+        now=now,
+        expiration=(now + timedelta(days=1)).replace(tzinfo=None),
+        last_synced_at=now.replace(tzinfo=None),
+    )
+
+
+class TestIsPushActive:
+    @pytest.mark.parametrize(
+        'channel_factory, expected',
+        [
+            pytest.param(_healthy_channel, True, id='healthy'),
+            pytest.param(_no_channel, False, id='none_channel'),
+            pytest.param(_expired_channel, False, id='expired'),
+            pytest.param(_channel_inside_expiry_margin, False, id='inside_expiry_margin'),
+            pytest.param(_channel_missing_sync_token, False, id='missing_sync_token'),
+            pytest.param(_never_synced_channel, False, id='never_synced'),
+            pytest.param(_channel_stale_beyond_max_sync_age, False, id='stale_beyond_max_sync_age'),
+            pytest.param(_channel_with_naive_db_datetimes, True, id='naive_db_datetimes_normalized'),
+        ],
+    )
+    def test_is_push_active_scenarios(self, channel_factory, expected):
+        now = datetime.now(tz=UTC)
+        channel = channel_factory(now)
+        assert is_push_active(channel, now=now) is expected
+
+
+class TestPushBackedCalendarIds:
+    def test_only_calendars_with_a_live_channel_are_returned(self, with_db, make_google_calendar):
+        watched = make_google_calendar(connected=True)
+        unwatched = make_google_calendar(connected=True)
+
+        with with_db() as db:
+            repo.google_calendar_channel.create(
+                db,
+                calendar_id=watched.id,
+                channel_id='chan-watched',
+                resource_id='res-watched',
+                expiration=datetime.now(tz=UTC) + timedelta(days=1),
+                state='state',
+                sync_token='sync-token',
+                last_synced_at=datetime.now(tz=UTC),
+            )
+            calendars = db.query(models.Calendar).filter(models.Calendar.id.in_([watched.id, unwatched.id])).all()
+            backed = push_backed_calendar_ids(db, calendars)
+
+        assert backed == {watched.user}
+
+    def test_expired_channel_is_excluded(self, with_db, make_google_calendar):
+        calendar = make_google_calendar(connected=True)
+
+        with with_db() as db:
+            repo.google_calendar_channel.create(
+                db,
+                calendar_id=calendar.id,
+                channel_id='chan-expired',
+                resource_id='res-expired',
+                expiration=datetime.now(tz=UTC) - timedelta(hours=1),
+                state='state',
+                sync_token='sync-token',
+                last_synced_at=datetime.now(tz=UTC),
+            )
+            calendars = db.query(models.Calendar).filter(models.Calendar.id == calendar.id).all()
+            backed = push_backed_calendar_ids(db, calendars)
+
+        assert backed == set()
+
+
+class TestGetStale:
+    def test_includes_never_synced_and_old_excludes_fresh(self, with_db, make_google_calendar):
+        never_synced = make_google_calendar(connected=True)
+        stale = make_google_calendar(connected=True)
+        fresh = make_google_calendar(connected=True)
+
+        now = datetime.now(tz=UTC)
+        cutoff = now - timedelta(minutes=15)
+
+        with with_db() as db:
+            repo.google_calendar_channel.create(
+                db,
+                calendar_id=never_synced.id,
+                channel_id='c1',
+                resource_id='r1',
+                expiration=now + timedelta(days=1),
+                state='s',
+                sync_token=None,
+                last_synced_at=None,
+            )
+            repo.google_calendar_channel.create(
+                db,
+                calendar_id=stale.id,
+                channel_id='c2',
+                resource_id='r2',
+                expiration=now + timedelta(days=1),
+                state='s',
+                sync_token='tok',
+                last_synced_at=now - timedelta(minutes=30),
+            )
+            repo.google_calendar_channel.create(
+                db,
+                calendar_id=fresh.id,
+                channel_id='c3',
+                resource_id='r3',
+                expiration=now + timedelta(days=1),
+                state='s',
+                sync_token='tok',
+                last_synced_at=now - timedelta(minutes=1),
+            )
+
+            stale_channels = repo.google_calendar_channel.get_stale(db, synced_before=cutoff)
+            stale_calendar_ids = {c.calendar_id for c in stale_channels}
+
+        assert stale_calendar_ids == {never_synced.id, stale.id}
+
+
+class TestRecordNotification:
+    def test_advances_high_water_mark(self, with_db, make_google_calendar):
+        calendar = make_google_calendar(connected=True)
+        with with_db() as db:
+            channel = repo.google_calendar_channel.create(
+                db,
+                calendar_id=calendar.id,
+                channel_id='c',
+                resource_id='r',
+                expiration=datetime.now(tz=UTC) + timedelta(days=1),
+                state='s',
+            )
+            previous = repo.google_calendar_channel.record_notification(db, channel, message_number=5)
+            assert previous is None
+            assert channel.last_message_number == 5
+
+            previous = repo.google_calendar_channel.record_notification(db, channel, message_number=6)
+            assert previous == 5
+            assert channel.last_message_number == 6
+
+    def test_duplicate_does_not_move_mark_backward(self, with_db, make_google_calendar):
+        calendar = make_google_calendar(connected=True)
+        with with_db() as db:
+            channel = repo.google_calendar_channel.create(
+                db,
+                calendar_id=calendar.id,
+                channel_id='c',
+                resource_id='r',
+                expiration=datetime.now(tz=UTC) + timedelta(days=1),
+                state='s',
+            )
+            repo.google_calendar_channel.record_notification(db, channel, message_number=10)
+            repo.google_calendar_channel.record_notification(db, channel, message_number=3)
+            assert channel.last_message_number == 10
+
+    def test_expiration_is_refreshed(self, with_db, make_google_calendar):
+        calendar = make_google_calendar(connected=True)
+        new_expiration = datetime.now(tz=UTC) + timedelta(days=7)
+        with with_db() as db:
+            channel = repo.google_calendar_channel.create(
+                db,
+                calendar_id=calendar.id,
+                channel_id='c',
+                resource_id='r',
+                expiration=datetime.now(tz=UTC) + timedelta(days=1),
+                state='s',
+            )
+            repo.google_calendar_channel.record_notification(db, channel, expiration=new_expiration)
+            assert channel.expiration.replace(tzinfo=UTC) == new_expiration
+
+    def test_notification_alone_does_not_make_push_active(self, with_db, make_google_calendar):
+        """A notification just means something changed; is_push_active shouldn't trust
+        a channel until it's actually been synced."""
+        calendar = make_google_calendar(connected=True)
+        with with_db() as db:
+            channel = repo.google_calendar_channel.create(
+                db,
+                calendar_id=calendar.id,
+                channel_id='c',
+                resource_id='r',
+                expiration=datetime.now(tz=UTC) + timedelta(days=1),
+                state='s',
+                sync_token='tok',
+            )
+            repo.google_calendar_channel.record_notification(db, channel, message_number=1)
+            assert is_push_active(channel) is False

--- a/backend/test/unit/test_google_freebusy_cache.py
+++ b/backend/test/unit/test_google_freebusy_cache.py
@@ -1,0 +1,100 @@
+"""Tests for GoogleConnector.get_busy_time()'s push-backed caching."""
+
+from datetime import datetime, timedelta, UTC
+from unittest.mock import Mock
+
+from defines import FakeRedis
+
+from appointment.controller.calendar import GoogleConnector
+from appointment.database import repo
+
+
+def _mock_google_client():
+    client = Mock()
+    client.SCOPES = ['https://www.googleapis.com/auth/calendar']
+    client.get_free_busy.return_value = [{'start': datetime(2026, 1, 1, 9), 'end': datetime(2026, 1, 1, 10)}]
+    return client
+
+
+def _channel_for(db, calendar, **overrides):
+    now = datetime.now(tz=UTC)
+    defaults = {
+        'channel_id': f'chan-{calendar.id}',
+        'resource_id': f'res-{calendar.id}',
+        'expiration': now + timedelta(days=1),
+        'state': 's',
+        'sync_token': 'tok',
+        'last_synced_at': now,
+    }
+    defaults.update(overrides)
+    return repo.google_calendar_channel.create(db, calendar_id=calendar.id, **defaults)
+
+
+def _connector(db, subscriber_id, remote_calendar_id, redis_instance, google_client):
+    return GoogleConnector(
+        subscriber_id=subscriber_id,
+        calendar_id=None,
+        redis_instance=redis_instance,
+        db=db,
+        remote_calendar_id=remote_calendar_id,
+        google_client=google_client,
+    )
+
+
+class TestGetBusyTimeCaching:
+    def test_push_backed_calendar_served_from_cache_on_second_call(self, with_db, make_google_calendar):
+        calendar = make_google_calendar(connected=True)
+        with with_db() as db:
+            _channel_for(db, calendar)
+
+            google_client = _mock_google_client()
+            connector = _connector(db, calendar.owner_id, calendar.user, FakeRedis(), google_client)
+
+            # Capture both results, not just the call count: a cache hit should
+            # return the same data as the fresh call it's standing in for.
+            first = connector.get_busy_time([calendar.user], '2026-01-01', '2026-01-02')
+            second = connector.get_busy_time([calendar.user], '2026-01-01', '2026-01-02')
+
+        assert google_client.get_free_busy.call_count == 1
+        assert first == second
+
+    def test_calendar_without_channel_still_polls_every_request(self, with_db, make_google_calendar):
+        calendar = make_google_calendar(connected=True)
+        with with_db() as db:
+            google_client = _mock_google_client()
+            connector = _connector(db, calendar.owner_id, calendar.user, FakeRedis(), google_client)
+
+            connector.get_busy_time([calendar.user], '2026-01-01', '2026-01-02')
+            connector.get_busy_time([calendar.user], '2026-01-01', '2026-01-02')
+
+        assert google_client.get_free_busy.call_count == 2
+
+    def test_expired_channel_falls_back_to_polling(self, with_db, make_google_calendar):
+        calendar = make_google_calendar(connected=True)
+        with with_db() as db:
+            _channel_for(db, calendar, expiration=datetime.now(tz=UTC) - timedelta(hours=1))
+
+            google_client = _mock_google_client()
+            connector = _connector(db, calendar.owner_id, calendar.user, FakeRedis(), google_client)
+
+            connector.get_busy_time([calendar.user], '2026-01-01', '2026-01-02')
+            connector.get_busy_time([calendar.user], '2026-01-01', '2026-01-02')
+
+        assert google_client.get_free_busy.call_count == 2
+
+    def test_cache_key_distinguishes_different_calendar_id_sets(self, with_db, make_google_calendar):
+        cal_a = make_google_calendar(connected=True)
+        cal_b = make_google_calendar(connected=True)
+        with with_db() as db:
+            _channel_for(db, cal_a)
+            _channel_for(db, cal_b)
+
+            google_client = _mock_google_client()
+            connector = _connector(db, cal_a.owner_id, cal_a.user, FakeRedis(), google_client)
+
+            connector.get_busy_time([cal_a.user], '2026-01-01', '2026-01-02')
+            connector.get_busy_time([cal_a.user, cal_b.user], '2026-01-01', '2026-01-02')
+
+        # adding cal_b to the request should miss cache, not reuse cal_a's entry
+        assert google_client.get_free_busy.call_count == 2
+

--- a/backend/test/unit/test_google_push_recovery.py
+++ b/backend/test/unit/test_google_push_recovery.py
@@ -1,0 +1,227 @@
+"""Tests for Google push sync, fallback/recovery, and channel reconciliation."""
+
+import json
+from datetime import datetime, timedelta, UTC
+from unittest.mock import Mock, patch
+
+from defines import FakeRedis
+
+from appointment.controller.calendar import BaseConnector
+from appointment.controller.google_watch import is_push_active
+from appointment.database import models, repo
+from appointment.defines import REDIS_REMOTE_EVENTS_KEY
+from appointment.tasks.google import sync_google_calendar_changes
+
+MODULE = 'appointment.tasks.google'
+
+
+def _google_token() -> str:
+    return json.dumps(
+        {
+            'token': 'access-token',
+            'refresh_token': 'refresh-token',
+            'client_id': 'client-id',
+            'client_secret': 'client-secret',
+            'scopes': ['https://www.googleapis.com/auth/calendar'],
+        }
+    )
+
+
+def _mock_client(**overrides):
+    client = Mock()
+    client.SCOPES = ['https://www.googleapis.com/auth/calendar']
+    client.list_events_sync.return_value = ([], 'new-sync-token')
+    client.get_initial_sync_token.return_value = 'reestablished-sync-token'
+    client.list_events.return_value = []
+    for key, value in overrides.items():
+        setattr(client, key, value)
+    return client
+
+
+def _run_sync(channel_id, with_db, google_client, redis_instance=None):
+    with (
+        patch(f'{MODULE}.get_engine_and_session', return_value=(None, with_db)),
+        patch(f'{MODULE}.get_google_client', return_value=google_client),
+        patch(f'{MODULE}.get_redis', return_value=redis_instance or FakeRedis()),
+    ):
+        sync_google_calendar_changes(channel_id)
+
+
+class TestNormalSync:
+    def test_successful_sync_advances_watermark_and_token(
+        self, with_db, make_google_calendar, make_external_connections
+    ):
+        ext = make_external_connections(
+            subscriber_id=1, type=models.ExternalConnectionType.google, token=_google_token()
+        )
+        calendar = make_google_calendar(connected=True, external_connection_id=ext.id)
+
+        with with_db() as db:
+            channel = repo.google_calendar_channel.create(
+                db,
+                calendar_id=calendar.id,
+                channel_id='chan-1',
+                resource_id='res-1',
+                expiration=datetime.now(tz=UTC) + timedelta(days=1),
+                state='s',
+                sync_token='old-token',
+                last_synced_at=datetime.now(tz=UTC) - timedelta(hours=1),
+            )
+
+        _run_sync('chan-1', with_db, _mock_client())
+
+        with with_db() as db:
+            channel = repo.google_calendar_channel.get_by_channel_id(db, 'chan-1')
+            assert channel.sync_token == 'new-sync-token'
+            assert channel.last_synced_at is not None
+            assert is_push_active(channel) is True
+
+    def test_sync_with_changes_busts_cache(self, with_db, make_google_calendar, make_external_connections):
+        ext = make_external_connections(
+            subscriber_id=1, type=models.ExternalConnectionType.google, token=_google_token()
+        )
+        calendar = make_google_calendar(connected=True, external_connection_id=ext.id)
+
+        with with_db() as db:
+            repo.google_calendar_channel.create(
+                db,
+                calendar_id=calendar.id,
+                channel_id='chan-2',
+                resource_id='res-2',
+                expiration=datetime.now(tz=UTC) + timedelta(days=1),
+                state='s',
+                sync_token='old-token',
+                last_synced_at=datetime.now(tz=UTC) - timedelta(hours=1),
+            )
+
+        redis_instance = FakeRedis()
+        connector = BaseConnector(calendar.owner_id, calendar.id, redis_instance)
+        key = f'{connector.get_key_body()}:cached'
+        redis_instance.store[f'{REDIS_REMOTE_EVENTS_KEY}:{key}'] = 'stale-cached-value'
+
+        client = _mock_client(list_events_sync=Mock(return_value=([{'id': 'evt-1'}], 'new-sync-token')))
+        _run_sync('chan-2', with_db, client, redis_instance=redis_instance)
+
+        assert redis_instance.store == {}
+
+    def test_quiet_sync_leaves_cache_intact(self, with_db, make_google_calendar, make_external_connections):
+        ext = make_external_connections(
+            subscriber_id=1, type=models.ExternalConnectionType.google, token=_google_token()
+        )
+        calendar = make_google_calendar(connected=True, external_connection_id=ext.id)
+
+        with with_db() as db:
+            repo.google_calendar_channel.create(
+                db,
+                calendar_id=calendar.id,
+                channel_id='chan-3',
+                resource_id='res-3',
+                expiration=datetime.now(tz=UTC) + timedelta(days=1),
+                state='s',
+                sync_token='old-token',
+                last_synced_at=datetime.now(tz=UTC) - timedelta(hours=1),
+            )
+
+        redis_instance = FakeRedis()
+        redis_instance.store['some-other-key'] = 'untouched'
+
+        _run_sync('chan-3', with_db, _mock_client(), redis_instance=redis_instance)
+
+        assert redis_instance.store == {'some-other-key': 'untouched'}
+
+
+class TestDuplicateNotifications:
+    def test_replayed_sync_is_idempotent(self, with_db, make_google_calendar, make_external_connections):
+        ext = make_external_connections(
+            subscriber_id=1, type=models.ExternalConnectionType.google, token=_google_token()
+        )
+        calendar = make_google_calendar(connected=True, external_connection_id=ext.id)
+
+        with with_db() as db:
+            repo.google_calendar_channel.create(
+                db,
+                calendar_id=calendar.id,
+                channel_id='chan-4',
+                resource_id='res-4',
+                expiration=datetime.now(tz=UTC) + timedelta(days=1),
+                state='s',
+                sync_token='old-token',
+                last_synced_at=datetime.now(tz=UTC) - timedelta(hours=1),
+            )
+
+        client = _mock_client()
+        _run_sync('chan-4', with_db, client)
+        _run_sync('chan-4', with_db, client)
+
+        with with_db() as db:
+            channel = repo.google_calendar_channel.get_by_channel_id(db, 'chan-4')
+            assert channel.sync_token == 'new-sync-token'
+
+
+class TestInvalidSyncToken:
+    def test_410_triggers_bounded_full_resync_and_reestablishes_token(
+        self, with_db, make_google_calendar, make_external_connections
+    ):
+        ext = make_external_connections(
+            subscriber_id=1, type=models.ExternalConnectionType.google, token=_google_token()
+        )
+        calendar = make_google_calendar(connected=True, external_connection_id=ext.id)
+
+        with with_db() as db:
+            repo.google_calendar_channel.create(
+                db,
+                calendar_id=calendar.id,
+                channel_id='chan-5',
+                resource_id='res-5',
+                expiration=datetime.now(tz=UTC) + timedelta(days=1),
+                state='s',
+                sync_token='dead-token',
+                last_synced_at=datetime.now(tz=UTC) - timedelta(hours=1),
+            )
+
+        client = _mock_client(list_events_sync=Mock(return_value=(None, None)))
+        _run_sync('chan-5', with_db, client)
+
+        client.get_initial_sync_token.assert_called_once()
+
+        with with_db() as db:
+            channel = repo.google_calendar_channel.get_by_channel_id(db, 'chan-5')
+            assert channel.sync_token == 'reestablished-sync-token'
+            assert is_push_active(channel) is True
+
+    def test_failure_to_reestablish_token_leaves_watermark_stale(
+        self, with_db, make_google_calendar, make_external_connections
+    ):
+        """If we can't get a new token, don't touch last_synced_at either, or
+        is_push_active() will trust a channel that still has a dead token."""
+        ext = make_external_connections(
+            subscriber_id=1, type=models.ExternalConnectionType.google, token=_google_token()
+        )
+        calendar = make_google_calendar(connected=True, external_connection_id=ext.id)
+
+        # 7h > MAX_SYNC_AGE (6h), so this channel should already read as inactive.
+        stale_since = datetime.now(tz=UTC) - timedelta(hours=7)
+        with with_db() as db:
+            repo.google_calendar_channel.create(
+                db,
+                calendar_id=calendar.id,
+                channel_id='chan-7',
+                resource_id='res-7',
+                expiration=datetime.now(tz=UTC) + timedelta(days=1),
+                state='s',
+                sync_token='dead-token',
+                last_synced_at=stale_since,
+            )
+
+        client = _mock_client(
+            list_events_sync=Mock(return_value=(None, None)),
+            get_initial_sync_token=Mock(return_value=None),
+        )
+        _run_sync('chan-7', with_db, client)
+
+        with with_db() as db:
+            channel = repo.google_calendar_channel.get_by_channel_id(db, 'chan-7')
+            # neither field should have moved
+            assert channel.sync_token == 'dead-token'
+            assert channel.last_synced_at == stale_since.replace(tzinfo=None)
+            assert is_push_active(channel) is False


### PR DESCRIPTION
## AI disclosure

This PR was created with the assistance of `gemma4:26b-a4b-it-q4_K_M` (via `ollama`) and `Claude Sonnet 5 (medium effort)`.

## What changed?

Added trust-gate, recovery, and cache-wiring tests only.

## Why?

Relates-to: https://github.com/thunderbird/appointment/issues/1607 

## Limitations and Notes

This branch is expected to provide failing tests (it is a work-in-progress / draft).

## Applicable Issues

Relates to #1607 , but does not close it.

## Screenshots

Not applicable — backend changes only.