### PR TITLE
Disable buttons while refreshing link in Refresh Link modal 

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -33,6 +33,8 @@
     "noConnectedCalendars": "Kalendereinrichtung zum Fortfahren erforderlich. {0}.",
     "noConnectedCalendarsLink": "Zu den Einstellungen wechseln.",
     "noSpecialCharacters": "Bitte die Sonderzeichen entfernen und nochmal versuchen.",
+    "refreshLinkError": "Dein Link konnte nicht aktualisiert werden. Bitte nochmal versuchen.",
+    "refreshLinkReloadError": "Dein Link wurde aktualisiert, konnte aber nicht neu geladen werden. Bitte lade die Seite neu.",
     "routeNotFound": "Entschuldigung, diese Seite wurde nicht gefunden.",
     "scheduleRemoteCalendarConnectionDetails": "Bitte kontaktiere den Eigentümer der Buchungsseite direkt, um dieses Problem zu beheben.",
     "scheduleRemoteCalendarConnectionError": "Es konnte keine Verbindung zum Kalender hergestellt werden.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -33,6 +33,8 @@
     "noConnectedCalendars": "Calendar setup required. Connect a calendar to continue. {0}.",
     "noConnectedCalendarsLink": "Go to settings",
     "noSpecialCharacters": "Please remove the special characters and try again.",
+    "refreshLinkError": "Your link couldn't be refreshed. Please try again.",
+    "refreshLinkReloadError": "Your link was refreshed, but we couldn't reload it. Please refresh the page.",
     "routeNotFound": "Sorry, this page could not be found.",
     "scheduleRemoteCalendarConnectionDetails": "Please contact the owner of the booking page directly to resolve this issue.",
     "scheduleRemoteCalendarConnectionError": "We couldn't connect to the calendar.",

--- a/frontend/src/views/AvailabilityView/components/BookingPageLink/components/RefreshLinkModal.vue
+++ b/frontend/src/views/AvailabilityView/components/BookingPageLink/components/RefreshLinkModal.vue
@@ -6,6 +6,10 @@ import { useI18n } from 'vue-i18n';
 const { t } = useI18n();
 const emit = defineEmits(['confirmed']);
 
+defineProps<{
+  loading?: boolean;
+}>();
+
 const modal = useTemplateRef('modal');
 
 /**
@@ -23,7 +27,7 @@ defineExpose({ show, hide });
 
 <template>
   <!-- Refresh link modal -->
-  <modal-dialog ref="modal" class="refresh-link-modal">
+  <modal-dialog ref="modal" class="refresh-link-modal" :class="{ 'is-loading': loading }" :close-outside="!loading">
     <template #header>
       {{ t('label.refreshLink') }}
     </template>
@@ -36,6 +40,7 @@ defineExpose({ show, hide });
       <primary-button
         name="cancel"
         variant="outline"
+        :disabled="loading"
         @click="modal?.hide()"
         class="cancel-button"
         data-testid="refresh-link-cancel-btn"
@@ -44,12 +49,21 @@ defineExpose({ show, hide });
       </primary-button>
       <primary-button
         name="confirm"
+        :disabled="loading"
         @click="emit('confirmed')"
         class="confirm-button"
         data-testid="refresh-link-confirm-btn"
       >
-        {{ t('label.confirm') }}
+        {{ loading ? t('label.loading') : t('label.confirm') }}
       </primary-button>
     </template>
   </modal-dialog>
 </template>
+
+<style scoped>
+.refresh-link-modal.is-loading :deep(.modal-close) {
+  pointer-events: none;
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+</style>

--- a/frontend/src/views/AvailabilityView/components/BookingPageLink/components/RefreshLinkModal.vue
+++ b/frontend/src/views/AvailabilityView/components/BookingPageLink/components/RefreshLinkModal.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
-import { ModalDialog, PrimaryButton } from '@thunderbirdops/services-ui';
+import { ModalDialog, PrimaryButton, IconButton, NoticeBar, NoticeBarTypes } from '@thunderbirdops/services-ui';
+import { PhX } from '@phosphor-icons/vue';
 import { useTemplateRef } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const { t } = useI18n();
-const emit = defineEmits(['confirmed']);
+const emit = defineEmits(['confirmed', 'dismiss-error']);
 
 defineProps<{
   loading?: boolean;
+  errorMessage?: string;
 }>();
 
 const modal = useTemplateRef('modal');
@@ -27,12 +29,26 @@ defineExpose({ show, hide });
 
 <template>
   <!-- Refresh link modal -->
-  <modal-dialog ref="modal" class="refresh-link-modal" :class="{ 'is-loading': loading }" :close-outside="!loading">
+  <modal-dialog
+    ref="modal"
+    class="refresh-link-modal"
+    :class="{ 'is-loading': loading }"
+    :close-outside="!loading"
+  >
     <template #header>
       {{ t('label.refreshLink') }}
     </template>
 
     <div class="refresh-link-modal-container">
+      <notice-bar v-if="errorMessage" class="notice-bar" :type="NoticeBarTypes.Critical">
+        {{ errorMessage }}
+        <template #cta>
+          <icon-button @click="emit('dismiss-error')" :title="t('label.close')">
+            <ph-x />
+          </icon-button>
+        </template>
+      </notice-bar>
+
       {{ t('text.refreshLinkNotice') }}
     </div>
 
@@ -61,6 +77,12 @@ defineExpose({ show, hide });
 </template>
 
 <style scoped>
+.refresh-link-modal-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
 .refresh-link-modal.is-loading :deep(.modal-close) {
   pointer-events: none;
   cursor: not-allowed;

--- a/frontend/src/views/AvailabilityView/components/BookingPageLink/index.vue
+++ b/frontend/src/views/AvailabilityView/components/BookingPageLink/index.vue
@@ -20,6 +20,7 @@ const emit = defineEmits<{ 'link-refreshed': [] }>();
 
 const refreshLinkModalRef = useTemplateRef('refreshLinkModalRef');
 const copyButtonLabel = ref(t('label.copy'));
+const refreshingLink = ref(false);
 
 const linkSlug = computed({
   get: () => currentState.value.slug || userStore.mySlug,
@@ -31,21 +32,31 @@ const linkSlug = computed({
 const shortUrlWithoutProtocol = computed(() => userStore.data.userLink.replace(/https?:\/\//g, ''));
 
 async function refreshLinkConfirm() {
-  await userStore.changeSignedUrl();
-  await userStore.profile();
+  if (refreshingLink.value) {
+    return;
+  }
 
-  // Update link slug in the "Customize Your Link" text field
-  // We need to update both initialState and currentState for the isDirty comparison
-  availabilityStore.$patch({
-    initialState: { slug: userStore.mySlug },
-    currentState: { slug: userStore.mySlug },
-  });
+  refreshingLink.value = true;
 
-  refreshLinkModalRef.value.hide();
-  emit('link-refreshed');
+  try {
+    await userStore.changeSignedUrl();
+    await userStore.profile();
 
-  if (usePosthog) {
-    posthog.capture(MetricEvents.RefreshLink);
+    // Update link slug in the "Customize Your Link" text field
+    // We need to update both initialState and currentState for the isDirty comparison
+    availabilityStore.$patch({
+      initialState: { slug: userStore.mySlug },
+      currentState: { slug: userStore.mySlug },
+    });
+
+    refreshLinkModalRef.value.hide();
+    emit('link-refreshed');
+
+    if (usePosthog) {
+      posthog.capture(MetricEvents.RefreshLink);
+    }
+  } finally {
+    refreshingLink.value = false;
   }
 }
 
@@ -97,7 +108,7 @@ export default {
   </text-input>
 
   <!-- Refresh link confirmation modal -->
-  <refresh-link-modal ref="refreshLinkModalRef" @confirmed="refreshLinkConfirm()" />
+  <refresh-link-modal ref="refreshLinkModalRef" :loading="refreshingLink" @confirmed="refreshLinkConfirm()" />
 </template>
 
 <style scoped>

--- a/frontend/src/views/AvailabilityView/components/BookingPageLink/index.vue
+++ b/frontend/src/views/AvailabilityView/components/BookingPageLink/index.vue
@@ -21,6 +21,7 @@ const emit = defineEmits<{ 'link-refreshed': [] }>();
 const refreshLinkModalRef = useTemplateRef('refreshLinkModalRef');
 const copyButtonLabel = ref(t('label.copy'));
 const refreshingLink = ref(false);
+const refreshLinkError = ref('');
 
 const linkSlug = computed({
   get: () => currentState.value.slug || userStore.mySlug,
@@ -37,10 +38,23 @@ async function refreshLinkConfirm() {
   }
 
   refreshingLink.value = true;
+  refreshLinkError.value = '';
 
   try {
-    await userStore.changeSignedUrl();
-    await userStore.profile();
+    const { error } = await userStore.changeSignedUrl();
+
+    if (error) {
+      refreshLinkError.value = typeof error === 'string' && error ? error : t('error.refreshLinkError');
+      return;
+    }
+
+    const { error: profileError } = await userStore.profile();
+
+    if (profileError) {
+      // Highly unlikely to happen, but just in case we fail to reload the profile
+      refreshLinkError.value = t('error.refreshLinkReloadError');
+      return;
+    }
 
     // Update link slug in the "Customize Your Link" text field
     // We need to update both initialState and currentState for the isDirty comparison
@@ -55,9 +69,16 @@ async function refreshLinkConfirm() {
     if (usePosthog) {
       posthog.capture(MetricEvents.RefreshLink);
     }
+  } catch {
+    refreshLinkError.value = t('error.refreshLinkError');
   } finally {
     refreshingLink.value = false;
   }
+}
+
+function openRefreshLinkModal() {
+  refreshLinkError.value = '';
+  refreshLinkModalRef.value.show();
 }
 
 async function copyLink() {
@@ -90,7 +111,7 @@ export default {
     v-model="linkSlug"
   >
     {{ t('label.customizeYourLink') }}:
-    <button @click="refreshLinkModalRef.show()">
+    <button @click="openRefreshLinkModal">
       <ph-arrow-clockwise size="24" :aria-label="t('label.refreshLink')" />
     </button>
   </text-input>
@@ -108,7 +129,13 @@ export default {
   </text-input>
 
   <!-- Refresh link confirmation modal -->
-  <refresh-link-modal ref="refreshLinkModalRef" :loading="refreshingLink" @confirmed="refreshLinkConfirm()" />
+  <refresh-link-modal
+    ref="refreshLinkModalRef"
+    :loading="refreshingLink"
+    :error-message="refreshLinkError"
+    @confirmed="refreshLinkConfirm()"
+    @dismiss-error="refreshLinkError = ''"
+  />
 </template>
 
 <style scoped>


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- Blocking the cancel / confirm buttons while loading since we can't actually `cancel` / rollback the action after you clicked confirm.
- Added error handling in case any of the two API requests related to this action fails.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

- Users were able to spam click confirm and trigger a lot of refreshes. This is quite common as it may take a while for the operation to complete.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Closes https://github.com/thunderbird/appointment/issues/1559

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

[Video in action]

https://github.com/user-attachments/assets/6339d0df-7526-4230-95a6-276bcc11f44f

[Error in case refreshing the link fails]

<img width="791" height="366" alt="Screenshot 2026-09-04 at 8 48 24 AM" src="https://github.com/user-attachments/assets/d63dd488-98f4-4ea6-bde3-72e16c4019ee" />

[Error in case refreshing the link works but we fail to reload the user info]

<img width="795" height="369" alt="Screenshot 2026-09-04 at 8 48 51 AM" src="https://github.com/user-attachments/assets/92555605-509c-4168-bae0-42a6be6d5cd6" />

