### PR TITLE
Improve availability page performance: Initialize stores in parallel

### DIFF
--- a/frontend/src/stores/availability-store.ts
+++ b/frontend/src/stores/availability-store.ts
@@ -32,23 +32,12 @@ export const useAvailabilityStore = defineStore('availability', () => {
     const scheduleStore = createScheduleStore(fetch);
     const externalConnectionStore = createExternalConnectionsStore(fetch);
 
-    const { isLoaded: isCalendarStoreLoaded, connectedCalendars } = toRefs(calendarStore);
-    const { isLoaded: isExternalConnectionStoreLoaded } = toRefs(externalConnectionStore);
-    const { isLoaded: isScheduleStoreLoaded, firstSchedule } = toRefs(scheduleStore);
+    const { connectedCalendars } = toRefs(calendarStore);
+    const { firstSchedule } = toRefs(scheduleStore);
 
     // First, let's make sure that all stores are loaded
     // so that we can initialize the currentState properly
-    if (!isCalendarStoreLoaded.value) {
-      await calendarStore.fetch();
-    }
-
-    if (!isExternalConnectionStoreLoaded.value) {
-      await externalConnectionStore.fetch();
-    }
-
-    if (!isScheduleStoreLoaded.value) {
-      await scheduleStore.fetch();
-    }
+    await Promise.all([calendarStore.fetch(), externalConnectionStore.fetch(), scheduleStore.fetch()]);
 
     if (firstSchedule.value) {
       initialState.value = deepClone({ ...firstSchedule.value });


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

This PR contains another fix for bad performance on the availability page. This time I improved a consecutive await calls on 3 stores in the availability-store and made them run in parallel.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->
Prevent long loading times and confusion by UI sitting seconds in an intermediate state.

## How to test

1. Don't check out this branch yet
2. Open the availability page and the web console with the network tab
3. Clear the network tab and hit CTRL+F5
4. See the different `http://localhost:5000/*` (calendars, external connections, schedule) requests running after each other
5. Now check out this branch and repeat steps 2-4
6. See the `http://localhost:5000/*` requests happening at the same time:
    <img width="973" height="319" alt="image" src="https://github.com/user-attachments/assets/29792ad9-b477-4815-a356-b30a2b294cf8" />


You can look at the overall page loading time average. This reduced the loading time by around 200ms on my machine.

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->
I removed all the `if (!is*StoreLoaded.value)` conditions, since the stores themselves already do that check, resulting in a no-op in case it's already loaded. But please double check that 😇 

There is no easy way to test this (I think) so I didn't write a regression test (again 😅).

## Applicable Issues

Related to #1371 

## Screenshots

No UI changes
