### PR TITLE
Improve general request performance

### DIFF
--- a/backend/src/appointment/dependencies/database.py
+++ b/backend/src/appointment/dependencies/database.py
@@ -3,7 +3,7 @@ import os
 import time
 from typing import Optional
 
-import sentry_sdk.metrics
+import sentry_sdk
 from redis import Redis, RedisCluster
 from redis.backoff import ExponentialBackoff
 from redis.retry import Retry

--- a/backend/src/appointment/dependencies/database.py
+++ b/backend/src/appointment/dependencies/database.py
@@ -8,24 +8,31 @@ from redis import Redis, RedisCluster
 from redis.backoff import ExponentialBackoff
 from redis.retry import Retry
 from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 from ..utils import get_database_url
 
 
 _redis_instance: Optional[RedisCluster] = None
 
+_engine: Optional[Engine] = None
+_session_local = None
+
 
 def get_engine_and_session():
-    database_url = get_database_url()
-    connect_args = {}
+    global _engine, _session_local
 
-    if 'sqlite://' in database_url:
-        connect_args = {'check_same_thread': False}
+    if _engine is None:
+        database_url = get_database_url()
+        connect_args = {}
 
-    engine = create_engine(database_url, connect_args=connect_args)
-    session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+        if 'sqlite://' in database_url:
+            connect_args = {'check_same_thread': False}
 
-    return engine, session_local
+        _engine = create_engine(database_url, connect_args=connect_args)
+        _session_local = sessionmaker(autocommit=False, autoflush=False, bind=_engine)
+
+    return _engine, _session_local
 
 
 def get_db():


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

This is the third (and last for today I promise 😂) PR improving the availability page performance. This one is not scoped to the availability page in particular, but to EVERY single request we made, that needs a database lookup.

We use `get_db()` as a per-request dependency, which is fine. But we were calling SQLAlchemy's `create_engine()` via `get_engine_and_session()` there, causing to open a whole new connection pool without looking for an already existing one.

This PR sets a global engine and session (like we do with the redis instance) and checks, if that already exists before creating a new one.

## Why?

Prevent long loading times and confusion by UI sitting seconds in an intermediate state.

## How to test

1. Don't check out this branch yet
2. Open the availability page and the web console with the network tab
3. Clear the network tab and hit CTRL+F5
4. See the different `http://localhost:5000/*` (calendars, external connections, schedule) requests and their timings
    <img width="973" height="319" alt="image" src="https://github.com/user-attachments/assets/29792ad9-b477-4815-a356-b30a2b294cf8" />
6. Now check out this branch and repeat steps 2-4
7. See the `http://localhost:5000/*` requests being faster:
    <img width="965" height="319" alt="image" src="https://github.com/user-attachments/assets/aea748fe-b89e-4ace-866a-51798b58246f" />

## Limitations and Notes

This is a very heavy impact change. So please double check if I did that right! Existing tests were running fine though.

## Applicable Issues

Related to #1371 

## Screenshots

No UI changes
