### PR TITLE
Fix failing E2E tests by updating page title check to work with recent app changes

### DIFF
--- a/test/e2e/utils/utils.ts
+++ b/test/e2e/utils/utils.ts
@@ -46,7 +46,7 @@ export const navigateToAppointmentAndSignIn = async (page: Page, testProjectName
   }
 
   // now that we're signed into the appointment dashboard give it time to load
-  await expect(page).toHaveTitle(APPT_PAGE_TITLE, { timeout: TIMEOUT_60_SECONDS }); // give generous time
+  await expect(page).toHaveTitle(/Appointment/i, { timeout: TIMEOUT_60_SECONDS });
 }
 
 /**


### PR DESCRIPTION
## What changed?
Update the E2E test auth to work with recent app changes.

## Why?
The E2E tests are [broken on stage](https://automate.browserstack.com/projects/Thunderbird+Appointment/builds/Appointment+Stage+Sanity+Test+Firefox+Desktop/95?testListView=spec) due to an [Appointment app change](https://github.com/thunderbird/appointment/pull/1812/changes#diff-959f9cada636604db33bc1ba82fed347457dcb032c37ac195b4343c5f0ea6e72) merged yesterday which changed the main Appointment page title. The E2E tests were checking for an exact match of this title in order to verify sign-in finished and the application is loaded.

Update the test to use a regex when checking the Appointment page title in case the title is changed again in the future, but still ensures the page is loaded.

## Applicable Issues
Fixes #1825.

## QA Log

In order to test the auth fix, I ran the settings-theme E2E test:

- On Firefox desktop on my local machine against my local Appointment dev stack ✅ 
- On Firefox desktop on my local machine against stage ✅ 
- On Firefox desktop [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Appointment/builds/Appointment+Stage+Sanity+Test+Firefox+Desktop/99?testListView=spec) against stage ✅ 
-  On Android Chrome [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Appointment/builds/Appointment+Nightly+Tests+Android+Chrome/325?tab=sessions&testListView=spec) against stage ✅ 
- On iOS Safari [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Appointment/builds/Appointment+Nightly+Tests+iOS+Safari/274?tab=sessions) against stage ✅ 