### PR TITLE
Fix book-appointment test when logout confirmation is not required

### DIFF
--- a/test/e2e/tests/book-appointment.spec.ts
+++ b/test/e2e/tests/book-appointment.spec.ts
@@ -72,13 +72,33 @@ test.describe('book an appointment', () => {
       // and must provide the booker's name and email address.
       await page.goto(`${APPT_URL}logout`);
 
-      // Appointment's OIDC logout redirects to Keycloak, which requires the
-      // user to confirm the logout before following post_logout_redirect_uri
-      // back to Appointment. Waiting for the button also ensures that the
-      // redirect to Keycloak has completed before the test tries to continue.
+      // Depending on the current Keycloak session, logout either stops on a
+      // confirmation page or completes immediately and returns to Sign In.
+      // Wait for either valid outcome instead of requiring the optional
+      // confirmation button, which makes this branch intermittent.
       const keycloakLogoutButton = page.getByRole('button', { name: 'Logout', exact: true });
-      await expect(keycloakLogoutButton).toBeVisible({ timeout: TIMEOUT_60_SECONDS });
-      await keycloakLogoutButton.click();
+      await expect
+        .poll(async () => {
+          if (await tbAcctsPage.signInButton.isVisible()) {
+            return 'signed-out';
+          }
+
+          if (await keycloakLogoutButton.isVisible()) {
+            return 'confirmation-required';
+          }
+
+          return 'logging-out';
+        }, {
+          timeout: TIMEOUT_60_SECONDS,
+          message: 'Waiting for Keycloak logout confirmation or the Sign In page',
+        })
+        .not.toBe('logging-out');
+
+      // The confirmation can be skipped by Keycloak when logout has already
+      // completed. Click it only when it is still present.
+      if (await keycloakLogoutButton.isVisible()) {
+        await keycloakLogoutButton.click();
+      }
 
       // Do not wait only for APPT_URL here. It is a transient stop in the
       // post-logout flow: Appointment immediately redirects from `/` to


### PR DESCRIPTION
## What changed

Follow-up to the changes made in #1827 to fix an intermittent log-out issue: The book-appointment test signs out of Appointment as we want to use the bookee page and select a time slot when not signed in; after navigating to the /logout URL the test is expecting the logout confirmation page to appear (with a Logout button) but turns out it doesn't appear every time.

Updated the desktop logout flow in `book-appointment.spec.ts` to support both valid Keycloak outcomes:

- If the logout confirmation page appears, click the **Logout** button.
- If logout completes automatically, continue when the **Sign In** page appears.
- Always wait for the stable Sign In page before navigating to the public booking page.

## Why

Keycloak does not consistently display the logout confirmation page. The test previously required the Logout button, causing intermittent timeouts when Keycloak completed logout automatically.

## Limitations

This handling applies only to desktop runs because mobile tests already begin unauthenticated. The synchronization relies on the current Keycloak Logout and Sign In controls.

## Notes

No Playwright tags, platform coverage, or booking behavior changed. The test still verifies the public booking flow while signed out and signs back in afterward to confirm the appointment was created.

I used Codex AI to write this patch.

## Applicable Issues
Fixes #1816.

## QA Log
Ran the updated book-appointment test on:

- Firefox desktop on my local dev stack ✅ 
- Firefox desktop against Appointment production ✅ 
- Chromium desktop [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Appointment/builds/Appointment+Nightly+Tests+Chromium+Desktop/319?tab=sessions&bls_localTimezone=true) against production ✅ 
- Android Chrome on a Google Pixel 10 device [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Appointment/builds/Appointment+Nightly+Tests+Android+Chrome/338?tab=sessions&bls_localTimezone=true) against production ✅ 